### PR TITLE
Adjust default prepare workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains scripts and Ansible playbooks used to provision xiNAS n
 ## Getting started
 
 1. Run `prepare_system.sh` on the target host (use the `-e` option for expert mode). This installs required packages including `yq` version 4, `whiptail`, and Ansible, then clones the repository.
-   By default a simplified menu is shown to enter the license and choose a preset. The `-e` flag loads the full interactive menu.
+   The script immediately launches a simplified start menu in default mode to enter the license and choose a preset. Use `-e` to access the full interactive menu and additional options such as updating the repository.
 2. Execute `startup_menu.sh` separately if you need the complete configuration menu outside of the expert mode.
 3. Optionally run the included Ansible playbook to apply the configuration.
 

--- a/prepare_system.sh
+++ b/prepare_system.sh
@@ -33,20 +33,22 @@ else
     cd "$REPO_DIR"
 fi
 
-# Ask whether to update repository
-if whiptail --yesno "Update xiNAS code from GitHub?" 8 60; then
-    git reset --hard
-    git pull origin main
+# In expert mode allow updating the repository from GitHub
+if [ "$EXPERT" -eq 1 ]; then
+    if whiptail --yesno "Update xiNAS code from GitHub?" 8 60; then
+        git reset --hard
+        git pull origin main
+    fi
 fi
 
-# Ask whether to run interactive configuration menu
-if whiptail --yesno "Configure this system now?" 8 60; then
-    chmod +x startup_menu.sh simple_menu.sh
-    if [ "$EXPERT" -eq 1 ]; then
+# Run the configuration menu
+chmod +x startup_menu.sh simple_menu.sh
+if [ "$EXPERT" -eq 1 ]; then
+    if whiptail --yesno "Configure this system now?" 8 60; then
         ./startup_menu.sh
-    else
-        ./simple_menu.sh
     fi
+else
+    ./simple_menu.sh
 fi
 
 # After the menu has finished, explain the Ansible run and optionally execute it


### PR DESCRIPTION
## Summary
- let `prepare_system.sh` automatically run the simplified menu in default mode
- restrict code update prompt to expert mode
- document new behavior in README

## Testing
- `bash -n prepare_system.sh`
- `shellcheck prepare_system.sh`
- `bash -n simple_menu.sh`
- `bash -n startup_menu.sh`


------
https://chatgpt.com/codex/tasks/task_e_684fc0bf9aac8328b6c930a4c992540f