### PR TITLE
Add NFS server roles

### DIFF
--- a/collection/roles/exports/README.md
+++ b/collection/roles/exports/README.md
@@ -1,0 +1,14 @@
+# Role **exports**
+Manages NFS export definitions in `/etc/exports` using a Jinja template so that
+access rules are easy to override.
+
+## Variables
+* `exports` – list of dictionaries `{ path, clients, options }`.
+
+## Example
+```yaml
+exports:
+  - path: /mnt/data
+    clients: 192.168.0.0/24
+    options: rw,sync,sec=sys,no_root_squash
+```

--- a/collection/roles/exports/defaults/main.yml
+++ b/collection/roles/exports/defaults/main.yml
@@ -1,0 +1,8 @@
+# List of export rules. Each item fields:
+#   path    – directory to export (will be created if missing)
+#   clients – host or network mask, or "*" for all
+#   options – NFS export options
+exports:
+  - path: /mnt/data
+    clients: "*"
+    options: "rw,sync,insecure,no_root_squash,no_subtree_check,no_wdelay"

--- a/collection/roles/exports/handlers/main.yml
+++ b/collection/roles/exports/handlers/main.yml
@@ -1,0 +1,3 @@
+- name: reload exports
+  ansible.builtin.command: exportfs -r
+  changed_when: true

--- a/collection/roles/exports/tasks/main.yml
+++ b/collection/roles/exports/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Ensure export directories exist
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  loop: "{{ exports }}"
+  tags: [exports]
+
+- name: Render /etc/exports from template
+  ansible.builtin.template:
+    src: exports.j2
+    dest: /etc/exports
+    owner: root
+    group: root
+    mode: '0644'
+  notify: reload exports
+  tags: [exports]

--- a/collection/roles/exports/templates/exports.j2
+++ b/collection/roles/exports/templates/exports.j2
@@ -1,0 +1,3 @@
+{% for ex in exports %}
+{{ ex.path }} {{ ex.clients }}({{ ex.options }})
+{% endfor %}

--- a/collection/roles/nfs_server/README.md
+++ b/collection/roles/nfs_server/README.md
@@ -1,0 +1,16 @@
+# Role **nfs_server**
+Installs and tunes `nfs-kernel-server` for RDMA access, with defaults based on
+Xinnor's high-performance NFS blog (Feb 3 2025).
+
+## Variables
+* `nfs_threads` – thread count for exportd & nfsd (default 64).
+* `nfs_rdma_port` – port for NFS-RDMA service (default 20049).
+
+## Example playbook
+```yaml
+- hosts: storage_nodes
+  roles:
+    - nfs_server
+```
+
+Reference: Xinnor blog, Feb 3 2025

--- a/collection/roles/nfs_server/defaults/main.yml
+++ b/collection/roles/nfs_server/defaults/main.yml
@@ -1,0 +1,5 @@
+# Number of threads for both exportd and nfsd (blog recommends 64)
+nfs_threads: 64
+
+# Port used for NFS-RDMA service (blog uses 20049)
+nfs_rdma_port: 20049

--- a/collection/roles/nfs_server/handlers/main.yml
+++ b/collection/roles/nfs_server/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: restart nfs
+  ansible.builtin.service:
+    name: nfs-server
+    state: restarted

--- a/collection/roles/nfs_server/tasks/main.yml
+++ b/collection/roles/nfs_server/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+- name: Install NFS server packages
+  ansible.builtin.apt:
+    name:
+      - nfs-kernel-server
+      - nfs-common
+    state: present
+  tags: [nfs_server, install]
+
+- name: Configure /etc/nfs.conf (threads, RDMA, port)
+  ansible.builtin.blockinfile:
+    path: /etc/nfs.conf
+    marker: "# {mark} ANSIBLE managed section – nfs_server role"
+    block: |
+      [exportd]
+      threads={{ nfs_threads }}
+
+      [nfsd]
+      threads={{ nfs_threads }}
+      vers3=y
+      vers4=y
+      vers4.0=y
+      vers4.1=y
+      vers4.2=y
+      rdma=y
+      rdma-port={{ nfs_rdma_port }}
+  notify: restart nfs
+  tags: [nfs_server, config]
+
+- name: Enable and start nfs-server service
+  ansible.builtin.service:
+    name: nfs-server
+    enabled: true
+    state: started
+  tags: [nfs_server, service]

--- a/collection/roles/raid_fs/tasks/create_array.yml
+++ b/collection/roles/raid_fs/tasks/create_array.yml
@@ -1,12 +1,20 @@
+- name: Build device list string
+  ansible.builtin.set_fact:
+    _devlist: "{{ item.devices | join(' ') }}"
+
+- name: Calculate data disk count (for RAID5/6 stripe-width)
+  ansible.builtin.set_fact:
+    _sw: "{{ (item.devices | length) - (item.parity_disks | default(0)) }}"
+
 - name: Create array {{ item.name }}
-  command: >-
+  ansible.builtin.command: >-
     xicli raid create -n {{ item.name }} -l {{ item.level }}
-    -d {{ item.devices | join(' ') }} -ss {{ item.strip_size_kb }}
+    -d {{ _devlist }} -ss {{ item.strip_size_kb }}
   register: raid_create
   tags: [raid_fs, raid]
 
 - name: Wait for xiRAID block device /dev/xi_{{ item.name }}
-  wait_for:
+  ansible.builtin.wait_for:
     path: "/dev/xi_{{ item.name }}"
     timeout: 120
   tags: [raid_fs, raid]

--- a/collection/roles/raid_fs/tasks/create_fs.yml
+++ b/collection/roles/raid_fs/tasks/create_fs.yml
@@ -1,11 +1,11 @@
 - name: Check if {{ item.data_device }} already has XFS label {{ item.label }}
-  command: blkid -s TYPE -o value {{ item.data_device }}
+  ansible.builtin.command: blkid -s TYPE -o value {{ item.data_device }}
   register: blkid_out
   failed_when: false
   changed_when: false
 
 - name: Make filesystem {{ item.label }} on {{ item.data_device }}
-  command: >-
+  ansible.builtin.command: >-
     mkfs.xfs -f -L {{ item.label }} -d su={{ item.su_kb }}k,sw={{ item.sw }}
     -l logdev={{ item.log_device }},size={{ item.log_size }}
     -s size={{ item.sector_size }} {{ item.data_device }}
@@ -13,14 +13,14 @@
   tags: [raid_fs, fs, mkfs]
 
 - name: Create mountpoint {{ item.mountpoint }}
-  file:
+  ansible.builtin.file:
     path: "{{ item.mountpoint }}"
     state: directory
     mode: '0755'
   tags: [raid_fs, fs]
 
 - name: Mount filesystem {{ item.label }} (and add to fstab)
-  mount:
+  ansible.builtin.mount:
     path: "{{ item.mountpoint }}"
     src: "LABEL={{ item.label }}"
     fstype: xfs

--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -1,32 +1,34 @@
 ---
 - name: Gather existing xiRAID arrays (json)
-  command: xicli raid list --json
+  ansible.builtin.command: xicli raid list --json
   register: xiraid_list
   changed_when: false
   failed_when: xiraid_list.rc != 0
   tags: [raid_fs, raid]
 
 - name: Set fact – parsed arrays
-  set_fact:
+  ansible.builtin.set_fact:
     existing_arrays: "{{ xiraid_list.stdout | from_json }}"
   tags: [raid_fs, raid]
 
 - name: Create xiRAID arrays that are missing
-  include_tasks: create_array.yml
+  ansible.builtin.include_tasks: create_array.yml
   loop: "{{ xiraid_arrays }}"
   loop_control:
     loop_var: item
   when: item.name not in existing_arrays | json_query('[].name')
+  tags: [raid_fs, raid]
 
 # ----------------------- Filesystem section -------------------
 - name: Ensure XFS utils present
-  apt:
+  ansible.builtin.apt:
     name: xfsprogs
     state: present
   tags: [raid_fs, fs]
 
 - name: Create XFS filesystems if absent
-  include_tasks: create_fs.yml
+  ansible.builtin.include_tasks: create_fs.yml
   loop: "{{ xfs_filesystems }}"
   loop_control:
     loop_var: item
+  tags: [raid_fs, fs]

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,2 +1,47 @@
-# Global variables for xiNAS
-# Currently empty; override role defaults here if needed.
+# Global variables for xiNAS example deployment
+
+# NFS server tuning
+nfs_threads: 64
+nfs_rdma_port: 20049
+
+# NFS exports
+exports:
+  - path: /mnt/data
+    clients: "*"
+    options: "rw,sync,insecure,no_root_squash,no_subtree_check,no_wdelay"
+
+# xiRAID arrays and filesystems
+xiraid_arrays:
+  - name: media6
+    level: 6
+    strip_size_kb: 128
+    devices:
+      - /dev/nvme16n2
+      - /dev/nvme9n2
+      - /dev/nvme20n2
+      - /dev/nvme18n2
+      - /dev/nvme8n2
+      - /dev/nvme12n2
+      - /dev/nvme13n2
+      - /dev/nvme19n2
+      - /dev/nvme23n2
+      - /dev/nvme24n2
+    parity_disks: 2
+
+  - name: media0
+    level: 0
+    strip_size_kb: 16
+    devices:
+      - /dev/nvme7n1
+      - /dev/nvme6n1
+
+xfs_filesystems:
+  - label: nfsdata
+    data_device: "/dev/xi_media6"
+    log_device: "/dev/xi_media0"
+    su_kb: 128
+    sw: 8
+    log_size: 1G
+    sector_size: 4k
+    mountpoint: /mnt/data
+    mount_opts: "logdev=/dev/xi_media0,noatime,nodiratime,logbsize=256k,largeio,inode64,swalloc,allocsize=131072k"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -1,5 +1,5 @@
 ---
-- name: Full storage-node configuration (common → OFED → xiRAID → perf)
+- name: Full storage-node configuration (common → OFED → xiRAID → NFS → perf)
   hosts: storage_nodes
   gather_facts: true
   roles:
@@ -7,4 +7,6 @@
     - role: doca_ofed
     - role: xiraid_classic
     - role: raid_fs
+    - role: exports       # manage /etc/exports
+    - role: nfs_server    # configure kernel NFS server
     - role: perf_tuning


### PR DESCRIPTION
## Summary
- add NFS server role with RDMA tuning
- add exports role for managing /etc/exports
- update raid_fs to create arrays and filesystems using include_tasks
- add example configuration to group_vars
- update main playbook with new roles

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_6845923413208328a589f514156c81f8