### PR TITLE
Enable automatic xiRAID EULA acceptance

### DIFF
--- a/collection/roles/xiraid_classic/README.md
+++ b/collection/roles/xiraid_classic/README.md
@@ -1,6 +1,7 @@
 # Role **xiraid_classic**
 Installs Xinnor xiRAID Classic {{ xiraid_version }} on Ubuntu LTS with DKMS-built
-kernel module.
+kernel module. The role accepts the xiRAID EULA automatically using
+`xicli settings eula modify -s accepted`.
 
 ## Variables
 * `xiraid_version` – set to 4.2.0, 4.1.0 ...
@@ -9,6 +10,7 @@ kernel module.
 * `xiraid_repo_pkg_url` – full URL to download the repository package; override for offline mirror.
 * `xiraid_packages` – list of deb packages (defaults to `xiraid-core`).
 * `xiraid_auto_reboot` – reboot after install.
+* `xiraid_accept_eula` – automatically accept the xiRAID EULA (default: `true`).
 
 ## Example play snippet
 ```yaml

--- a/collection/roles/xiraid_classic/defaults/main.yml
+++ b/collection/roles/xiraid_classic/defaults/main.yml
@@ -24,3 +24,6 @@ xiraid_packages:
 
 # Whether to reboot automatically after install (usually not required)
 xiraid_auto_reboot: false
+
+# Automatically accept xiRAID EULA after installation
+xiraid_accept_eula: true

--- a/collection/roles/xiraid_classic/tasks/main.yml
+++ b/collection/roles/xiraid_classic/tasks/main.yml
@@ -35,6 +35,12 @@
   register: xiraid_pkgs
   tags: [xiraid, install]
 
+- name: Accept xiRAID EULA
+  ansible.builtin.command: xicli settings eula modify -s accepted
+  when: xiraid_accept_eula | bool
+  changed_when: false
+  tags: [xiraid, eula]
+
 # Optional verification section
 - name: Verify xiRAID kernel module loaded
   ansible.builtin.shell: "lsmod | grep -q xiraid"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -5,7 +5,7 @@
   roles:
     - role: common
     - role: doca_ofed
-    - role: xiraid_classic
+    - role: xiraid_classic  # EULA is accepted automatically
     - role: raid_fs
     - role: exports       # manage /etc/exports
     - role: nfs_server    # configure kernel NFS server


### PR DESCRIPTION
## Summary
- accept the xiRAID EULA automatically after install
- expose a variable `xiraid_accept_eula` (defaults to true)
- document the default EULA acceptance
- mention in the playbook template that EULA is accepted automatically

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_68467f2e0ed08328bcbebb1af9f95f7e