### PR TITLE
Uppercase hardware key output

### DIFF
--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -14,7 +14,7 @@ enter_license() {
     local license_file="/tmp/license"
     [ -x ./hwkey ] || chmod +x ./hwkey
     local hwkey_val
-    hwkey_val=$(./hwkey 2>/dev/null | tr -d '\n')
+    hwkey_val=$(./hwkey 2>/dev/null | tr -d '\n' | tr '[:lower:]' '[:upper:]')
 
     # Show HWKEY to the user
     whiptail --title "Hardware Key" --msgbox "HWKEY: ${hwkey_val}\nRequest your license key from xiNNOR Support." 10 60


### PR DESCRIPTION
## Summary
- show hardware key in uppercase on Hardware Key screen

## Testing
- `shellcheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a73ecd3b08328adfd4e33cf5fa255