### PR TITLE
Add configurable chrony service name

### DIFF
--- a/collection/roles/common/README.md
+++ b/collection/roles/common/README.md
@@ -6,6 +6,7 @@ Baseline configuration for all storage nodes. Installs essential packages, confi
 * **`common_timezone`** – system timezone (default `Europe/Amsterdam`).
 * **`common_packages`** – list of baseline packages to install.
 * **`common_sysctl`** – dictionary of sysctl parameters.
+* **`chrony_service_name`** – name of the chrony service to manage (default `chrony`).
 
 ## Example
 ```yaml

--- a/collection/roles/common/defaults/main.yml
+++ b/collection/roles/common/defaults/main.yml
@@ -14,6 +14,7 @@ common_packages:
   - chrony                # NTP daemon; change to ntp if preferred
   - unattended-upgrades
   - ca-certificates
+chrony_service_name: chrony
 common_sysctl:
   net.core.rmem_max: 268435456
   net.core.wmem_max: 268435456

--- a/collection/roles/common/tasks/main.yml
+++ b/collection/roles/common/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: Enable and start chrony (NTP)
   ansible.builtin.service:
-    name: chrony
+    name: "{{ chrony_service_name }}"
     enabled: yes
     state: started
   when: "'chrony' in common_packages"


### PR DESCRIPTION
## Summary
- allow the service name for chrony to be configured
- expose a `chrony_service_name` default variable
- document the new variable

## Testing
- `ansible-playbook playbooks/common.yml -i inventories --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f165a41c8328a2794b28f90413c0