### PR TITLE
Enhance network setup script

### DIFF
--- a/collection/roles/net_controllers/README.md
+++ b/collection/roles/net_controllers/README.md
@@ -4,4 +4,6 @@ Configures static IPv4 addresses for network controllers using netplan.
 
 By default, the template sets interface `ib0` with address `100.100.100.1/24`.
 A startup script can modify the template before running Ansible to configure
-other interfaces and addresses.
+other interfaces and addresses. When executed it lists all available interfaces
+along with their current IPv4 address and link speed so that you can select the
+correct device.

--- a/configure_network.sh
+++ b/configure_network.sh
@@ -5,8 +5,16 @@ ROLE_TEMPLATE="collection/roles/net_controllers/templates/netplan.yaml.j2"
 # list available interfaces excluding loopback
 available=$(ip -o link show | awk -F': ' '{print $2}' | grep -v lo)
 
-echo "Available interfaces:"
-echo "$available"
+echo "Available interfaces (current IPv4, speed):"
+for iface in $available; do
+    ip_addr=$(ip -o -4 addr show "$iface" | awk '{print $4}')
+    [[ -z "$ip_addr" ]] && ip_addr="none"
+    speed="unknown"
+    if [[ -e "/sys/class/net/$iface/speed" ]]; then
+        speed=$(cat "/sys/class/net/$iface/speed" 2>/dev/null || echo "unknown")
+    fi
+    echo "  $iface - $ip_addr - ${speed}Mb/s"
+done
 
 configs=()
 count=0


### PR DESCRIPTION
## Summary
- show existing IPv4 and link speed for each interface during configuration
- document new behaviour in `net_controllers` role README

## Testing
- `bash -n configure_network.sh`
- `ansible-playbook playbooks/site.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_68488fd107388328b0ab0e4395454ba6