### PR TITLE
Switch log RAID device to RAID1 media1

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -31,8 +31,8 @@ xiraid_arrays:
       - /dev/nvme10n1
     parity_disks: 2
 
-  - name: media0
-    level: 10
+  - name: media1
+    level: 1
     strip_size_kb: 16
     devices:
       - /dev/nvme11n1
@@ -41,10 +41,10 @@ xiraid_arrays:
 xfs_filesystems:
   - label: nfsdata
     data_device: "/dev/xi_media6"
-    log_device: "/dev/xi_media0"
+    log_device: "/dev/xi_media1"
     su_kb: 128
     sw: 8
     log_size: 1G
     sector_size: 4k
     mountpoint: /mnt/data
-    mount_opts: "logdev=/dev/xi_media0,noatime,nodiratime,logbsize=256k,largeio,inode64,swalloc,allocsize=131072k"
+    mount_opts: "logdev=/dev/xi_media1,noatime,nodiratime,logbsize=256k,largeio,inode64,swalloc,allocsize=131072k"


### PR DESCRIPTION
## Summary
- switch RAID array level from 10 to 1 and rename array media0 to media1
- update filesystem configuration with new media1 device

## Testing
- `ansible-lint` *(fails: 66 failure(s))*

------
https://chatgpt.com/codex/tasks/task_e_68497ae3c7f883289bf5546994c7174f