### PR TITLE
Update xiRAID role to add repo package workflow

### DIFF
--- a/collection/roles/xiraid_classic/README.md
+++ b/collection/roles/xiraid_classic/README.md
@@ -4,7 +4,9 @@ kernel module.
 
 ## Variables
 * `xiraid_version` – set to 4.2.0, 4.1.0 ...
-* `xiraid_repo_url` – auto-derived; override for offline mirror.
+* `xiraid_repo_version` – version of `xiraid-repo_*.deb` package.
+* `xiraid_kernel` – kernel version used for the repo package (defaults to current).
+* `xiraid_repo_pkg_url` – full URL to download the repository package; override for offline mirror.
 * `xiraid_packages` – list of debs (`xiraid-core`, `xicli`, etc.).
 * `xiraid_auto_reboot` – reboot after install.
 

--- a/collection/roles/xiraid_classic/defaults/main.yml
+++ b/collection/roles/xiraid_classic/defaults/main.yml
@@ -1,16 +1,20 @@
 # xiRAID version to install (use 4.x.y). The repo package is auto-derived.
 xiraid_version: "4.2.0"
 
-# Repo package filename for current kernel (override if you mirror files)
-# Example: xiraid-repo_1.2.0-1462.kver.6.8_amd64.deb
-# xiRAID repo package uses major.minor kernel version only
-xiraid_repo_kernel: "{{ ansible_kernel | regex_replace('^(\\d+\\.\\d+).*', '\\1') }}"
-xiraid_repo_filename: "xiraid-repo_1.2.0-1462.kver.{{ xiraid_repo_kernel }}_amd64.deb"
+# Version of the repository package
+xiraid_repo_version: "1.2.0-1462"
+
+# Target kernel for the repo package (current kernel by default)
+xiraid_kernel: "{{ ansible_kernel }}"
+
+# Compose repository package name
+xiraid_repo_pkg: "xiraid-repo_{{ xiraid_repo_version }}.kver.{{ xiraid_kernel }}_amd64.deb"
 
 # Base URL to Xinnor repository (multi-pack works for 20.04/22.04/24.04)
-xiraid_repo_base_url: "https://pkg.xinnor.io/repository/Repository/xiraid/ubuntu/multi-pack"
+xiraid_repo_url_base: "https://pkg.xinnor.io/repository/Repository/xiraid/ubuntu/multi-pack"
 
-xiraid_repo_url: "{{ xiraid_repo_base_url }}/{{ xiraid_repo_filename }}"
+# Full URL of repository package
+xiraid_repo_pkg_url: "{{ xiraid_repo_url_base }}/{{ xiraid_repo_pkg }}"
 
 # List of xiRAID packages; adjust if version scheme changes.
 xiraid_packages:

--- a/collection/roles/xiraid_classic/tasks/main.yml
+++ b/collection/roles/xiraid_classic/tasks/main.yml
@@ -5,25 +5,27 @@
     state: present
   tags: [xiraid, deps]
 
-- name: Download xiRAID repository package for current kernel
+
+- name: Download xiRAID repo package
   ansible.builtin.get_url:
-    url: "{{ xiraid_repo_url }}"
-    dest: "/tmp/{{ xiraid_repo_filename }}"
-    mode: 0644
+    url: "{{ xiraid_repo_pkg_url }}"
+    dest: "/tmp/{{ xiraid_repo_pkg }}"
+    mode: '0644'
     force: no
-  register: xiraid_repo_pkg
+  register: xiraid_repo_dl
   tags: [xiraid, download]
 
-- name: Add xiRAID APT repository (.deb)
+- name: Install xiRAID repo package
   ansible.builtin.apt:
-    deb: "/tmp/{{ xiraid_repo_filename }}"
+    deb: "/tmp/{{ xiraid_repo_pkg }}"
     state: present
+  when: xiraid_repo_dl.changed
   register: xiraid_repo_added
   tags: [xiraid, repo]
 
-- name: Update APT cache (if repo added)
+- name: Update apt cache after xiRAID repo added
   ansible.builtin.apt:
-    update_cache: yes
+    update_cache: true
   when: xiraid_repo_added is changed
   tags: [xiraid, repo]
 


### PR DESCRIPTION
## Summary
- configure xiRAID role defaults with repo package variables
- download/install repo package then update apt cache
- document new variables in README

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_6846070aba688328b52190f98602170f