### PR TITLE
Remove license display from prep script

### DIFF
--- a/prepare_system.sh
+++ b/prepare_system.sh
@@ -20,11 +20,6 @@ fi
 # Pull latest changes
 git pull origin main
 
-# Show hardware key required for license for reference
-echo "HWKEY:"
-chmod +x ./hwkey
-./hwkey
-
 # Ask whether to run interactive configuration menu
 if whiptail --yesno "Configure this system now?" 8 60; then
     chmod +x startup_menu.sh


### PR DESCRIPTION
## Summary
- stop printing the hardware key during system prep

## Testing
- `shellcheck prepare_system.sh startup_menu.sh configure_network.sh`

------
https://chatgpt.com/codex/tasks/task_e_68492594db548328bf9fca13cc66a17b