### PR TITLE
Add RAID configuration menu

### DIFF
--- a/configure_raid.sh
+++ b/configure_raid.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Interactive editor for RAID drive lists
+set -euo pipefail
+
+vars_file="group_vars/all.yml"
+
+if [ ! -f "$vars_file" ]; then
+    echo "Error: $vars_file not found" >&2
+    exit 1
+fi
+
+get_devices() {
+    local level="$1"
+    yq -r ".xiraid_arrays[] | select(.level==${level}) | .devices | join(' ')" "$vars_file" 2>/dev/null
+}
+
+edit_devices() {
+    local level="$1"
+    local current new tmp status
+    current="$(get_devices "$level")"
+    if [ -z "$current" ]; then
+        whiptail --msgbox "No RAID${level} array defined" 8 60
+        return
+    fi
+    set +e
+    new=$(whiptail --inputbox "Space-separated devices for RAID${level}" 10 70 "$current" 3>&1 1>&2 2>&3)
+    status=$?
+    set -e
+    [ $status -ne 0 ] && return
+    tmp=$(mktemp)
+    NEW_LIST="$new" yq -y "(.xiraid_arrays[] | select(.level==${level})).devices = (env(NEW_LIST) | split(\" \") )" "$vars_file" > "$tmp"
+    mv "$tmp" "$vars_file"
+}
+
+while true; do
+    raid6_devices=$(get_devices 6)
+    raid1_devices=$(get_devices 1)
+    menu=$(whiptail --title "RAID Configuration" --menu "Select array to edit:" 15 70 5 \
+        1 "RAID6: ${raid6_devices:-none}" \
+        2 "RAID1: ${raid1_devices:-none}" \
+        3 "Back" 3>&1 1>&2 2>&3)
+    case "$menu" in
+        1) edit_devices 6 ;;
+        2) edit_devices 1 ;;
+        *) break ;;
+    esac
+done
+

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -91,6 +91,11 @@ edit_nfs_exports() {
     ./configure_nfs_exports.sh
 }
 
+# Configure RAID devices interactively
+configure_raid() {
+    ./configure_raid.sh
+}
+
 # Run ansible-playbook and stream output
 run_playbook() {
     local log="$TMP_DIR/playbook.log"
@@ -117,14 +122,16 @@ while true; do
     choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 20 70 10 \
         1 "Enter License" \
         2 "Configure Network" \
-        3 "Edit NFS Exports" \
-        4 "Exit" \
+        3 "Configure RAID" \
+        4 "Edit NFS Exports" \
+        5 "Exit" \
         3>&1 1>&2 2>&3)
     case "$choice" in
         1) enter_license ;;
         2) configure_network ;;
-        3) edit_nfs_exports ;;
-        4) exit 0 ;;
+        3) configure_raid ;;
+        4) edit_nfs_exports ;;
+        5) exit 0 ;;
     esac
 done
 


### PR DESCRIPTION
## Summary
- provide an interactive script `configure_raid.sh` to view and edit RAID6 and RAID1 drives
- extend `startup_menu.sh` with a new menu item to invoke the RAID configuration

## Testing
- `bash -n configure_raid.sh startup_menu.sh`

------
https://chatgpt.com/codex/tasks/task_e_684950a99e3083289438aeaf1c24593a