### PR TITLE
Add backups for configuration changes

### DIFF
--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -21,6 +21,9 @@ enter_license() {
 
     if [ -f "$license_file" ]; then
         if whiptail --yesno "License already exists. Replace it?" 10 60; then
+            local ts
+            ts=$(date +%Y%m%d%H%M%S)
+            cp "$license_file" "${license_file}.${ts}.bak"
             rm -f "$license_file"
         else
             return


### PR DESCRIPTION
## Summary
- add automatic backup of license file in `startup_menu.sh`
- add helper to backup changed files in configuration scripts
- backup netplan, exports and RAID config before applying edits

## Testing
- `shellcheck startup_menu.sh configure_network.sh configure_nfs_exports.sh configure_raid.sh`

------
https://chatgpt.com/codex/tasks/task_e_684985d6c1c8832888c3e7f43f0cc8e5