### PR TITLE
Add xiRAID Classic role

### DIFF
--- a/collection/roles/xiraid_classic/README.md
+++ b/collection/roles/xiraid_classic/README.md
@@ -1,0 +1,20 @@
+# Role **xiraid_classic**
+Installs Xinnor xiRAID Classic {{ xiraid_version }} on Ubuntu LTS with DKMS-built
+kernel module.
+
+## Variables
+* `xiraid_version` – set to 4.2.0, 4.1.0 ...
+* `xiraid_repo_url` – auto-derived; override for offline mirror.
+* `xiraid_packages` – list of debs (`xiraid-core`, `xicli`, etc.).
+* `xiraid_auto_reboot` – reboot after install.
+
+## Example play snippet
+```yaml
+- hosts: storage_nodes
+  roles:
+    - xiraid_classic
+```
+
+### References
+* Xinnor xiRAID 4.2.0 Installation Guide (Ubuntu)
+* xiRAID Classic 4.1.0 PDF – package names and repo workflow

--- a/collection/roles/xiraid_classic/defaults/main.yml
+++ b/collection/roles/xiraid_classic/defaults/main.yml
@@ -1,0 +1,19 @@
+# xiRAID version to install (use 4.x.y). The repo package is auto-derived.
+xiraid_version: "4.2.0"
+
+# Repo package filename for current kernel (override if you mirror files)
+# Example: xiraid-repo_1.2.0-1462.kver.6.8_amd64.deb
+xiraid_repo_filename: "xiraid-repo_1.2.0-1462.kver.{{ ansible_kernel }}_amd64.deb"
+
+# Base URL to Xinnor repository (multi-pack works for 20.04/22.04/24.04)
+xiraid_repo_base_url: "https://pkg.xinnor.io/repository/Repository/xiraid/ubuntu/multi-pack"
+
+xiraid_repo_url: "{{ xiraid_repo_base_url }}/{{ xiraid_repo_filename }}"
+
+# List of xiRAID packages; adjust if version scheme changes.
+xiraid_packages:
+  - xiraid-core
+  - xicli
+
+# Whether to reboot automatically after install (usually not required)
+xiraid_auto_reboot: false

--- a/collection/roles/xiraid_classic/handlers/main.yml
+++ b/collection/roles/xiraid_classic/handlers/main.yml
@@ -1,0 +1,1 @@
+# empty – xiRAID services start automatically post-install

--- a/collection/roles/xiraid_classic/tasks/main.yml
+++ b/collection/roles/xiraid_classic/tasks/main.yml
@@ -1,0 +1,55 @@
+---
+- name: Ensure kernel headers present (xiRAID DKMS needs them)
+  ansible.builtin.apt:
+    name: "linux-headers-{{ ansible_kernel }}"
+    state: present
+  tags: [xiraid, deps]
+
+- name: Download xiRAID repository package for current kernel
+  ansible.builtin.get_url:
+    url: "{{ xiraid_repo_url }}"
+    dest: "/tmp/{{ xiraid_repo_filename }}"
+    mode: 0644
+    force: no
+  register: xiraid_repo_pkg
+  tags: [xiraid, download]
+
+- name: Add xiRAID APT repository (.deb)
+  ansible.builtin.apt:
+    deb: "/tmp/{{ xiraid_repo_filename }}"
+    state: present
+  register: xiraid_repo_added
+  tags: [xiraid, repo]
+
+- name: Update APT cache (if repo added)
+  ansible.builtin.apt:
+    update_cache: yes
+  when: xiraid_repo_added is changed
+  tags: [xiraid, repo]
+
+- name: Install xiRAID packages (kernel module + CLI)
+  ansible.builtin.apt:
+    name: "{{ xiraid_packages }}"
+    state: present
+  register: xiraid_pkgs
+  tags: [xiraid, install]
+
+# Optional verification section
+- name: Verify xiRAID kernel module loaded
+  ansible.builtin.shell: "lsmod | grep -q xiraid"
+  changed_when: false
+  register: mod_check
+  failed_when: mod_check.rc != 0
+  tags: [xiraid, verify]
+
+- name: Show xiRAID version
+  ansible.builtin.command: "xicli -v"
+  changed_when: false
+  tags: [xiraid, verify]
+
+- name: Reboot to complete xiRAID installation (if requested)
+  ansible.builtin.reboot:
+    reboot_timeout: 1200
+    msg: "Reboot by xiraid_classic role after install"
+  when: xiraid_pkgs is changed and xiraid_auto_reboot | bool
+  tags: [xiraid, reboot]

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -1,8 +1,9 @@
 ---
-- name: Configure storage node (baseline + performance tuning)
+- name: Full storage-node configuration (common → OFED → xiRAID → perf)
   hosts: storage_nodes
   gather_facts: true
   roles:
     - role: common
     - role: doca_ofed
+    - role: xiraid_classic
     - role: perf_tuning


### PR DESCRIPTION
## Summary
- add xiraid_classic role with default variables and tasks
- document the role and usage
- call xiraid_classic from the main site playbook

## Testing
- `ansible-playbook -i inventories/lab.ini playbooks/site.yml --syntax-check`
- `ansible-lint` *(fails: 74 violation(s))*

------
https://chatgpt.com/codex/tasks/task_e_68441340451c8328b71b22c1e12a4833