### PR TITLE
Add doca_ofed role for DOCA-OFED installation

### DIFF
--- a/collection/roles/doca_ofed/README.md
+++ b/collection/roles/doca_ofed/README.md
@@ -1,0 +1,13 @@
+# Role **doca_ofed**
+Installs NVIDIA DOCA-OFED stack (e.g., 24.07-0.6.1.0) on Ubuntu 24.04 using
+DKMS so that kernel modules survive future kernel updates.
+
+Variables:
+  * `doca_ofed_version`         – upstream version string.
+  * `doca_ofed_components`      – list of APT packages to install.
+  * `doca_ofed_auto_reboot`     – reboot automatically if modules built.
+
+### References
+* NVIDIA Docs – Installing Mellanox OFED on Ubuntu (DKMS)
+* DOCA-OFED installation guide (ConnectX-7)
+* DKMS packaging notes for mlnx-ofed-kernel on Ubuntu

--- a/collection/roles/doca_ofed/defaults/main.yml
+++ b/collection/roles/doca_ofed/defaults/main.yml
@@ -1,0 +1,15 @@
+doca_ofed_version: "24.07-0.6.1.0"
+# Repository package (*.deb) that adds the APT repo for DOCA-OFED
+# For other versions/OS tweak only this variable.
+doca_ofed_repo_deb: "doca-ofed-{{ doca_ofed_version }}-ubuntu24.04-x86_64.deb"
+# Direct URL to download the repo package (can be a local mirror)
+doca_ofed_dl_url: "https://content.mellanox.com/ofed/MLNX_OFED-{{ doca_ofed_version }}/{{ doca_ofed_repo_deb }}"
+
+# List of OFED components to install via apt once the repo is added.
+doca_ofed_components:
+  - doca-ofed-dkms
+  - doca-ofed-basic
+  # - doca-ofed-debuginfo
+
+# Whether to automatically reboot if the installer asks for it
+doca_ofed_auto_reboot: false

--- a/collection/roles/doca_ofed/handlers/main.yml
+++ b/collection/roles/doca_ofed/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: restart openibd
+  service:
+    name: openibd
+    state: restarted

--- a/collection/roles/doca_ofed/tasks/main.yml
+++ b/collection/roles/doca_ofed/tasks/main.yml
@@ -1,0 +1,44 @@
+- name: Ensure build dependencies are present
+  apt:
+    name:
+      - dkms
+      - build-essential
+      - linux-headers-{{ ansible_kernel }}
+      - libelf-dev
+    state: present
+  tags: [ofed, deps]
+
+- name: Download DOCA-OFED repo package
+  get_url:
+    url: "{{ doca_ofed_dl_url }}"
+    dest: "/tmp/{{ doca_ofed_repo_deb }}"
+    mode: '0644'
+    force: no
+  tags: [ofed, download]
+
+- name: Add DOCA-OFED APT repository (.deb)
+  apt:
+    deb: "/tmp/{{ doca_ofed_repo_deb }}"
+    state: present
+  register: repo_added
+  tags: [ofed, repo]
+
+- name: Update APT cache (if repo added)
+  apt:
+    update_cache: yes
+  when: repo_added is changed
+  tags: [ofed, repo]
+
+- name: Install DOCA-OFED components (DKMS will build modules)
+  apt:
+    name: "{{ doca_ofed_components }}"
+    state: present
+  register: ofed_pkgs
+  tags: [ofed, install]
+
+- name: Reboot if kernel modules built and reboot requested
+  reboot:
+    msg: "Reboot after DOCA-OFED install (role doca_ofed)"
+    reboot_timeout: 1200
+  when: ofed_pkgs is changed and doca_ofed_auto_reboot | bool
+  tags: [ofed, reboot]

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -4,4 +4,5 @@
   gather_facts: true
   roles:
     - role: common
+    - role: doca_ofed
     - role: perf_tuning


### PR DESCRIPTION
## Summary
- add `doca_ofed` role with defaults, tasks and handlers
- update site playbook to include `doca_ofed` between `common` and `perf_tuning`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68440d4591288328832d4fddd6484bec