### PR TITLE
Switch doca_ofed to apt repository

### DIFF
--- a/collection/roles/doca_ofed/README.md
+++ b/collection/roles/doca_ofed/README.md
@@ -1,11 +1,13 @@
 # Role **doca_ofed**
-Installs NVIDIA DOCA-OFED stack (e.g., 24.07-0.6.1.0) on Ubuntu 24.04 using
-DKMS so that kernel modules survive future kernel updates.
+Installs NVIDIA DOCA-OFED from the official DOCA APT repository on Ubuntu.
 
 Variables:
-  * `doca_ofed_version`         – upstream version string.
-  * `doca_ofed_components`      – list of APT packages to install.
-  * `doca_ofed_auto_reboot`     – reboot automatically if modules built.
+  * `doca_version` – release version string (`DGX_latest_DOCA` for latest).
+  * `doca_distro_series` – Ubuntu series used in repository path.
+  * `doca_repo_base` – base URL of the DOCA repository.
+  * `doca_repo_component` – component path built from version and distro.
+  * `doca_pkgs` – list of packages to install (kernel stack and userspace).
+  * `doca_ofed_auto_reboot` – reboot automatically if modules built.
 
 ### References
 * NVIDIA Docs – Installing Mellanox OFED on Ubuntu (DKMS)

--- a/collection/roles/doca_ofed/defaults/main.yml
+++ b/collection/roles/doca_ofed/defaults/main.yml
@@ -1,15 +1,10 @@
-doca_ofed_version: "24.07-0.6.1.0"
-# Repository package (*.deb) that adds the APT repo for DOCA-OFED
-# For other versions/OS tweak only this variable.
-doca_ofed_repo_deb: "doca-ofed-{{ doca_ofed_version }}-ubuntu24.04-x86_64.deb"
-# Direct URL to download the repo package (can be a local mirror)
-doca_ofed_dl_url: "https://content.mellanox.com/ofed/MLNX_OFED-{{ doca_ofed_version }}/{{ doca_ofed_repo_deb }}"
+doca_distro_series: "ubuntu24.04"
+doca_version: "2.9.1"          # or "DGX_latest_DOCA" for always-latest
+doca_repo_base: "https://linux.mellanox.com/public/repo/doca"
+doca_repo_component: "{{ doca_version }}/{{ doca_distro_series }}/x86_64"
 
-# List of OFED components to install via apt once the repo is added.
-doca_ofed_components:
-  - doca-ofed-dkms
-  - doca-ofed-basic
-  # - doca-ofed-debuginfo
+doca_pkgs:
+  - doca-ofed          # DKMS-driven kernel stack
+  - doca-ofed-userspace
 
-# Whether to automatically reboot if the installer asks for it
 doca_ofed_auto_reboot: false

--- a/collection/roles/doca_ofed/tasks/main.yml
+++ b/collection/roles/doca_ofed/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Ensure build dependencies are present
-  apt:
+  ansible.builtin.apt:
     name:
       - dkms
       - build-essential
@@ -8,36 +8,36 @@
     state: present
   tags: [ofed, deps]
 
-- name: Download DOCA-OFED repo package
-  get_url:
-    url: "{{ doca_ofed_dl_url }}"
-    dest: "/tmp/{{ doca_ofed_repo_deb }}"
-    mode: '0644'
-    force: no
-  tags: [ofed, download]
+- name: Add Mellanox GPG key
+  ansible.builtin.apt_key:
+    url: "{{ doca_repo_base }}/GPG-KEY-Mellanox.pub"
+    state: present
+  tags: [ofed, repo]
 
-- name: Add DOCA-OFED APT repository (.deb)
-  apt:
-    deb: "/tmp/{{ doca_ofed_repo_deb }}"
+- name: Add DOCA-OFED APT repo
+  ansible.builtin.apt_repository:
+    repo: "deb {{ doca_repo_base }}/{{ doca_repo_component }} /"
+    filename: "mellanox-doca"
     state: present
   register: repo_added
   tags: [ofed, repo]
 
 - name: Update APT cache (if repo added)
-  apt:
+  ansible.builtin.apt:
     update_cache: yes
   when: repo_added is changed
   tags: [ofed, repo]
 
-- name: Install DOCA-OFED components (DKMS will build modules)
-  apt:
-    name: "{{ doca_ofed_components }}"
+- name: Install DOCA-OFED packages
+  ansible.builtin.apt:
+    name: "{{ doca_pkgs }}"
     state: present
+    update_cache: yes
   register: ofed_pkgs
   tags: [ofed, install]
 
 - name: Reboot if kernel modules built and reboot requested
-  reboot:
+  ansible.builtin.reboot:
     msg: "Reboot after DOCA-OFED install (role doca_ofed)"
     reboot_timeout: 1200
   when: ofed_pkgs is changed and doca_ofed_auto_reboot | bool


### PR DESCRIPTION
## Summary
- change the DOCA-OFED defaults to define repo location
- fetch Mellanox repo key and apt repo in tasks
- install packages directly from the repository
- document new variables

## Testing
- `ansible-lint` *(fails: many warnings/errors)*
- `ansible-playbook playbooks/site.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_6845f5c4080483288bd8e2b9b1f44cf7