### PR TITLE
Add xiRAID license update step

### DIFF
--- a/collection/roles/raid_fs/README.md
+++ b/collection/roles/raid_fs/README.md
@@ -4,6 +4,7 @@ Creates xiRAID arrays and tuned XFS filesystems as per Xinnor NFS RDMA blog.
 ## Variables
 * `xiraid_arrays` – list of array definitions (name, level, devices, strip size, parity).
 * `xfs_filesystems` – list defining data/log device pairs, mount point, mkfs params.
+* `xiraid_license_path` – path to license file applied before arrays are created.
 
 ## Example playbook
 ```yaml

--- a/collection/roles/raid_fs/defaults/main.yml
+++ b/collection/roles/raid_fs/defaults/main.yml
@@ -5,6 +5,8 @@
 #   strip_size_kb – stripe size in KiB (e.g. 128)
 #   devices       – list of NVMe block devices (absolute paths)
 #   parity_disks  – optional, if level 6/5 specify data disk count for sw calc
+xiraid_license_path: "/tmp/license"
+
 xiraid_arrays:
   - name: media6
     level: 6

--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Apply xiRAID license
+  ansible.builtin.command: "xicli license update -p {{ xiraid_license_path }}"
+  changed_when: false
+  tags: [raid_fs, raid]
+
 - name: Gather existing xiRAID arrays (json)
   ansible.builtin.command: xicli raid show -f json
   register: xiraid_list

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -4,6 +4,9 @@
 nfs_threads: 64
 nfs_rdma_port: 20049
 
+# xiRAID license file path
+xiraid_license_path: /tmp/license
+
 # NFS exports
 exports:
   - path: /mnt/data


### PR DESCRIPTION
## Summary
- update RAID role defaults with `xiraid_license_path`
- configure `xiraid_license_path` in inventory
- apply xiRAID license before creating arrays
- document new variable

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_6846cb0370348328b466fb172e48fc36