### PR TITLE
Adjust inventory prompt

### DIFF
--- a/prepare_system.sh
+++ b/prepare_system.sh
@@ -73,7 +73,11 @@ while true; do
     done
 
     if whiptail --yesno --scrolltext "Run Ansible playbook to configure the system?\n\nThis will execute the following roles:${ROLE_LIST}" 20 70; then
-        INV_FILE=$(whiptail --inputbox "Inventory to use for Ansible" 10 70 "inventories/lab.ini" 3>&1 1>&2 2>&3)
+        if [ "$EXPERT" -eq 1 ]; then
+            INV_FILE=$(whiptail --inputbox "Inventory to use for Ansible" 10 70 "inventories/lab.ini" 3>&1 1>&2 2>&3)
+        else
+            INV_FILE="inventories/lab.ini"
+        fi
         ansible-playbook "$PLAYBOOK" -i "$INV_FILE" -v
         chmod +x post_install_menu.sh
         ./post_install_menu.sh


### PR DESCRIPTION
## Summary
- default Ansible inventory file in `prepare_system.sh`
- only prompt for inventory in expert mode

## Testing
- `bash -n prepare_system.sh`

------
https://chatgpt.com/codex/tasks/task_e_68515259e6ac832890ff7ce1f9773fef