### PR TITLE
Add dependency checks to RAID config script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# xiNAS
+
+This repository contains scripts and Ansible playbooks used to provision xiNAS nodes.
+
+## Getting started
+
+1. Run `prepare_system.sh` on the target host. This installs required packages such as `yq`, `whiptail`, Ansible and clones the repository.
+2. Execute `startup_menu.sh` to configure network, RAID arrays and NFS exports interactively.
+3. Optionally run the included Ansible playbook to apply the configuration.
+
+The `prepare_system.sh` script installs dependencies required by the interactive helper scripts. If you encounter an error like `yq: command not found` when selecting **Configure RAID**, ensure that `prepare_system.sh` has been run or install `yq` manually.

--- a/configure_raid.sh
+++ b/configure_raid.sh
@@ -4,6 +4,14 @@ set -euo pipefail
 
 vars_file="group_vars/all.yml"
 
+# Ensure required commands are present
+for cmd in yq whiptail; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "Error: required command '$cmd' not found. Please run prepare_system.sh or install it manually." >&2
+        exit 1
+    fi
+done
+
 if [ ! -f "$vars_file" ]; then
     echo "Error: $vars_file not found" >&2
     exit 1


### PR DESCRIPTION
## Summary
- alert users when yq or whiptail are missing in `configure_raid.sh`
- document setup steps and dependency requirements in a new `README.md`

## Testing
- `bash configure_raid.sh 2>&1 | head`
- `bash prepare_system.sh >/tmp/prepare.log 2>&1` *(fails: Operation was interrupted before it could finish)*

------
https://chatgpt.com/codex/tasks/task_e_68495a1c23c48328b95ac820a7730b39