### PR TITLE
Fix xiRAID install packages

### DIFF
--- a/collection/roles/xiraid_classic/README.md
+++ b/collection/roles/xiraid_classic/README.md
@@ -7,7 +7,7 @@ kernel module.
 * `xiraid_repo_version` – version of `xiraid-repo_*.deb` package.
 * `xiraid_kernel` – kernel version used for the repo package (defaults to major.minor of the current kernel).
 * `xiraid_repo_pkg_url` – full URL to download the repository package; override for offline mirror.
-* `xiraid_packages` – list of debs (`xiraid-core`, `xicli`, etc.).
+* `xiraid_packages` – list of deb packages (defaults to `xiraid-core`).
 * `xiraid_auto_reboot` – reboot after install.
 
 ## Example play snippet

--- a/collection/roles/xiraid_classic/defaults/main.yml
+++ b/collection/roles/xiraid_classic/defaults/main.yml
@@ -21,7 +21,6 @@ xiraid_repo_pkg_url: "{{ xiraid_repo_url_base }}/{{ xiraid_repo_pkg }}"
 # List of xiRAID packages; adjust if version scheme changes.
 xiraid_packages:
   - xiraid-core
-  - xicli
 
 # Whether to reboot automatically after install (usually not required)
 xiraid_auto_reboot: false

--- a/collection/roles/xiraid_classic/tasks/main.yml
+++ b/collection/roles/xiraid_classic/tasks/main.yml
@@ -23,13 +23,12 @@
   register: xiraid_repo_added
   tags: [xiraid, repo]
 
-- name: Update apt cache after xiRAID repo added
+- name: Update apt cache
   ansible.builtin.apt:
     update_cache: true
-  when: xiraid_repo_added is changed
-  tags: [xiraid, repo]
+  tags: [xiraid, install]
 
-- name: Install xiRAID packages (kernel module + CLI)
+- name: Install xiRAID core package
   ansible.builtin.apt:
     name: "{{ xiraid_packages }}"
     state: present


### PR DESCRIPTION
## Summary
- update apt cache before installing
- only install `xiraid-core`

## Testing
- `ansible-lint -v` *(fails: 89 failure(s))*
- `ansible-playbook playbooks/site.yml --syntax-check`
- `ansible-playbook playbooks/common.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_684669724e44832899fffb39f77470f4