### PR TITLE
Add HWKEY display to prepare script

### DIFF
--- a/prepare_system.sh
+++ b/prepare_system.sh
@@ -20,6 +20,11 @@ fi
 # Pull latest changes
 git pull origin main
 
+# Show hardware key required for license
+echo "HWKEY:"
+chmod +x ./hwkey
+./hwkey
+
 # Ask for license and store it
 if [ -f /tmp/license ]; then
     echo "Using existing license from /tmp/license"


### PR DESCRIPTION
## Summary
- update `prepare_system.sh` to show hardware key before license entry

## Testing
- `bash -n prepare_system.sh`


------
https://chatgpt.com/codex/tasks/task_e_684886d2a63c8328895ea980d4adf4bc