### PR TITLE
Fix xiraid repo filename

### DIFF
--- a/collection/roles/xiraid_classic/defaults/main.yml
+++ b/collection/roles/xiraid_classic/defaults/main.yml
@@ -2,8 +2,8 @@
 xiraid_version: "4.2.0"
 
 # Repo package filename for current kernel (override if you mirror files)
-# Example: xiraid-repo_1.2.0-1462.kver.6.8_amd64.deb
-xiraid_repo_filename: "xiraid-repo_1.2.0-1462.kver.{{ ansible_kernel }}_amd64.deb"
+# Example: xiraid-repo_4.2.0-1462.kver.6.8_amd64.deb
+xiraid_repo_filename: "xiraid-repo_{{ xiraid_version }}-1462.kver.{{ ansible_kernel }}_amd64.deb"
 
 # Base URL to Xinnor repository (multi-pack works for 20.04/22.04/24.04)
 xiraid_repo_base_url: "https://pkg.xinnor.io/repository/Repository/xiraid/ubuntu/multi-pack"


### PR DESCRIPTION
## Summary
- fix xiRAID repo filename template to use variable version

## Testing
- `ansible-lint` *(fails: listing 48 violations)*

------
https://chatgpt.com/codex/tasks/task_e_684416a4a53c83288c71207fa38cf084