### PR TITLE
Add ability to save current configuration as preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This repository contains scripts and Ansible playbooks used to provision xiNAS n
 ## Getting started
 
 1. Run `prepare_system.sh` on the target host (use the `-e` option for expert mode). This installs required packages including `yq` version 4, `whiptail`, and Ansible, then clones the repository.
-   The script immediately launches a simplified start menu in default mode to enter the license and choose a preset. Use `-e` to access the full interactive menu and additional options such as updating the repository.
-2. Execute `startup_menu.sh` separately if you need the complete configuration menu outside of the expert mode.
+   The script immediately launches a simplified start menu in default mode to enter the license and choose a preset. Use `-e` to access the full interactive menu with additional options such as updating the repository or saving the current configuration as a new preset.
+2. Execute `startup_menu.sh` separately if you need the complete configuration menu outside of the expert mode. Any presets you create in expert mode will also be available here and in the simplified menu.
 3. Optionally run the included Ansible playbook to apply the configuration.
    The menus also provide an **Exit** option if you want to leave without running the playbook.
 4. To configure an NFS client on another system, run `sudo ./client_setup.sh`. Root


### PR DESCRIPTION
## Summary
- allow saving the current setup as a preset from the expert startup menu
- document preset saving in README

## Testing
- `shellcheck startup_menu.sh`

------
https://chatgpt.com/codex/tasks/task_e_68515396b3b88328a5772e37d83d2a93