### PR TITLE
Remove unused NFS configuration option

### DIFF
--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -117,16 +117,14 @@ while true; do
     choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 20 70 10 \
         1 "Enter License" \
         2 "Configure Network" \
-        3 "Configure NFS Shares" \
-        4 "Edit NFS Exports" \
-        5 "Exit" \
+        3 "Edit NFS Exports" \
+        4 "Exit" \
         3>&1 1>&2 2>&3)
     case "$choice" in
         1) enter_license ;;
         2) configure_network ;;
-        3) configure_nfs_shares ;;
-        4) edit_nfs_exports ;;
-        5) exit 0 ;;
+        3) edit_nfs_exports ;;
+        4) exit 0 ;;
     esac
 done
 


### PR DESCRIPTION
## Summary
- remove the "Configure NFS Shares" option from the startup menu

## Testing
- `bash -n startup_menu.sh`

------
https://chatgpt.com/codex/tasks/task_e_68494dd90d8483288acd82123feb5c7a