### PR TITLE
Fix raid_fs when condition

### DIFF
--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -18,7 +18,8 @@
     loop_var: item
   # If `xiraid_list.stdout` couldn't be parsed, `existing_arrays` may be `None`.
   # Apply `default([])` before the `json_query` filter to avoid type errors.
-  when: item.name not in ((existing_arrays | default([]) | json_query('[].name')) | default([]))
+  # Pass `true` to `default` so that `None` is treated as undefined.
+  when: item.name not in ((existing_arrays | default([], true) | json_query('[].name')) | default([], true))
   tags: [raid_fs, raid]
 
 # ----------------------- Filesystem section -------------------


### PR DESCRIPTION
## Summary
- handle `None` values in raid_fs role when condition

## Testing
- `ansible-playbook -i inventories/lab.ini test_play.yml -e ansible_python_interpreter=/usr/bin/python3.12` *(fails: community.general.yaml deprecation warning etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6846ac48cf848328939be8fa6e06f580