### PR TITLE
Improve mdraid cleanup

### DIFF
--- a/collection/roles/raid_fs/README.md
+++ b/collection/roles/raid_fs/README.md
@@ -7,6 +7,9 @@ Creates xiRAID arrays and tuned XFS filesystems as per Xinnor NFS RDMA blog.
 * `xiraid_license_path` – path to license file applied before arrays are created.
 * `xiraid_force_metadata` – when `true` add `--force_metadata` to array creation.
 
+This role requires the **mdadm** package to be installed so that any
+leftover Linux MD arrays on xiRAID devices can be stopped and wiped.
+
 ## Example playbook
 ```yaml
 - hosts: storage_nodes

--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -9,6 +9,12 @@
     xiraid_device_basenames: "{{ xiraid_arrays | map(attribute='devices') | flatten | map('basename') | list }}"
   tags: [raid_fs, raid]
 
+- name: Ensure mdadm package present
+  ansible.builtin.apt:
+    name: mdadm
+    state: present
+  tags: [raid_fs, raid]
+
 - name: Find active MD RAID arrays
   ansible.builtin.command: lsblk -ln -o NAME,TYPE | awk '$2 ~ /^raid/ {print "/dev/"$1}'
   register: mdraid_scan
@@ -25,7 +31,10 @@
       comps=$(lsblk -nr -o NAME "$md" | tail -n +2)
       for c in $comps; do
         case " {{ xiraid_device_basenames | join(' ') }} " in
-          *" $c "*) mdadm --stop "$md" ;; 
+          *" $c "*)
+            mdadm --stop "$md"
+            mdadm --zero-superblock "/dev/$c"
+            ;;
         esac
       done
     done


### PR DESCRIPTION
## Summary
- ensure mdadm is installed by raid_fs role
- wipe leftover MD superblocks when stopping arrays
- document mdadm requirement in raid_fs README

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check`
- `ansible-lint playbooks/site.yml` *(fails: 53 violations)*

------
https://chatgpt.com/codex/tasks/task_e_6846f9902b0083289b0dada6cfc4038a