### PR TITLE
Fix xiRAID repo URL for current kernel

### DIFF
--- a/collection/roles/xiraid_classic/defaults/main.yml
+++ b/collection/roles/xiraid_classic/defaults/main.yml
@@ -2,8 +2,10 @@
 xiraid_version: "4.2.0"
 
 # Repo package filename for current kernel (override if you mirror files)
-# Example: xiraid-repo_4.2.0-1462.kver.6.8_amd64.deb
-xiraid_repo_filename: "xiraid-repo_{{ xiraid_version }}-1462.kver.{{ ansible_kernel }}_amd64.deb"
+# Example: xiraid-repo_1.2.0-1462.kver.6.8_amd64.deb
+# xiRAID repo package uses major.minor kernel version only
+xiraid_repo_kernel: "{{ ansible_kernel | regex_replace('^(\\d+\\.\\d+).*', '\\1') }}"
+xiraid_repo_filename: "xiraid-repo_1.2.0-1462.kver.{{ xiraid_repo_kernel }}_amd64.deb"
 
 # Base URL to Xinnor repository (multi-pack works for 20.04/22.04/24.04)
 xiraid_repo_base_url: "https://pkg.xinnor.io/repository/Repository/xiraid/ubuntu/multi-pack"


### PR DESCRIPTION
## Summary
- handle kernels with a release suffix when constructing the xiRAID repo filename

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_6845fbcacf3c8328aa327314a9c7f03e