### PR TITLE
Fix playbook log viewer

### DIFF
--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -45,8 +45,13 @@ run_playbook() {
     local playbook="${1:-$REPO_DIR/site.yml}"
     local log="$TMP_DIR/playbook.log"
     touch "$log"
-    whiptail --title "Ansible Playbook" --tailbox "$log" 20 70 &
-    local box_pid=$!
+    if command -v dialog >/dev/null 2>&1; then
+        dialog --title "Ansible Playbook" --tailboxbg "$log" 20 70 &
+        local box_pid=$!
+    else
+        whiptail --title "Ansible Playbook" --textbox "$log" 20 70 &
+        local box_pid=$!
+    fi
     if ansible-playbook "$playbook" >"$log" 2>&1; then
         result=0
     else

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -177,8 +177,13 @@ run_playbook() {
     local playbook="${1:-$REPO_DIR/site.yml}"
     local log="$TMP_DIR/playbook.log"
     touch "$log"
-    whiptail --title "Ansible Playbook" --tailbox "$log" 20 70 &
-    local box_pid=$!
+    if command -v dialog >/dev/null 2>&1; then
+        dialog --title "Ansible Playbook" --tailboxbg "$log" 20 70 &
+        local box_pid=$!
+    else
+        whiptail --title "Ansible Playbook" --textbox "$log" 20 70 &
+        local box_pid=$!
+    fi
     if ansible-playbook "$playbook" >"$log" 2>&1; then
         result=0
     else


### PR DESCRIPTION
## Summary
- show playbook output with `dialog --tailboxbg` when available
- fallback to whiptail textbox if `dialog` is missing

## Testing
- `shellcheck simple_menu.sh startup_menu.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851566db28c83288ea886b96d60d4b0