### PR TITLE
Run playbook only from Continue option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This repository contains scripts and Ansible playbooks used to provision xiNAS n
 1. Run `prepare_system.sh` on the target host (use the `-e` option for expert mode). This installs required packages including `yq` version 4, `whiptail`, and Ansible, then clones the repository.
    The script immediately launches a simplified start menu in default mode to enter the license and choose a preset. Use `-e` to access the full interactive menu with additional options such as updating the repository or saving the current configuration as a new preset.
 2. Execute `startup_menu.sh` separately if you need the complete configuration menu outside of the expert mode. Any presets you create in expert mode will also be available here and in the simplified menu.
-3. Optionally run the included Ansible playbook to apply the configuration.
-   The menus also provide an **Exit** option if you want to leave without running the playbook.
+3. To apply the configuration, choose **Continue** from the menu.
+   The playbook will run at that point, executing all configured roles. An **Exit** option is available if you want to leave without running the playbook.
 4. To configure an NFS client on another system, run `sudo ./client_setup.sh`. Root
    privileges are required to install packages, create the mount point and mount
    the exported share.

--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -42,7 +42,7 @@ enter_license() {
 }
 
 run_playbook() {
-    local playbook="${1:-$REPO_DIR/site.yml}"
+    local playbook="${1:-$REPO_DIR/playbooks/site.yml}"
     local log="$TMP_DIR/playbook.log"
     touch "$log"
     if command -v dialog >/dev/null 2>&1; then
@@ -85,7 +85,8 @@ apply_preset() {
         msg+="- NFS exports\n"
     fi
     if [ -f "$pdir/playbook.yml" ]; then
-        run_playbook "$pdir/playbook.yml"
+        cp "$pdir/playbook.yml" "playbooks/site.yml"
+        msg+="- playbook updated\n"
     fi
     whiptail --msgbox "$msg" 15 70
 }
@@ -120,7 +121,12 @@ while true; do
     case "$choice" in
         1) enter_license ;;
         2) choose_preset ;;
-        3) exit 0 ;;
+        3)
+            run_playbook "playbooks/site.yml"
+            chmod +x post_install_menu.sh
+            ./post_install_menu.sh
+            exit 0
+            ;;
         4) exit 2 ;;
     esac
 done

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -174,7 +174,7 @@ configure_git_repo() {
 
 # Run ansible-playbook and stream output
 run_playbook() {
-    local playbook="${1:-$REPO_DIR/site.yml}"
+    local playbook="${1:-$REPO_DIR/playbooks/site.yml}"
     local log="$TMP_DIR/playbook.log"
     touch "$log"
     if command -v dialog >/dev/null 2>&1; then
@@ -219,7 +219,8 @@ apply_preset() {
         msg+="- NFS exports\n"
     fi
     if [ -f "$pdir/playbook.yml" ]; then
-        run_playbook "$pdir/playbook.yml"
+        cp "$pdir/playbook.yml" "playbooks/site.yml"
+        msg+="- playbook updated\n"
     fi
     whiptail --msgbox "$msg" 15 70
 }
@@ -292,7 +293,12 @@ while true; do
         4) edit_nfs_exports ;;
         5) choose_preset ;;
         6) configure_git_repo ;;
-        7) exit 0 ;;
+        7)
+            run_playbook "playbooks/site.yml"
+            chmod +x post_install_menu.sh
+            ./post_install_menu.sh
+            exit 0
+            ;;
         8) exit 2 ;;
     esac
 done


### PR DESCRIPTION
## Summary
- don't launch Ansible playbook automatically when selecting a preset
- copy a preset playbook into `playbooks/site.yml`
- run the playbook when `Continue` is selected in the menu
- adjust install script to rely on menu for running Ansible
- update documentation

## Testing
- `bash -n simple_menu.sh startup_menu.sh prepare_system.sh`

------
https://chatgpt.com/codex/tasks/task_e_68515982f56c83288fdef3a625358b41