### PR TITLE
Remove expert mode prompt

### DIFF
--- a/prepare_system.sh
+++ b/prepare_system.sh
@@ -48,12 +48,8 @@ PLAYBOOK="playbooks/site.yml"
 while true; do
     menu_status=0
     if [ "$EXPERT" -eq 1 ]; then
-        if whiptail --yesno "Configure this system now?" 8 60; then
-            ./startup_menu.sh
-            menu_status=$?
-        else
-            menu_status=2
-        fi
+        ./startup_menu.sh
+        menu_status=$?
     else
         ./simple_menu.sh
         menu_status=$?


### PR DESCRIPTION
## Summary
- skip prompt asking to configure in expert mode

## Testing
- `shellcheck startup_menu.sh simple_menu.sh configure_raid.sh configure_network.sh configure_nfs_exports.sh post_install_menu.sh client_setup.sh`
- `shellcheck prepare_system.sh`

------
https://chatgpt.com/codex/tasks/task_e_685150c7ef308328aace15a226fb7234