### PR TITLE
Add perf_tuning role

### DIFF
--- a/collection/roles/perf_tuning/README.md
+++ b/collection/roles/perf_tuning/README.md
@@ -1,0 +1,25 @@
+# Role: perf_tuning
+
+High-performance tuning for xiRAID storage nodes running Ubuntu 22.04/24.04, as
+recommended in Xinnor blogs (2023-2025) and NVIDIA ConnectX-7 (400 Gbit) docs.
+
+## Features
+* Disables or relaxes CPU security mitigations (optional) to reduce latency.
+* Enables NVMe polling queues and noop scheduler.
+* Stops **irqbalance**, sets CPU governor to *performance*, applies TuneD
+  *throughput-performance* profile.
+* Turns off THP/KSM and ups read-ahead, queue depth and *nr_requests*.
+* Network block:
+  * MTU 9000, enlarged RX/TX rings, big socket buffers, netdev backlog for
+    400 Gbit ConnectX-7 links.
+
+## Variables
+See `defaults/main.yml` for the full list; most tuning knobs can be disabled or
+altered via inventory/group_vars.
+
+## Example
+```yaml
+- hosts: storage_nodes
+  roles:
+    - perf_tuning
+```

--- a/collection/roles/perf_tuning/defaults/main.yml
+++ b/collection/roles/perf_tuning/defaults/main.yml
@@ -1,0 +1,25 @@
+# =============================================================
+# Role: perf_tuning
+# Directory: collection/roles/perf_tuning/
+# Purpose: Apply Xinnor-recommended performance and 400 Gbit network tuning.
+# =============================================================
+# These variables can be overridden in group_vars/<group>.yml
+perf_disable_mitigations: true         # add Spectre/Meltdown mitigations=off, etc.
+perf_nvme_poll_queues: 4               # echo "options nvme poll_queues=4"
+perf_stop_irqbalance: true             # stop irqbalance
+perf_cpu_governor: "performance"       # cpupower governor
+perf_disable_thp: true                 # transparent hugepages=never
+perf_disable_ksm: true
+perf_scheduler: "noop"                  # I/O scheduler for NVMe
+perf_nr_requests: 512
+perf_read_ahead_kb: 65536             # blockdev --setra
+perf_tuned_profile: "throughput-performance"
+
+# network (400 Gbit / ConnectX-7) section
+perf_net_ifaces: []                   # list of iface names, e.g. ["mlx0"]
+perf_net_mtu: 9000
+perf_net_ring_rx: 8192
+perf_net_ring_tx: 8192
+perf_net_rmem_max: 1073741824         # 1 GiB
+perf_net_wmem_max: 1073741824
+perf_net_backlog: 250000

--- a/collection/roles/perf_tuning/handlers/main.yml
+++ b/collection/roles/perf_tuning/handlers/main.yml
@@ -1,0 +1,9 @@
+# -------------------------------------------------------------
+# handlers/main.yml
+# -------------------------------------------------------------
+---
+- name: update grub
+  ansible.builtin.command: update-grub
+
+- name: rebuild initramfs
+  ansible.builtin.command: update-initramfs -u -k all

--- a/collection/roles/perf_tuning/tasks/main.yml
+++ b/collection/roles/perf_tuning/tasks/main.yml
@@ -1,0 +1,103 @@
+# -------------------------------------------------------------
+# tasks/main.yml
+# -------------------------------------------------------------
+---
+- name: Install auxiliary packages needed by tuning tasks
+  ansible.builtin.apt:
+    name:
+      - cpufrequtils
+      - tuned
+    state: present
+  tags: [packages]
+
+# ===== Kernel boot parameters =====
+- name: Add high-performance kernel parameters (Xinnor guide)
+  ansible.builtin.lineinfile:
+    path: /etc/default/grub
+    regexp: '^GRUB_CMDLINE_LINUX="(.*)"'
+    line: 'GRUB_CMDLINE_LINUX="intel_idle.max_cstate=0 {{ "mitigations=off noibrs noibpb nopti nospectre_v2 nospec_store_bypass_disable no_stf_barrier mds=off" if perf_disable_mitigations else "" }} $1"'
+    backrefs: yes
+  notify: update grub
+  when: ansible_facts['cmdline'] is defined
+  tags: [kernel]
+
+- name: Configure NVMe polling mode ({{ perf_nvme_poll_queues }} queues)
+  ansible.builtin.lineinfile:
+    path: /etc/modprobe.d/nvme.conf
+    create: yes
+    line: "options nvme poll_queues={{ perf_nvme_poll_queues }}"
+  notify: rebuild initramfs
+  tags: [nvme]
+
+# ===== CPU governor & irqbalance =====
+- name: Set CPU frequency governor to {{ perf_cpu_governor }}
+  ansible.builtin.command: "cpupower frequency-set -g {{ perf_cpu_governor }}"
+  when: ansible_facts['architecture'] == 'x86_64'
+  tags: [cpu]
+
+- name: Stop and disable irqbalance if requested
+  ansible.builtin.service:
+    name: irqbalance
+    state: stopped
+    enabled: no
+  when: perf_stop_irqbalance
+  tags: [cpu]
+
+# ===== Disable THP / KSM =====
+- name: Disable Transparent Huge Pages at runtime
+  ansible.builtin.shell: |
+    echo never > /sys/kernel/mm/transparent_hugepage/enabled
+    echo never > /sys/kernel/mm/transparent_hugepage/defrag
+  when: perf_disable_thp
+  tags: [memory]
+
+- name: Disable Kernel Samepage Merging (KSM)
+  ansible.builtin.shell: "echo 0 > /sys/kernel/mm/ksm/run"
+  when: perf_disable_ksm
+  tags: [memory]
+
+# ===== I/O scheduler & queue depth =====
+- name: Force {{ perf_scheduler }} scheduler on NVMe devices
+  ansible.builtin.shell: |
+    for dev in /sys/block/nvme*/queue/scheduler; do echo {{ perf_scheduler }} > "$dev"; done
+  tags: [io]
+
+- name: Increase nr_requests queue depth to {{ perf_nr_requests }} on NVMe devices
+  ansible.builtin.shell: |
+    for dev in /sys/block/nvme*/queue/nr_requests; do echo {{ perf_nr_requests }} > "$dev"; done
+  tags: [io]
+
+- name: Set read-ahead to {{ perf_read_ahead_kb }} KB for NVMe devices
+  ansible.builtin.shell: |
+    for blk in /dev/nvme*n*; do /sbin/blockdev --setra {{ perf_read_ahead_kb }} "$blk"; done
+  tags: [io]
+
+# ===== Sysctl network 400 Gbit =====
+- name: Apply network sysctl parameters for 400 Gbit throughput
+  ansible.builtin.sysctl:
+    name: "{{ item.key }}"
+    value: "{{ item.value }}"
+    state: present
+    reload: yes
+  loop:
+    - { key: 'net.core.rmem_max',     value: '{{ perf_net_rmem_max }}' }
+    - { key: 'net.core.wmem_max',     value: '{{ perf_net_wmem_max }}' }
+    - { key: 'net.core.netdev_max_backlog', value: '{{ perf_net_backlog }}' }
+  tags: [network]
+
+- name: Configure MTU {{ perf_net_mtu }} on high-speed interfaces
+  ansible.builtin.command: "ip link set dev {{ item }} mtu {{ perf_net_mtu }}"
+  loop: "{{ perf_net_ifaces }}"
+  when: perf_net_ifaces | length > 0
+  tags: [network]
+
+- name: Increase ring buffers via ethtool on 400 Gbit NICs
+  ansible.builtin.command: "ethtool -G {{ item }} rx {{ perf_net_ring_rx }} tx {{ perf_net_ring_tx }}"
+  loop: "{{ perf_net_ifaces }}"
+  when: perf_net_ifaces | length > 0
+  tags: [network]
+
+# ===== TuneD profile =====
+- name: Activate tuned profile {{ perf_tuned_profile }}
+  ansible.builtin.command: "tuned-adm profile {{ perf_tuned_profile }}"
+  tags: [tuned]

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,0 +1,2 @@
+# Global variables for xiNAS
+# Currently empty; override role defaults here if needed.

--- a/inventories/lab.ini
+++ b/inventories/lab.ini
@@ -1,0 +1,2 @@
+[storage_nodes]
+localhost ansible_connection=local

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -1,0 +1,7 @@
+---
+- name: Configure storage node (baseline + performance tuning)
+  hosts: storage_nodes
+  gather_facts: true
+  roles:
+    - role: common
+    - role: perf_tuning


### PR DESCRIPTION
## Summary
- add `perf_tuning` role skeleton for high‑performance tuning
- add inventories and group vars directories
- create `site.yml` playbook calling `common` and `perf_tuning`

## Testing
- `ansible-lint playbooks/site.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68440a0f55508328a15bee70fbbdbc08