### PR TITLE
Interactive configuration option and menu polish

### DIFF
--- a/configure_network.sh
+++ b/configure_network.sh
@@ -31,6 +31,8 @@ while true; do
         desc+=" - ${speed}Mb/s"
         menu_items+=("$iface" "$desc")
     done
+    # Add a blank line before the finish option for clarity
+    menu_items+=("" "")
     menu_items+=("Finish" "Finish configuration")
 
     # Show interface selection menu

--- a/prepare_system.sh
+++ b/prepare_system.sh
@@ -25,6 +25,8 @@ echo "HWKEY:"
 chmod +x ./hwkey
 ./hwkey
 
-# Launch interactive startup menu for configuration and deployment
-chmod +x startup_menu.sh
-./startup_menu.sh
+# Ask whether to run interactive configuration menu
+if whiptail --yesno "Configure this system now?" 8 60; then
+    chmod +x startup_menu.sh
+    ./startup_menu.sh
+fi


### PR DESCRIPTION
## Summary
- ask before launching the interactive configuration menu in `prepare_system.sh`
- visually separate the `Finish` option in network configuration menu

## Testing
- `bash -n prepare_system.sh`
- `bash -n configure_network.sh`


------
https://chatgpt.com/codex/tasks/task_e_6849244782f08328a8a60d72fbf8a677