### PR TITLE
Add NetPlan Apply comment

### DIFF
--- a/collection/roles/net_controllers/handlers/main.yml
+++ b/collection/roles/net_controllers/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: apply netplan
-  ansible.builtin.command: netplan apply
+  ansible.builtin.command: netplan apply  # NetPlan Apply
   become: true


### PR DESCRIPTION
## Summary
- show that `netplan apply` runs by adding a comment in the handler of the `net_controllers` role

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_684be169d4e083289cc52f88c9181312