### PR TITLE
Fix repo handling and commit messages

### DIFF
--- a/post_install_menu.sh
+++ b/post_install_menu.sh
@@ -74,17 +74,17 @@ has_repo_changes() {
 }
 
 store_config_repo() {
-    local msg
+    local msg out
     msg=$(whiptail --inputbox "Commit message" 8 60 "Save configuration" 3>&1 1>&2 2>&3) || return 0
     git -C "$REPO_DIR" add -A
-    if git -C "$REPO_DIR" commit -m "$msg" >/dev/null 2>&1; then
+    if out=$(git -C "$REPO_DIR" commit -m "$msg" 2>&1); then
         if git -C "$REPO_DIR" push >/dev/null 2>&1; then
             whiptail --msgbox "Configuration saved to repository" 8 60
         else
             whiptail --msgbox "Failed to push changes" 8 60
         fi
     else
-        whiptail --msgbox "No changes to commit" 8 60
+        whiptail --msgbox "Git commit failed:\n${out}" 15 70
     fi
 }
 

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -6,6 +6,8 @@
 
 set -euo pipefail
 TMP_DIR="$(mktemp -d)"
+# Directory of the repository currently being configured
+REPO_DIR="$(pwd)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 # Prompt user for license string and store it in /tmp/license
@@ -162,6 +164,8 @@ configure_git_repo() {
     echo "$branch" >"$repo_dir/repo.branch"
 
     whiptail --msgbox "Repository configured at $repo_dir" 8 60
+    REPO_DIR="$repo_dir"
+    cd "$REPO_DIR"
 }
 
 # Run ansible-playbook and stream output
@@ -170,7 +174,7 @@ run_playbook() {
     touch "$log"
     whiptail --title "Ansible Playbook" --tailbox "$log" 20 70 &
     local box_pid=$!
-    if ansible-playbook /opt/provision/site.yml >"$log" 2>&1; then
+    if ansible-playbook "$REPO_DIR/site.yml" >"$log" 2>&1; then
         result=0
     else
         result=$?


### PR DESCRIPTION
## Summary
- keep track of repository directory in startup script
- change working directory to the repo after configuring git
- run playbook using that repo
- show git commit errors instead of misleading message

## Testing
- `bash -n startup_menu.sh`
- `bash -n post_install_menu.sh`


------
https://chatgpt.com/codex/tasks/task_e_684c03869e0483289965a7e7a25732d4