### PR TITLE
Add simplified start menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This repository contains scripts and Ansible playbooks used to provision xiNAS n
 
 ## Getting started
 
-1. Run `prepare_system.sh` on the target host. This installs required packages including `yq` version 4, `whiptail`, and Ansible, then clones the repository. The script also asks if you want to update the code from GitHub before proceeding.
-2. Execute `startup_menu.sh` to configure network, RAID arrays and NFS exports interactively.
+1. Run `prepare_system.sh` on the target host (use the `-e` option for expert mode). This installs required packages including `yq` version 4, `whiptail`, and Ansible, then clones the repository.
+   By default a simplified menu is shown to enter the license and choose a preset. The `-e` flag loads the full interactive menu.
+2. Execute `startup_menu.sh` separately if you need the complete configuration menu outside of the expert mode.
 3. Optionally run the included Ansible playbook to apply the configuration.
 
 The `prepare_system.sh` script installs dependencies required by the interactive helper scripts. The helper scripts rely on the [`mikefarah/yq`](https://github.com/mikefarah/yq) binary (v4+). If you encounter errors such as `jq: error: env/1 is not defined`, make sure this version of `yq` is installed by re-running `prepare_system.sh` or installing it manually.

--- a/prepare_system.sh
+++ b/prepare_system.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 set -e
+
+usage() {
+    echo "Usage: $0 [-e]" >&2
+    echo "  -e  Expert mode with full startup menu" >&2
+}
+
+EXPERT=0
+while getopts "e" opt; do
+    case $opt in
+        e) EXPERT=1 ;;
+        *) usage; exit 1 ;;
+    esac
+done
 # Install required packages
 sudo apt-get update -y
 sudo apt-get install -y ansible git whiptail dialog wget
@@ -28,8 +41,12 @@ fi
 
 # Ask whether to run interactive configuration menu
 if whiptail --yesno "Configure this system now?" 8 60; then
-    chmod +x startup_menu.sh
-    ./startup_menu.sh
+    chmod +x startup_menu.sh simple_menu.sh
+    if [ "$EXPERT" -eq 1 ]; then
+        ./startup_menu.sh
+    else
+        ./simple_menu.sh
+    fi
 fi
 
 # After the menu has finished, explain the Ansible run and optionally execute it

--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Simplified startup menu for xiNAS
+set -euo pipefail
+TMP_DIR="$(mktemp -d)"
+REPO_DIR="$(pwd)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+enter_license() {
+    local license_file="/tmp/license"
+    [ -x ./hwkey ] || chmod +x ./hwkey
+    local hwkey_val
+    hwkey_val=$(./hwkey 2>/dev/null | tr -d '\n' | tr '[:lower:]' '[:upper:]')
+    whiptail --title "Hardware Key" --msgbox "HWKEY: ${hwkey_val}\nRequest your license key from xiNNOR Support." 10 60
+    if [ -f "$license_file" ]; then
+        if whiptail --yesno "License already exists. Replace it?" 10 60; then
+            local ts
+            ts=$(date +%Y%m%d%H%M%S)
+            cp "$license_file" "${license_file}.${ts}.bak"
+            rm -f "$license_file"
+        else
+            return 0
+        fi
+    fi
+    : > "$TMP_DIR/license_tmp"
+    if command -v dialog >/dev/null 2>&1; then
+        if dialog --title "Enter License" --editbox "$TMP_DIR/license_tmp" 20 70 2>"$TMP_DIR/license"; then
+            :
+        else
+            return 0
+        fi
+    else
+        whiptail --title "Enter License" --msgbox "Paste license in the terminal. End with Ctrl-D." 10 60
+        cat >>"$TMP_DIR/license"
+    fi
+    cat "$TMP_DIR/license" > "$license_file"
+}
+
+run_playbook() {
+    local playbook="${1:-$REPO_DIR/site.yml}"
+    local log="$TMP_DIR/playbook.log"
+    touch "$log"
+    whiptail --title "Ansible Playbook" --tailbox "$log" 20 70 &
+    local box_pid=$!
+    if ansible-playbook "$playbook" >"$log" 2>&1; then
+        result=0
+    else
+        result=$?
+    fi
+    kill "$box_pid" 2>/dev/null || true
+    wait "$box_pid" 2>/dev/null || true
+    if [ $result -eq 0 ]; then
+        whiptail --msgbox "Playbook completed successfully" 8 60
+    else
+        whiptail --msgbox "Playbook failed. Check log: $log" 10 60
+    fi
+    return $result
+}
+
+apply_preset() {
+    local preset="$1"
+    local pdir="$REPO_DIR/presets/$preset"
+    [ -d "$pdir" ] || { whiptail --msgbox "Preset $preset not found" 8 60; return; }
+    local msg="Applying preset: $preset\n"
+    if [ -f "$pdir/netplan.yaml.j2" ]; then
+        cp "$pdir/netplan.yaml.j2" "collection/roles/net_controllers/templates/netplan.yaml.j2"
+        msg+="- network configuration\n"
+    fi
+    if [ -f "$pdir/raid_fs.yml" ]; then
+        cp "$pdir/raid_fs.yml" "collection/roles/raid_fs/defaults/main.yml"
+        msg+="- RAID configuration\n"
+    fi
+    if [ -f "$pdir/nfs_exports.yml" ]; then
+        cp "$pdir/nfs_exports.yml" "collection/roles/exports/defaults/main.yml"
+        msg+="- NFS exports\n"
+    fi
+    if [ -f "$pdir/playbook.yml" ]; then
+        run_playbook "$pdir/playbook.yml"
+    fi
+    whiptail --msgbox "$msg" 15 70
+}
+
+choose_preset() {
+    local preset_dir="$REPO_DIR/presets"
+    [ -d "$preset_dir" ] || { whiptail --msgbox "No presets available" 8 60; return; }
+    local items=()
+    for d in "$preset_dir"/*/; do
+        [ -d "$d" ] || continue
+        items+=("$(basename "$d")" "")
+    done
+    items+=("Back" "Return")
+    set +e
+    local choice
+    choice=$(whiptail --title "Presets" --menu "Select preset:" 20 70 10 "${items[@]}" 3>&1 1>&2 2>&3)
+    local status=$?
+    set -e
+    if [ $status -ne 0 ] || [ "$choice" = "Back" ]; then
+        return
+    fi
+    apply_preset "$choice"
+}
+
+while true; do
+    choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 15 70 5 \
+        1 "Enter License" \
+        2 "Presets" \
+        3 "Continue" \
+        3>&1 1>&2 2>&3)
+    case "$choice" in
+        1) enter_license ;;
+        2) choose_preset ;;
+        3) exit 0 ;;
+    esac
+done


### PR DESCRIPTION
## Summary
- support expert mode with `-e` flag in `prepare_system.sh`
- create `simple_menu.sh` for default simplified start menu
- mention expert mode in README

## Testing
- `bash -n prepare_system.sh`
- `bash -n simple_menu.sh`
- `bash -n startup_menu.sh`

------
https://chatgpt.com/codex/tasks/task_e_684fb9f71e588328be033e55a736994d