### PR TITLE
Add optional --force_metadata to RAID creation

### DIFF
--- a/collection/roles/raid_fs/README.md
+++ b/collection/roles/raid_fs/README.md
@@ -5,6 +5,7 @@ Creates xiRAID arrays and tuned XFS filesystems as per Xinnor NFS RDMA blog.
 * `xiraid_arrays` – list of array definitions (name, level, devices, strip size, parity).
 * `xfs_filesystems` – list defining data/log device pairs, mount point, mkfs params.
 * `xiraid_license_path` – path to license file applied before arrays are created.
+* `xiraid_force_metadata` – when `true` add `--force_metadata` to array creation.
 
 ## Example playbook
 ```yaml

--- a/collection/roles/raid_fs/defaults/main.yml
+++ b/collection/roles/raid_fs/defaults/main.yml
@@ -7,6 +7,10 @@
 #   parity_disks  – optional, if level 6/5 specify data disk count for sw calc
 xiraid_license_path: "/tmp/license"
 
+# Whether to pass `--force_metadata` when creating arrays
+# Set to `false` if metadata should not be overwritten
+xiraid_force_metadata: true
+
 xiraid_arrays:
   - name: media6
     level: 6

--- a/collection/roles/raid_fs/tasks/create_array.yml
+++ b/collection/roles/raid_fs/tasks/create_array.yml
@@ -10,6 +10,7 @@
   ansible.builtin.command: >-
     xicli raid create -n {{ item.name }} -l {{ item.level }}
     -d {{ _devlist }} -ss {{ item.strip_size_kb }}
+    {% if xiraid_force_metadata | bool %}--force_metadata{% endif %}
   register: raid_create
   tags: [raid_fs, raid]
 


### PR DESCRIPTION
## Summary
- add `xiraid_force_metadata` variable
- include `--force_metadata` in raid creation when enabled
- document the new variable

## Testing
- `ansible-playbook --syntax-check playbooks/site.yml`

------
https://chatgpt.com/codex/tasks/task_e_6846e5ad73a083289ceeda0b8e6c2764