### PR TITLE
Fix duplicated RAID configuration

### DIFF
--- a/collection/roles/raid_fs/defaults/main.yml
+++ b/collection/roles/raid_fs/defaults/main.yml
@@ -1,48 +1,16 @@
-# List of arrays to create
-# Each item:
-#   name          – array name (will appear as /dev/xi_<name>)
-#   level         – 0, 5, 6, 10 …
-#   strip_size_kb – stripe size in KiB (e.g. 128)
-#   devices       – list of NVMe block devices (absolute paths)
-#   parity_disks  – optional, if level 6/5 specify data disk count for sw calc
+# Default values for the raid_fs role
+#
+# The actual RAID array and filesystem configuration should be defined in the
+# inventory (e.g. ``group_vars/all.yml``).  Interactive helper scripts expect to
+# modify variables in that location.
 xiraid_license_path: "/tmp/license"
 
 # Whether to pass `--force_metadata` when creating arrays
 # Set to `false` if metadata should not be overwritten
 xiraid_force_metadata: true
 
-xiraid_arrays:
-  - name: media6
-    level: 6
-    strip_size_kb: 128
-    devices:
-      - /dev/nvme1n1
-      - /dev/nvme2n1
-      - /dev/nvme3n1
-      - /dev/nvme4n1
-      - /dev/nvme5n1
-      - /dev/nvme6n1
-      - /dev/nvme7n1
-      - /dev/nvme8n1
-      - /dev/nvme9n1
-      - /dev/nvme10n1
-    parity_disks: 2          # for RAID6 strip‑width calc (data = devs - parity)
-
-  - name: media0             # log device, RAID10
-    level: 10
-    strip_size_kb: 16
-    devices:
-      - /dev/nvme11n1
-      - /dev/nvme12n1
-
-# Filesystems to create and mount
-xfs_filesystems:
-  - label: nfsdata
-    data_device: "/dev/xi_media6"
-    log_device:  "/dev/xi_media0"
-    su_kb: 128        # stripe unit (match strip_size_kb)
-    sw: 8             # stripe width – data drives count
-    log_size: 1G
-    sector_size: 4k
-    mountpoint: /mnt/data
-    mount_opts: "logdev=/dev/xi_media0,noatime,nodiratime,logbsize=256k,largeio,inode64,swalloc,allocsize=131072k"
+# RAID array and filesystem definitions should be supplied via inventory
+# variables (e.g. in ``group_vars/all.yml``).  Keeping them empty here avoids
+# duplicating configuration.
+xiraid_arrays: []
+xfs_filesystems: []


### PR DESCRIPTION
## Summary
- keep array configuration only in `group_vars`
- clean up `raid_fs` role defaults so they don't override inventory values

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849d2b37c3c8328a442a09e338141cb