### PR TITLE
Keep scrolling only for Ansible role info

### DIFF
--- a/post_install_menu.sh
+++ b/post_install_menu.sh
@@ -14,7 +14,7 @@ show_raid_info() {
     if ! xicli raid show >"$out" 2>&1; then
         echo "Failed to run xicli raid show" >"$out"
     fi
-    whiptail --title "RAID Groups" --scrolltext --textbox "$out" 20 70
+    whiptail --title "RAID Groups" --textbox "$out" 20 70
 }
 
 show_license_info() {
@@ -22,7 +22,7 @@ show_license_info() {
     if ! xicli license show >"$out" 2>&1; then
         echo "Failed to run xicli license show" >"$out"
     fi
-    whiptail --title "xiRAID License" --scrolltext --textbox "$out" 20 70
+    whiptail --title "xiRAID License" --textbox "$out" 20 70
 }
 
 show_nfs_info() {
@@ -41,13 +41,13 @@ show_nfs_info() {
             echo "/etc/exports not found"
         fi
     } >"$out"
-    whiptail --title "Filesystem & NFS" --scrolltext --textbox "$out" 20 70
+    whiptail --title "Filesystem & NFS" --textbox "$out" 20 70
 }
 
 manage_network() {
     local out="$TMP_DIR/net_info"
     ip -o -4 addr show | awk '{print $2, $4}' >"$out"
-    whiptail --title "Network Interfaces" --scrolltext --textbox "$out" 20 70
+    whiptail --title "Network Interfaces" --textbox "$out" 20 70
     if whiptail --yesno "Modify network configuration?" 8 60; then
         ROLE_TEMPLATE_OVERRIDE=/etc/netplan/99-xinas.yaml ./configure_network.sh
         netplan apply

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -70,7 +70,7 @@ configure_network() {
         cat "$TMP_DIR/netplan_new" > "$template"
     fi
 
-    whiptail --title "Ansible Netplan" --scrolltext --textbox "$template" 20 70
+    whiptail --title "Ansible Netplan" --textbox "$template" 20 70
 }
 
 # Display playbook information from /opt/provision/README.md
@@ -94,7 +94,7 @@ configure_nfs_shares() {
     share_start=$(grep -n '^exports:' "$vars_file" | cut -d: -f1)
     local tmp="$TMP_DIR/nfs_info"
     sed -n "$((share_start+1)),$((share_start+3))p" "$vars_file" > "$tmp"
-    whiptail --title "NFS Share" --scrolltext --textbox "$tmp" 12 70
+    whiptail --title "NFS Share" --textbox "$tmp" 12 70
 
     local default_path
     default_path=$(awk '/^exports:/ {flag=1; next} flag && /- path:/ {print $3; exit}' "$vars_file")
@@ -132,7 +132,7 @@ configure_git_repo() {
     else
         git config --list >"$out" 2>&1 || echo "No git configuration found" >"$out"
     fi
-    whiptail --title "Current Git Configuration" --scrolltext --textbox "$out" 20 70
+    whiptail --title "Current Git Configuration" --textbox "$out" 20 70
     if ! whiptail --yesno "Modify Git repository settings?" 8 60; then
         return 0
     fi


### PR DESCRIPTION
## Summary
- show RAID, license, NFS and network info without scrolling
- only keep scrolling for the Ansible roles screen

## Testing
- `bash -n startup_menu.sh post_install_menu.sh prepare_system.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c12f66b408328a2f74b1d5dd59232