### PR TITLE
Add edit/add options for NFS share view

### DIFF
--- a/configure_nfs_exports.sh
+++ b/configure_nfs_exports.sh
@@ -51,6 +51,15 @@ add_export() {
     mv "$tmp" "$vars_file"
 }
 
+# Allow non-interactive calls for editing or adding a single export
+if [ "${1:-}" = "--edit" ] && [ -n "${2:-}" ]; then
+    edit_export "$2"
+    exit 0
+elif [ "${1:-}" = "--add" ]; then
+    add_export
+    exit 0
+fi
+
 while true; do
     mapfile -t paths < <(yq -r '.exports[].path' "$vars_file")
     menu_items=()


### PR DESCRIPTION
## Summary
- improve NFS export editing script with non-interactive options
- show default NFS share and provide edit/add choices in startup menu

## Testing
- `bash -n startup_menu.sh`
- `bash -n configure_nfs_exports.sh`
- `ansible-playbook --syntax-check playbooks/site.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494a21c8ac832896740d448eff1615