### PR TITLE
Add client NFS setup helper

### DIFF
--- a/client_setup.sh
+++ b/client_setup.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Configure NFS client with optional RDMA according to xiNNOR blog post
+set -euo pipefail
+
+WHIPTAIL=$(command -v whiptail || true)
+
+ask_yes_no() {
+    local prompt="$1"
+    if [ -n "$WHIPTAIL" ]; then
+        whiptail --yesno "$prompt" 10 60
+        return $?
+    else
+        read -rp "$prompt [y/N]: " ans
+        [[ "$ans" =~ ^[Yy]$ ]]
+        return
+    fi
+}
+
+ask_input() {
+    local prompt="$1" default="$2" result
+    if [ -n "$WHIPTAIL" ]; then
+        result=$(whiptail --inputbox "$prompt" 8 60 "$default" 3>&1 1>&2 2>&3) || return 1
+    else
+        read -rp "$prompt [$default]: " result
+        result=${result:-$default}
+    fi
+    echo "$result"
+}
+
+run_playbook() {
+    local pb="$1" log
+    log=$(mktemp)
+    if [ -n "$WHIPTAIL" ]; then
+        whiptail --title "Ansible" --infobox "Running $pb" 8 60
+    fi
+    if ansible-playbook "$pb" -i inventories/lab.ini >"$log" 2>&1; then
+        [ -n "$WHIPTAIL" ] && whiptail --textbox "$log" 20 70 && whiptail --msgbox "Playbook succeeded" 8 60 || cat "$log"
+    else
+        [ -n "$WHIPTAIL" ] && whiptail --textbox "$log" 20 70 && whiptail --msgbox "Playbook failed" 8 60 || cat "$log"
+        return 1
+    fi
+    rm -f "$log"
+}
+
+main() {
+    if ask_yes_no "Install DOCA OFED using Ansible playbook?"; then
+        run_playbook playbooks/doca_ofed_install.yml
+    fi
+
+    proto=$(ask_input "Protocol to use (NFS or RDMA)" "RDMA")
+    proto=${proto^^}
+    server_ip=$(ask_input "Server IP address" "10.239.239.100")
+    share=$(ask_input "NFS share" "/mnt/data")
+    mount_point=$(ask_input "Local mount point" "/mnt/nfs")
+
+    if command -v apt-get >/dev/null 2>&1; then
+        apt-get update -y
+        apt-get install -y nfs-common
+    elif command -v yum >/dev/null 2>&1; then
+        yum install -y nfs-utils
+    fi
+
+    echo "options nfs max_session_slots=180" > /etc/modprobe.d/nfsclient.conf
+
+    mkdir -p "$mount_point"
+    if [[ "$proto" == "RDMA" ]]; then
+        opts="rdma,port=20049,nconnect=16,vers=4.2"
+    else
+        opts="nconnect=16,vers=4.2"
+    fi
+    if ! mountpoint -q "$mount_point"; then
+        mount -t nfs -o "$opts" "$server_ip:$share" "$mount_point"
+    fi
+
+    grep -q "^$server_ip:$share" /etc/fstab || echo "$server_ip:$share $mount_point nfs $opts 0 0" >> /etc/fstab
+
+    echo "Configuration complete. Reboot recommended to apply module options." >&2
+}
+
+main "$@"

--- a/playbooks/doca_ofed_install.yml
+++ b/playbooks/doca_ofed_install.yml
@@ -1,0 +1,6 @@
+---
+- name: Install DOCA OFED on client
+  hosts: storage_nodes
+  gather_facts: true
+  roles:
+    - role: doca_ofed


### PR DESCRIPTION
## Summary
- add client_setup.sh for configuring RDMA/NFS client
- add accompanying playbook for DOCA OFED installation

## Testing
- `bash -n client_setup.sh`
- `ansible-playbook --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fdc353c90832880c372373317073f