### PR TITLE
Remove NVMe scheduler configuration

### DIFF
--- a/collection/roles/perf_tuning/README.md
+++ b/collection/roles/perf_tuning/README.md
@@ -5,7 +5,7 @@ recommended in Xinnor blogs (2023-2025) and NVIDIA ConnectX-7 (400 Gbit) docs.
 
 ## Features
 * Disables or relaxes CPU security mitigations (optional) to reduce latency.
-* Enables NVMe polling queues and noop scheduler.
+* Enables NVMe polling queues.
 * Optionally stops **irqbalance**, sets CPU governor to *performance*, applies TuneD
   *throughput-performance* profile.
 * Turns off THP/KSM and ups read-ahead, queue depth and *nr_requests*.

--- a/collection/roles/perf_tuning/defaults/main.yml
+++ b/collection/roles/perf_tuning/defaults/main.yml
@@ -10,7 +10,7 @@ perf_stop_irqbalance: false            # stop irqbalance
 perf_cpu_governor: "performance"       # cpupower governor
 perf_disable_thp: true                 # transparent hugepages=never
 perf_disable_ksm: true
-perf_scheduler: "noop"                  # I/O scheduler for NVMe
+perf_scheduler: "noop"                  # I/O scheduler for NVMe (unused)
 perf_nr_requests: 512
 perf_read_ahead_kb: 65536             # blockdev --setra
 perf_tuned_profile: "throughput-performance"

--- a/collection/roles/perf_tuning/tasks/main.yml
+++ b/collection/roles/perf_tuning/tasks/main.yml
@@ -57,10 +57,7 @@
   tags: [memory]
 
 # ===== I/O scheduler & queue depth =====
-- name: Force {{ perf_scheduler }} scheduler on NVMe devices
-  ansible.builtin.shell: |
-    for dev in /sys/block/nvme*/queue/scheduler; do echo {{ perf_scheduler }} > "$dev"; done
-  tags: [io]
+# noop scheduler configuration removed
 
 - name: Increase nr_requests queue depth to {{ perf_nr_requests }} on NVMe devices
   ansible.builtin.shell: |


### PR DESCRIPTION
## Summary
- remove step that enforced NVMe scheduler in `perf_tuning` role
- document the change in README
- mark scheduler variable as unused

## Testing
- `ansible-playbook --syntax-check playbooks/*`

------
https://chatgpt.com/codex/tasks/task_e_68481c3fb6408328b90ff0c095e6ef5d