### PR TITLE
Modify license entry flow

### DIFF
--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -9,17 +9,24 @@ enter_license() {
     local license_file="/tmp/license"
     [ -x ./hwkey ] || chmod +x ./hwkey
     local hwkey_val
-    hwkey_val=$(./hwkey 2>/dev/null | tr -d '\n' | tr '[:lower:]' '[:upper:]')
-    whiptail --title "Hardware Key" --msgbox "HWKEY: ${hwkey_val}\nRequest your license key from xiNNOR Support." 10 60
+    local replace=0
+
     if [ -f "$license_file" ]; then
         if whiptail --yesno "License already exists. Replace it?" 10 60; then
-            local ts
-            ts=$(date +%Y%m%d%H%M%S)
-            cp "$license_file" "${license_file}.${ts}.bak"
-            rm -f "$license_file"
+            replace=1
         else
             return 0
         fi
+    fi
+
+    hwkey_val=$(./hwkey 2>/dev/null | tr -d '\n' | tr '[:lower:]' '[:upper:]')
+    whiptail --title "Hardware Key" --msgbox "HWKEY: ${hwkey_val}\nRequest your license key from xiNNOR Support." 10 60
+
+    if [ $replace -eq 1 ]; then
+        local ts
+        ts=$(date +%Y%m%d%H%M%S)
+        cp "$license_file" "${license_file}.${ts}.bak"
+        rm -f "$license_file"
     fi
     : > "$TMP_DIR/license_tmp"
     if command -v dialog >/dev/null 2>&1; then

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -16,20 +16,26 @@ enter_license() {
     local license_file="/tmp/license"
     [ -x ./hwkey ] || chmod +x ./hwkey
     local hwkey_val
+    local replace=0
+
+    if [ -f "$license_file" ]; then
+        if whiptail --yesno "License already exists. Replace it?" 10 60; then
+            replace=1
+        else
+            return 0
+        fi
+    fi
+
     hwkey_val=$(./hwkey 2>/dev/null | tr -d '\n' | tr '[:lower:]' '[:upper:]')
 
     # Show HWKEY to the user
     whiptail --title "Hardware Key" --msgbox "HWKEY: ${hwkey_val}\nRequest your license key from xiNNOR Support." 10 60
 
-    if [ -f "$license_file" ]; then
-        if whiptail --yesno "License already exists. Replace it?" 10 60; then
-            local ts
-            ts=$(date +%Y%m%d%H%M%S)
-            cp "$license_file" "${license_file}.${ts}.bak"
-            rm -f "$license_file"
-        else
-            return 0
-        fi
+    if [ $replace -eq 1 ]; then
+        local ts
+        ts=$(date +%Y%m%d%H%M%S)
+        cp "$license_file" "${license_file}.${ts}.bak"
+        rm -f "$license_file"
     fi
 
     : > "$TMP_DIR/license_tmp"


### PR DESCRIPTION
## Summary
- check for existing license before computing HWKEY
- show HWKEY only after user agrees to replace existing license
- same flow for expert and simple startup menus

## Testing
- `bash -n simple_menu.sh`
- `bash -n startup_menu.sh`


------
https://chatgpt.com/codex/tasks/task_e_685140eb0b948328868eb6c0b9d2e4fc