### PR TITLE
Add scrollable pretty JSON display for RAID info

### DIFF
--- a/post_install_menu.sh
+++ b/post_install_menu.sh
@@ -11,10 +11,17 @@ DEFAULT_GIT_URL="https://github.com/XinnorLab/xiNAS"
 
 show_raid_info() {
     local out="$TMP_DIR/raid_info"
-    if ! xicli raid show >"$out" 2>&1; then
+    local raw="$TMP_DIR/raid_raw"
+    if xicli raid show -f json >"$raw" 2>&1; then
+        if python3 -m json.tool "$raw" >"$out" 2>/dev/null; then
+            :
+        else
+            cat "$raw" >"$out"
+        fi
+    else
         echo "Failed to run xicli raid show" >"$out"
     fi
-    whiptail --title "RAID Groups" --textbox "$out" 20 70
+    whiptail --title "RAID Groups" --scrolltext --textbox "$out" 20 70
 }
 
 show_license_info() {


### PR DESCRIPTION
## Summary
- display RAID information in JSON format in post install menu
- make RAID info textbox scrollable

## Testing
- `bash -n post_install_menu.sh configure_raid.sh configure_network.sh configure_nfs_exports.sh startup_menu.sh prepare_system.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d5c192a9c8328b03c0b9bf4dc9d7d