### PR TITLE
Fix mdadm stop loop

### DIFF
--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -29,10 +29,20 @@
     for md in $md_devs; do
       [ -n "$(lsblk -nro MOUNTPOINT "$md")" ] && continue
       comps=$(ls -1 /sys/block/$(basename "$md")/slaves)
+      stop_md=0
       for c in $comps; do
         case " {{ xiraid_device_basenames | join(' ') }} " in
           *" $c "*)
-            mdadm --stop "$md"
+            stop_md=1
+            ;;
+        esac
+      done
+      if [ "$stop_md" = 1 ]; then
+        mdadm --stop "$md"
+      fi
+      for c in $comps; do
+        case " {{ xiraid_device_basenames | join(' ') }} " in
+          *" $c "*)
             mdadm --zero-superblock "/dev/$c"
             ;;
         esac


### PR DESCRIPTION
## Summary
- stop each MD raid array only once during cleanup

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_68472b46bd488328b62c8b280f329dce