### PR TITLE
Fix quoting in configure_raid.sh

### DIFF
--- a/configure_raid.sh
+++ b/configure_raid.sh
@@ -19,7 +19,7 @@ fi
 
 get_devices() {
     local level="$1"
-    yq -r ".xiraid_arrays[] | select(.level==${level}) | .devices | join(' ')" "$vars_file" 2>/dev/null
+    yq -r ".xiraid_arrays[] | select(.level==${level}) | .devices | join(\" \" )" "$vars_file" 2>/dev/null
 }
 
 edit_devices() {


### PR DESCRIPTION
## Summary
- fix quoting when fetching RAID device lists

## Testing
- `shellcheck configure_raid.sh`

------
https://chatgpt.com/codex/tasks/task_e_68495c72382c8328bccc5583ca3edc5f