### PR TITLE
Add presets feature

### DIFF
--- a/presets/default/netplan.yaml.j2
+++ b/presets/default/netplan.yaml.j2
@@ -1,0 +1,7 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    ib0:
+      dhcp4: no
+      addresses: [ 100.100.100.1/24 ]

--- a/presets/default/nfs_exports.yml
+++ b/presets/default/nfs_exports.yml
@@ -1,0 +1,8 @@
+# List of export rules. Each item fields:
+#   path    – directory to export (will be created if missing)
+#   clients – host or network mask, or "*" for all
+#   options – NFS export options
+exports:
+  - path: /mnt/data
+    clients: "*"
+    options: "rw,sync,insecure,no_root_squash,no_subtree_check,no_wdelay"

--- a/presets/default/playbook.yml
+++ b/presets/default/playbook.yml
@@ -1,0 +1,13 @@
+---
+- name: Full storage-node configuration (common → OFED → xiRAID → NFS → perf)
+  hosts: storage_nodes
+  gather_facts: true
+  roles:
+    - role: common
+    - role: doca_ofed
+    - role: net_controllers
+    - role: xiraid_classic  # EULA is accepted automatically
+    - role: raid_fs
+    - role: exports       # manage /etc/exports
+    - role: nfs_server    # configure kernel NFS server
+    - role: perf_tuning

--- a/presets/default/raid_fs.yml
+++ b/presets/default/raid_fs.yml
@@ -1,0 +1,46 @@
+# Default values for the raid_fs role
+#
+# The actual RAID array and filesystem configuration is stored here so
+# interactive helper scripts can modify it directly.
+xiraid_license_path: "/tmp/license"
+
+# Whether to pass `--force_metadata` when creating arrays
+# Set to `false` if metadata should not be overwritten
+xiraid_force_metadata: true
+
+# Default RAID arrays and filesystem definitions used by the xiNAS example
+# deployment. Modify these values directly rather than using group variables.
+xiraid_arrays:
+  - name: media6
+    level: 6
+    strip_size_kb: 128
+    devices:
+      - /dev/nvme1n1
+      - /dev/nvme2n1
+      - /dev/nvme3n1
+      - /dev/nvme4n1
+      - /dev/nvme5n1
+      - /dev/nvme6n1
+      - /dev/nvme7n1
+      - /dev/nvme8n1
+      - /dev/nvme9n1
+      - /dev/nvme10n1
+    parity_disks: 2
+
+  - name: media1
+    level: 1
+    strip_size_kb: 16
+    devices:
+      - /dev/nvme11n1
+      - /dev/nvme12n1
+
+xfs_filesystems:
+  - label: nfsdata
+    data_device: "/dev/xi_media6"
+    log_device: "/dev/xi_media1"
+    su_kb: 128
+    sw: 8
+    log_size: 1G
+    sector_size: 4k
+    mountpoint: /mnt/data
+    mount_opts: "logdev=/dev/xi_media1,noatime,nodiratime,logbsize=256k,largeio,inode64,swalloc,allocsize=131072k"


### PR DESCRIPTION
## Summary
- add default preset files for RAID, netplan and NFS exports
- extend `startup_menu.sh` with Presets menu
- allow custom playbook path when running ansible

## Testing
- `shellcheck startup_menu.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c164908688328980e0946d5ec7df2