### PR TITLE
Add post install menu

### DIFF
--- a/configure_network.sh
+++ b/configure_network.sh
@@ -11,7 +11,9 @@ backup_if_changed() {
     fi
 }
 
-ROLE_TEMPLATE="collection/roles/net_controllers/templates/netplan.yaml.j2"
+ROLE_TEMPLATE_DEFAULT="collection/roles/net_controllers/templates/netplan.yaml.j2"
+# Allow override of the configuration file via environment variable
+ROLE_TEMPLATE="${ROLE_TEMPLATE_OVERRIDE:-$ROLE_TEMPLATE_DEFAULT}"
 
 # Gather available interfaces excluding loopback
 readarray -t interfaces < <(ip -o link show | awk -F': ' '{print $2}' | grep -v lo)

--- a/post_install_menu.sh
+++ b/post_install_menu.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Post installation information and management menu for xiNAS
+set -euo pipefail
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+show_raid_info() {
+    local out="$TMP_DIR/raid_info"
+    if ! xicli raid show >"$out" 2>&1; then
+        echo "Failed to run xicli raid show" >"$out"
+    fi
+    whiptail --title "RAID Groups" --textbox "$out" 20 70
+}
+
+show_license_info() {
+    local out="$TMP_DIR/license_info"
+    if ! xicli license show >"$out" 2>&1; then
+        echo "Failed to run xicli license show" >"$out"
+    fi
+    whiptail --title "xiRAID License" --textbox "$out" 20 70
+}
+
+show_nfs_info() {
+    local out="$TMP_DIR/nfs_info"
+    {
+        echo "NFS exports from /etc/exports:";
+        if [ -f /etc/exports ]; then
+            cat /etc/exports
+            echo
+            awk '{print $1}' /etc/exports | while read -r p; do
+                [ -z "$p" ] && continue
+                df -hT "$p" 2>/dev/null || true
+                echo
+            done
+        else
+            echo "/etc/exports not found"
+        fi
+    } >"$out"
+    whiptail --title "Filesystem & NFS" --textbox "$out" 20 70
+}
+
+manage_network() {
+    local out="$TMP_DIR/net_info"
+    ip -o -4 addr show | awk '{print $2, $4}' >"$out"
+    whiptail --title "Network Interfaces" --textbox "$out" 20 70
+    if whiptail --yesno "Modify network configuration?" 8 60; then
+        ROLE_TEMPLATE_OVERRIDE=/etc/netplan/99-xinas.yaml ./configure_network.sh
+        netplan apply
+    fi
+}
+
+while true; do
+    choice=$(whiptail --title "Post Install Menu" --menu "Select an option:" 20 70 10 \
+        1 "RAID Groups information" \
+        2 "xiRAID license information" \
+        3 "File system and NFS share information" \
+        4 "Network post install settings" \
+        5 "Exit" 3>&1 1>&2 2>&3)
+    case "$choice" in
+        1) show_raid_info ;;
+        2) show_license_info ;;
+        3) show_nfs_info ;;
+        4) manage_network ;;
+        *) break ;;
+    esac
+done

--- a/prepare_system.sh
+++ b/prepare_system.sh
@@ -48,4 +48,6 @@ done
 if whiptail --yesno "Run Ansible playbook to configure the system?\n\nThis will execute the following roles:${ROLE_LIST}" 20 70; then
     INV_FILE=$(whiptail --inputbox "Inventory to use for Ansible" 10 70 "inventories/lab.ini" 3>&1 1>&2 2>&3)
     ansible-playbook "$PLAYBOOK" -i "$INV_FILE" -v
+    chmod +x post_install_menu.sh
+    ./post_install_menu.sh
 fi


### PR DESCRIPTION
## Summary
- allow overriding network config file in configure_network.sh
- add interactive post_install_menu.sh for RAID info, license info, NFS, and network settings
- invoke post-install menu after running the Ansible playbook

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684a929820e48328975b1b0c8231bf73