### PR TITLE
Unify Git configuration view and edit

### DIFF
--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -124,6 +124,17 @@ configure_git_repo() {
     local repo_dir="/opt/provision"
     mkdir -p "$repo_dir"
 
+    local out="$TMP_DIR/git_config"
+    if [ -d "$repo_dir/.git" ]; then
+        git -C "$repo_dir" config --list >"$out" 2>&1
+    else
+        git config --list >"$out" 2>&1 || echo "No git configuration found" >"$out"
+    fi
+    whiptail --title "Current Git Configuration" --textbox "$out" 20 70
+    if ! whiptail --yesno "Modify Git repository settings?" 8 60; then
+        return 0
+    fi
+
     local current_url=""
     local current_branch="main"
     if [ -d "$repo_dir/.git" ]; then
@@ -151,18 +162,6 @@ configure_git_repo() {
     echo "$branch" >"$repo_dir/repo.branch"
 
     whiptail --msgbox "Repository configured at $repo_dir" 8 60
-}
-
-# Show current git configuration from /opt/provision
-show_git_config() {
-    local repo_dir="/opt/provision"
-    local out="$TMP_DIR/git_config"
-    if [ -d "$repo_dir/.git" ]; then
-        git -C "$repo_dir" config --list >"$out" 2>&1
-    else
-        git config --list >"$out" 2>&1 || echo "No git configuration found" >"$out"
-    fi
-    whiptail --title "Git Configuration" --textbox "$out" 20 70
 }
 
 # Run ansible-playbook and stream output
@@ -193,9 +192,8 @@ while true; do
         2 "Configure Network" \
         3 "Configure RAID" \
         4 "Edit NFS Exports" \
-        5 "Configure Git Repository" \
-        6 "Show Git Configuration" \
-        7 "Continue" \
+        5 "Git Repository Configuration" \
+        6 "Continue" \
         3>&1 1>&2 2>&3)
     case "$choice" in
         1) enter_license ;;
@@ -203,8 +201,7 @@ while true; do
         3) configure_raid ;;
         4) edit_nfs_exports ;;
         5) configure_git_repo ;;
-        6) show_git_config ;;
-        7) exit 0 ;;
+        6) exit 0 ;;
     esac
 done
 


### PR DESCRIPTION
## Summary
- show current Git settings before editing
- remove separate 'Show Git Configuration' entry
- keep one menu entry for Git repository configuration

## Testing
- `bash -n startup_menu.sh`

------
https://chatgpt.com/codex/tasks/task_e_684bee1d1a3883289788c9a60d7bffea