### PR TITLE
Restart openibd after DOCA OFED install

### DIFF
--- a/collection/roles/doca_ofed/tasks/main.yml
+++ b/collection/roles/doca_ofed/tasks/main.yml
@@ -34,6 +34,7 @@
     state: present
     update_cache: yes
   register: ofed_pkgs
+  notify: restart openibd
   tags: [ofed, install]
 
 - name: Reboot if kernel modules built and reboot requested


### PR DESCRIPTION
## Summary
- restart OpenIBD service whenever DOCA OFED packages are installed

## Testing
- `ansible-playbook --syntax-check playbooks/site.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a90b63f7c832894232ea72197e383