### PR TITLE
Remove playbook-related menu options

### DIFF
--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -82,16 +82,12 @@ while true; do
     choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 20 70 10 \
         1 "Enter License" \
         2 "Configure Network" \
-        3 "Show Playbook Info" \
-        4 "Run Ansible Playbook" \
-        5 "Exit" \
+        3 "Exit" \
         3>&1 1>&2 2>&3)
     case "$choice" in
         1) enter_license ;;
         2) configure_network ;;
-        3) show_playbook_info ;;
-        4) run_playbook && exit 0 || exit 1 ;;
-        5) exit 0 ;;
+        3) exit 0 ;;
     esac
 done
 


### PR DESCRIPTION
## Summary
- remove 'Show Playbook Info' and 'Run Ansible Playbook' from the startup menu

## Testing
- `shellcheck startup_menu.sh`

------
https://chatgpt.com/codex/tasks/task_e_68492ae5af588328a52903fab2b55eaa