### PR TITLE
Set irqbalance stop to opt-in

### DIFF
--- a/collection/roles/perf_tuning/README.md
+++ b/collection/roles/perf_tuning/README.md
@@ -6,7 +6,7 @@ recommended in Xinnor blogs (2023-2025) and NVIDIA ConnectX-7 (400 Gbit) docs.
 ## Features
 * Disables or relaxes CPU security mitigations (optional) to reduce latency.
 * Enables NVMe polling queues and noop scheduler.
-* Stops **irqbalance**, sets CPU governor to *performance*, applies TuneD
+* Optionally stops **irqbalance**, sets CPU governor to *performance*, applies TuneD
   *throughput-performance* profile.
 * Turns off THP/KSM and ups read-ahead, queue depth and *nr_requests*.
 * Network block:

--- a/collection/roles/perf_tuning/defaults/main.yml
+++ b/collection/roles/perf_tuning/defaults/main.yml
@@ -6,7 +6,7 @@
 # These variables can be overridden in group_vars/<group>.yml
 perf_disable_mitigations: true         # add Spectre/Meltdown mitigations=off, etc.
 perf_nvme_poll_queues: 4               # echo "options nvme poll_queues=4"
-perf_stop_irqbalance: true             # stop irqbalance
+perf_stop_irqbalance: false            # stop irqbalance
 perf_cpu_governor: "performance"       # cpupower governor
 perf_disable_thp: true                 # transparent hugepages=never
 perf_disable_ksm: true


### PR DESCRIPTION
## Summary
- perf_tuning role now leaves irqbalance running unless enabled
- update README to state irqbalance stopping is optional

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_6847b15a76f883288a7eb2226dcf1ec5