### PR TITLE
Enhance system preparation with optional playbook run

### DIFF
--- a/prepare_system.sh
+++ b/prepare_system.sh
@@ -25,3 +25,14 @@ if whiptail --yesno "Configure this system now?" 8 60; then
     chmod +x startup_menu.sh
     ./startup_menu.sh
 fi
+
+# After the menu has finished, explain the Ansible run and optionally execute it
+PLAYBOOK="playbooks/site.yml"
+
+# Build a short description of roles from the site.yml file
+ROLE_LIST=$(grep -E '^\s*- role:' "$PLAYBOOK" | awk '{print $3}' | tr '\n' ' ')
+
+if whiptail --yesno "Run Ansible playbook to configure the system?\n\nThis will execute the following roles: $ROLE_LIST" 15 70; then
+    INV_FILE=$(whiptail --inputbox "Inventory to use for Ansible" 10 70 "inventories/lab.ini" 3>&1 1>&2 2>&3)
+    ansible-playbook "$PLAYBOOK" -i "$INV_FILE" -v
+fi


### PR DESCRIPTION
## Summary
- prompt for startup menu
- offer user to run the site playbook after menu
- display roles from the playbook and allow inventory choice

## Testing
- `shellcheck prepare_system.sh`

------
https://chatgpt.com/codex/tasks/task_e_684926d960788328a02f54760ffd2b6b