### PR TITLE
Fix license menu return path

### DIFF
--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -26,7 +26,7 @@ enter_license() {
             cp "$license_file" "${license_file}.${ts}.bak"
             rm -f "$license_file"
         else
-            return
+            return 0
         fi
     fi
 


### PR DESCRIPTION
## Summary
- ensure declining license replacement returns to menu

## Testing
- `bash -n startup_menu.sh`


------
https://chatgpt.com/codex/tasks/task_e_684a6e7821c88328a2293528ff9b2d7a