### PR TITLE
Fix scripts for yq v4 compatibility

### DIFF
--- a/configure_nfs_exports.sh
+++ b/configure_nfs_exports.sh
@@ -24,7 +24,7 @@ edit_export() {
     set -e
     [ $status -ne 0 ] && return
     tmp=$(mktemp)
-    yq -y ".exports |= map(if .path==\"$path\" then .clients=\"${clients}\" | .options=\"${options}\" else . end)" "$vars_file" > "$tmp"
+    yq ".exports |= map(if .path==\"$path\" then .clients=\"${clients}\" | .options=\"${options}\" else . end)" "$vars_file" > "$tmp"
     mv "$tmp" "$vars_file"
 }
 
@@ -47,7 +47,7 @@ add_export() {
     set -e
     [ $status -ne 0 ] && return
     tmp=$(mktemp)
-    yq -y ".exports += [{\"path\": \"${path}\", \"clients\": \"${clients}\", \"options\": \"${options}\"}]" "$vars_file" > "$tmp"
+    yq ".exports += [{\"path\": \"${path}\", \"clients\": \"${clients}\", \"options\": \"${options}\"}]" "$vars_file" > "$tmp"
     mv "$tmp" "$vars_file"
 }
 

--- a/configure_raid.sh
+++ b/configure_raid.sh
@@ -36,7 +36,7 @@ edit_devices() {
     set -e
     [ $status -ne 0 ] && return
     tmp=$(mktemp)
-    NEW_LIST="$new" yq -y "(.xiraid_arrays[] | select(.level==${level})).devices = (env(NEW_LIST) | split(\" \") )" "$vars_file" > "$tmp"
+    NEW_LIST="$new" yq "(.xiraid_arrays[] | select(.level==${level})).devices = (env(NEW_LIST) | split(\" \") )" "$vars_file" > "$tmp"
     mv "$tmp" "$vars_file"
 }
 


### PR DESCRIPTION
## Summary
- update helper scripts to drop deprecated `-y` flag now that `yq` v4 is used

## Testing
- `shellcheck configure_nfs_exports.sh configure_raid.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849758d9a6083289b61a71a13e946cd