### PR TITLE
Ensure fstab line is written even if mount fails

### DIFF
--- a/client_setup.sh
+++ b/client_setup.sh
@@ -74,10 +74,13 @@ main() {
         opts="nconnect=16,vers=4.2,sync"
     fi
     if ! mountpoint -q "$mount_point"; then
-        mount -t nfs -o "$opts" "$server_ip:$share" "$mount_point"
+        mount -t nfs -o "$opts" "$server_ip:$share" "$mount_point" || \
+            echo "Warning: failed to mount $server_ip:$share" >&2
     fi
 
-    grep -q "^$server_ip:$share" /etc/fstab || echo "$server_ip:$share $mount_point nfs $opts 0 0" >> /etc/fstab
+    if ! grep -q "^$server_ip:$share" /etc/fstab; then
+        echo "$server_ip:$share $mount_point nfs $opts 0 0" >> /etc/fstab
+    fi
 
     echo "Configuration complete. Reboot recommended to apply module options." >&2
 }


### PR DESCRIPTION
## Summary
- update `client_setup.sh` so that `/etc/fstab` is updated even when mounting fails

## Testing
- `shellcheck client_setup.sh`
- `apt-get update`
- `apt-get install -y shellcheck`


------
https://chatgpt.com/codex/tasks/task_e_684ff0fe9690832898a74079a0c0f4d9