### PR TITLE
Remove add NFS share option

### DIFF
--- a/configure_nfs_exports.sh
+++ b/configure_nfs_exports.sh
@@ -63,12 +63,9 @@ add_export() {
     mv "$tmp" "$vars_file"
 }
 
-# Allow non-interactive calls for editing or adding a single export
+# Allow non-interactive calls for editing a single export
 if [ "${1:-}" = "--edit" ] && [ -n "${2:-}" ]; then
     edit_export "$2"
-    exit 0
-elif [ "${1:-}" = "--add" ]; then
-    add_export
     exit 0
 fi
 
@@ -79,7 +76,6 @@ while true; do
         clients=$(yq -r ".exports[] | select(.path==\"$p\") | .clients" "$vars_file")
         menu_items+=("$p" "clients: $clients")
     done
-    menu_items+=("Add" "Add new export")
     menu_items+=("Back" "Return to main menu")
     set +e
     choice=$(whiptail --title "NFS Exports" --menu "Select export to edit:" 20 70 10 "${menu_items[@]}" 3>&1 1>&2 2>&3)
@@ -88,9 +84,5 @@ while true; do
     if [ $status -ne 0 ] || [ "$choice" = "Back" ]; then
         break
     fi
-    if [ "$choice" = "Add" ]; then
-        add_export
-    else
-        edit_export "$choice"
-    fi
+    edit_export "$choice"
 done

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -99,13 +99,11 @@ configure_nfs_shares() {
 
     while true; do
         local choice
-        choice=$(whiptail --title "NFS Share" --menu "Choose an action:" 15 70 5 \
+        choice=$(whiptail --title "NFS Share" --menu "Choose an action:" 15 70 4 \
             1 "Edit default share" \
-            2 "Add new share" \
-            3 "Back" 3>&1 1>&2 2>&3)
+            2 "Back" 3>&1 1>&2 2>&3)
         case "$choice" in
             1) ./configure_nfs_exports.sh --edit "$default_path" ;;
-            2) ./configure_nfs_exports.sh --add ;;
             *) break ;;
         esac
     done


### PR DESCRIPTION
## Summary
- remove the "Add new share" item from NFS Share menu
- remove add export actions from `configure_nfs_exports.sh`

## Testing
- `shellcheck startup_menu.sh configure_nfs_exports.sh`


------
https://chatgpt.com/codex/tasks/task_e_684b1e70ea7c8328ae82e2dbbd10e8ed