### PR TITLE
Rename exit option in startup menu

### DIFF
--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -149,7 +149,7 @@ while true; do
         2 "Configure Network" \
         3 "Configure RAID" \
         4 "Edit NFS Exports" \
-        5 "Exit" \
+        5 "Continue" \
         3>&1 1>&2 2>&3)
     case "$choice" in
         1) enter_license ;;


### PR DESCRIPTION
## Summary
- update the startup menu to display `Continue` instead of `Exit`

## Testing
- `shellcheck startup_menu.sh`

------
https://chatgpt.com/codex/tasks/task_e_684b130ea11483288c5e3757b84be4ce