### PR TITLE
Fix raid_fs condition for empty arrays

### DIFF
--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -18,7 +18,7 @@
     loop_var: item
   # If `xiraid_list.stdout` couldn't be parsed, `existing_arrays` may be `None`.
   # Apply `default([])` before the `json_query` filter to avoid type errors.
-  when: item.name not in (existing_arrays | default([]) | json_query('[].name'))
+  when: item.name not in ((existing_arrays | default([]) | json_query('[].name')) | default([]))
   tags: [raid_fs, raid]
 
 # ----------------------- Filesystem section -------------------


### PR DESCRIPTION
## Summary
- handle empty or malformed existing_arrays

## Testing
- `ansible-playbook --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a305ff7c8328bb1b4e5c147dc6b1