### PR TITLE
Fix xiRAID array creation condition

### DIFF
--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -16,7 +16,7 @@
   loop: "{{ xiraid_arrays }}"
   loop_control:
     loop_var: item
-  when: item.name not in existing_arrays | json_query('[].name')
+  when: item.name not in (existing_arrays | json_query('[].name') | default([]))
   tags: [raid_fs, raid]
 
 # ----------------------- Filesystem section -------------------


### PR DESCRIPTION
## Summary
- handle empty xiRAID array list correctly

## Testing
- `ansible-lint` *(fails: command not found)*
- `ansible-playbook playbooks/site.yml --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846851b265c83289dd52040a21f07a6