### PR TITLE
Fix repo URL by using major.minor kernel

### DIFF
--- a/collection/roles/xiraid_classic/README.md
+++ b/collection/roles/xiraid_classic/README.md
@@ -5,7 +5,7 @@ kernel module.
 ## Variables
 * `xiraid_version` – set to 4.2.0, 4.1.0 ...
 * `xiraid_repo_version` – version of `xiraid-repo_*.deb` package.
-* `xiraid_kernel` – kernel version used for the repo package (defaults to current).
+* `xiraid_kernel` – kernel version used for the repo package (defaults to major.minor of the current kernel).
 * `xiraid_repo_pkg_url` – full URL to download the repository package; override for offline mirror.
 * `xiraid_packages` – list of debs (`xiraid-core`, `xicli`, etc.).
 * `xiraid_auto_reboot` – reboot after install.

--- a/collection/roles/xiraid_classic/defaults/main.yml
+++ b/collection/roles/xiraid_classic/defaults/main.yml
@@ -4,8 +4,10 @@ xiraid_version: "4.2.0"
 # Version of the repository package
 xiraid_repo_version: "1.2.0-1462"
 
-# Target kernel for the repo package (current kernel by default)
-xiraid_kernel: "{{ ansible_kernel }}"
+# Target kernel for the repo package (current kernel's major.minor by default)
+# Repository packages are named with just the major and minor kernel numbers
+# (e.g. `kver.6.8`), so extract those from `ansible_kernel`.
+xiraid_kernel: "{{ ansible_kernel | regex_replace('^(\\d+\\.\\d+).*', '\\1') }}"
 
 # Compose repository package name
 xiraid_repo_pkg: "xiraid-repo_{{ xiraid_repo_version }}.kver.{{ xiraid_kernel }}_amd64.deb"


### PR DESCRIPTION
## Summary
- fix xiRAID repo URL generation: strip patch level from `ansible_kernel`
- document the default kernel format in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684668217e488328bb0e524c22576421