### PR TITLE
Improve role descriptions in setup message

### DIFF
--- a/prepare_system.sh
+++ b/prepare_system.sh
@@ -41,7 +41,7 @@ ROLE_LIST=""
 for role in $ROLE_NAMES; do
     desc_file="collection/roles/${role}/README.md"
     if [ -f "$desc_file" ]; then
-        desc=$(awk 'NF && $0 !~ /^#/ {print; exit}' "$desc_file")
+        desc=$(awk '/^#/ {next} /^\s*$/ {if(found) exit; else next} {if(found) {printf " %s", $0} else {printf "%s", $0; found=1}} END {print ""}' "$desc_file")
     else
         desc="No description available"
     fi


### PR DESCRIPTION
## Summary
- capture the first paragraph from each role README
- show that full text when confirming the Ansible run

## Testing
- `bash -n prepare_system.sh`
- `bash -n startup_menu.sh post_install_menu.sh configure_network.sh configure_nfs_exports.sh configure_raid.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c0ed47550832880a4fb44b5948adb