### PR TITLE
Handle existing xiRAID arrays gracefully

### DIFF
--- a/collection/roles/raid_fs/README.md
+++ b/collection/roles/raid_fs/README.md
@@ -10,6 +10,10 @@ Creates xiRAID arrays and tuned XFS filesystems as per Xinnor NFS RDMA blog.
 This role requires the **mdadm** package to be installed so that any
 leftover Linux MD arrays on xiRAID devices can be stopped and wiped.
 
+Array creation is idempotent. If a RAID with the same name already
+exists in the xiRAID configuration file, the role will skip creation
+without failing.
+
 ## Example playbook
 ```yaml
 - hosts: storage_nodes

--- a/collection/roles/raid_fs/tasks/create_array.yml
+++ b/collection/roles/raid_fs/tasks/create_array.yml
@@ -12,6 +12,10 @@
     -d {{ _devlist }} -ss {{ item.strip_size_kb }}
     {% if xiraid_force_metadata | bool %}--force_metadata{% endif %}
   register: raid_create
+  changed_when: raid_create.rc == 0
+  failed_when:
+    - raid_create.rc != 0
+    - raid_create.stderr is not search('already exists')
   tags: [raid_fs, raid]
 
 - name: Wait for xiRAID block device /dev/xi_{{ item.name }}


### PR DESCRIPTION
## Summary
- avoid failing when an array already exists
- document idempotent array creation behavior

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_68473b9bacf08328a9d899deef7d3f19