### PR TITLE
Fix RAID show JSON command

### DIFF
--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Gather existing xiRAID arrays (json)
-  ansible.builtin.command: xicli raid list --json
+  ansible.builtin.command: xicli raid show -f json
   register: xiraid_list
   changed_when: false
   failed_when: xiraid_list.rc != 0


### PR DESCRIPTION
## Summary
- call `xicli raid show -f json` when enumerating arrays

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684681a28f1883288c085a0af3f88542