### PR TITLE
Fix xiRAID arrays condition

### DIFF
--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -16,7 +16,9 @@
   loop: "{{ xiraid_arrays }}"
   loop_control:
     loop_var: item
-  when: item.name not in (existing_arrays | json_query('[].name') | default([]))
+  # If `xiraid_list.stdout` couldn't be parsed, `existing_arrays` may be `None`.
+  # Apply `default([])` before the `json_query` filter to avoid type errors.
+  when: item.name not in (existing_arrays | default([]) | json_query('[].name'))
   tags: [raid_fs, raid]
 
 # ----------------------- Filesystem section -------------------


### PR DESCRIPTION
## Summary
- avoid NoneType errors when checking for existing arrays

## Testing
- `ansible-playbook -i inventories/lab.ini playbooks/site.yml --syntax-check`
- `ansible-playbook -i inventories/lab.ini playbooks/site.yml --check` *(fails: hwclock missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846a0647e7c832885ac0d222dc97d1e