### PR TITLE
Add exit option to menus and loop on skipped playbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains scripts and Ansible playbooks used to provision xiNAS n
    The script immediately launches a simplified start menu in default mode to enter the license and choose a preset. Use `-e` to access the full interactive menu and additional options such as updating the repository.
 2. Execute `startup_menu.sh` separately if you need the complete configuration menu outside of the expert mode.
 3. Optionally run the included Ansible playbook to apply the configuration.
+   The menus also provide an **Exit** option if you want to leave without running the playbook.
 4. To configure an NFS client on another system, run `sudo ./client_setup.sh`. Root
    privileges are required to install packages, create the mount point and mount
    the exported share.

--- a/prepare_system.sh
+++ b/prepare_system.sh
@@ -41,35 +41,46 @@ if [ "$EXPERT" -eq 1 ]; then
     fi
 fi
 
-# Run the configuration menu
 chmod +x startup_menu.sh simple_menu.sh
-if [ "$EXPERT" -eq 1 ]; then
-    if whiptail --yesno "Configure this system now?" 8 60; then
-        ./startup_menu.sh
-    fi
-else
-    ./simple_menu.sh
-fi
 
-# After the menu has finished, explain the Ansible run and optionally execute it
 PLAYBOOK="playbooks/site.yml"
 
-# Build a short description of roles from the site.yml file
-ROLE_NAMES=$(grep -E '^\s*- role:' "$PLAYBOOK" | awk '{print $3}')
-ROLE_LIST=""
-for role in $ROLE_NAMES; do
-    desc_file="collection/roles/${role}/README.md"
-    if [ -f "$desc_file" ]; then
-        desc=$(awk '/^#/ {next} /^\s*$/ {if(found) exit; else next} {if(found) {printf " %s", $0} else {printf "%s", $0; found=1}} END {print ""}' "$desc_file")
+while true; do
+    menu_status=0
+    if [ "$EXPERT" -eq 1 ]; then
+        if whiptail --yesno "Configure this system now?" 8 60; then
+            ./startup_menu.sh
+            menu_status=$?
+        else
+            menu_status=2
+        fi
     else
-        desc="No description available"
+        ./simple_menu.sh
+        menu_status=$?
     fi
-    ROLE_LIST="${ROLE_LIST}\n - ${role}: ${desc}"
-done
 
-if whiptail --yesno --scrolltext "Run Ansible playbook to configure the system?\n\nThis will execute the following roles:${ROLE_LIST}" 20 70; then
-    INV_FILE=$(whiptail --inputbox "Inventory to use for Ansible" 10 70 "inventories/lab.ini" 3>&1 1>&2 2>&3)
-    ansible-playbook "$PLAYBOOK" -i "$INV_FILE" -v
-    chmod +x post_install_menu.sh
-    ./post_install_menu.sh
-fi
+    if [ "$menu_status" -eq 2 ]; then
+        exit 0
+    fi
+
+    # Build a short description of roles from the site.yml file
+    ROLE_NAMES=$(grep -E '^\s*- role:' "$PLAYBOOK" | awk '{print $3}')
+    ROLE_LIST=""
+    for role in $ROLE_NAMES; do
+        desc_file="collection/roles/${role}/README.md"
+        if [ -f "$desc_file" ]; then
+            desc=$(awk '/^#/ {next} /^\s*$/ {if(found) exit; else next} {if(found) {printf " %s", $0} else {printf "%s", $0; found=1}} END {print ""}' "$desc_file")
+        else
+            desc="No description available"
+        fi
+        ROLE_LIST="${ROLE_LIST}\n - ${role}: ${desc}"
+    done
+
+    if whiptail --yesno --scrolltext "Run Ansible playbook to configure the system?\n\nThis will execute the following roles:${ROLE_LIST}" 20 70; then
+        INV_FILE=$(whiptail --inputbox "Inventory to use for Ansible" 10 70 "inventories/lab.ini" 3>&1 1>&2 2>&3)
+        ansible-playbook "$PLAYBOOK" -i "$INV_FILE" -v
+        chmod +x post_install_menu.sh
+        ./post_install_menu.sh
+        break
+    fi
+done

--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -106,14 +106,16 @@ choose_preset() {
 }
 
 while true; do
-    choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 15 70 5 \
+    choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 15 70 6 \
         1 "Enter License" \
         2 "Presets" \
         3 "Continue" \
+        4 "Exit" \
         3>&1 1>&2 2>&3)
     case "$choice" in
         1) enter_license ;;
         2) choose_preset ;;
         3) exit 0 ;;
+        4) exit 2 ;;
     esac
 done

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -244,7 +244,7 @@ choose_preset() {
 
 # Main menu loop
 while true; do
-    choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 20 70 14 \
+    choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 20 70 15 \
         1 "Enter License" \
         2 "Configure Network" \
         3 "Configure RAID" \
@@ -252,6 +252,7 @@ while true; do
         5 "Presets" \
         6 "Git Repository Configuration" \
         7 "Continue" \
+        8 "Exit" \
         3>&1 1>&2 2>&3)
     case "$choice" in
         1) enter_license ;;
@@ -261,6 +262,7 @@ while true; do
         5) choose_preset ;;
         6) configure_git_repo ;;
         7) exit 0 ;;
+        8) exit 2 ;;
     esac
 done
 


### PR DESCRIPTION
## Summary
- add `Exit` option in both startup and simple menus
- loop in `prepare_system.sh` to return to the menu if playbook execution is declined
- document `Exit` option in README

## Testing
- `shellcheck startup_menu.sh simple_menu.sh prepare_system.sh`
- `sudo apt-get update -y`
- `sudo apt-get install -y shellcheck`

------
https://chatgpt.com/codex/tasks/task_e_685147f020048328b764b5c028881fd6