### PR TITLE
Add network controller configuration role

### DIFF
--- a/collection/roles/net_controllers/README.md
+++ b/collection/roles/net_controllers/README.md
@@ -1,0 +1,7 @@
+# Role: net_controllers
+
+Configures static IPv4 addresses for network controllers using netplan.
+
+By default, the template sets interface `ib0` with address `100.100.100.1/24`.
+A startup script can modify the template before running Ansible to configure
+other interfaces and addresses.

--- a/collection/roles/net_controllers/handlers/main.yml
+++ b/collection/roles/net_controllers/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: apply netplan
+  ansible.builtin.command: netplan apply
+  become: true

--- a/collection/roles/net_controllers/tasks/main.yml
+++ b/collection/roles/net_controllers/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Deploy netplan configuration for network controllers
+  ansible.builtin.template:
+    src: netplan.yaml.j2
+    dest: /etc/netplan/99-xinas.yaml
+    owner: root
+    group: root
+    mode: '0644'
+  notify: apply netplan
+  tags: [network]

--- a/collection/roles/net_controllers/templates/netplan.yaml.j2
+++ b/collection/roles/net_controllers/templates/netplan.yaml.j2
@@ -1,0 +1,7 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    ib0:
+      dhcp4: no
+      addresses: [ 100.100.100.1/24 ]

--- a/configure_network.sh
+++ b/configure_network.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+ROLE_TEMPLATE="collection/roles/net_controllers/templates/netplan.yaml.j2"
+
+# list available interfaces excluding loopback
+available=$(ip -o link show | awk -F': ' '{print $2}' | grep -v lo)
+
+echo "Available interfaces:"
+echo "$available"
+
+configs=()
+count=0
+while [[ $count -lt 4 ]]; do
+    read -rp "Interface to configure (leave empty to finish): " iface
+    [[ -z "$iface" ]] && break
+    if ! echo "$available" | grep -qw "$iface"; then
+        echo "Interface $iface not found" >&2
+        continue
+    fi
+    read -rp "IPv4 address for $iface (A.B.C.D/EE): " addr
+    configs+=("$iface:$addr")
+    count=$((count+1))
+done
+
+if [[ ${#configs[@]} -eq 0 ]]; then
+    configs=("ib0:100.100.100.1/24")
+fi
+
+cat > "$ROLE_TEMPLATE" <<EOF2
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+EOF2
+
+for cfg in "${configs[@]}"; do
+    IFS=: read name addr <<< "$cfg"
+    cat >> "$ROLE_TEMPLATE" <<EOF2
+    $name:
+      dhcp4: no
+      addresses: [ $addr ]
+EOF2
+done
+
+echo "Updated $ROLE_TEMPLATE"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -5,6 +5,7 @@
   roles:
     - role: common
     - role: doca_ofed
+    - role: net_controllers
     - role: xiraid_classic  # EULA is accepted automatically
     - role: raid_fs
     - role: exports       # manage /etc/exports

--- a/prepare_system.sh
+++ b/prepare_system.sh
@@ -33,6 +33,9 @@ else
     cat > /tmp/license
 fi
 
+# Configure network interfaces via startup script
+./configure_network.sh
+
 # Show tasks to be performed by Ansible
 echo "The following Ansible tasks will be executed:"
 ansible-playbook playbooks/site.yml --list-tasks


### PR DESCRIPTION
## Summary
- add `net_controllers` role to deploy static netplan configuration
- add startup script `configure_network.sh` that generates the role's template
- call startup script in `prepare_system.sh`
- include new role in `site.yml` playbook

## Testing
- `ansible-playbook --syntax-check playbooks/site.yml`

------
https://chatgpt.com/codex/tasks/task_e_68488c02194883289faf862ae2b17e5f