### PR TITLE
Fix MD RAID cleanup by listing components via /sys

### DIFF
--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -28,7 +28,7 @@
     md_devs=$(lsblk -ln -o NAME,TYPE | awk '$2 ~ /^raid/ {print "/dev/"$1}')
     for md in $md_devs; do
       [ -n "$(lsblk -nro MOUNTPOINT "$md")" ] && continue
-      comps=$(lsblk -nr -o NAME "$md" | tail -n +2)
+      comps=$(ls -1 /sys/block/$(basename "$md")/slaves)
       for c in $comps; do
         case " {{ xiraid_device_basenames | join(' ') }} " in
           *" $c "*)


### PR DESCRIPTION
## Summary
- fix script to list array components via `/sys/block/<md>/slaves`

## Testing
- `ansible-playbook --syntax-check playbooks/site.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471efd82c88328a9ba0f264bd4b7c9