### PR TITLE
Add spare pool support and xinnorVM preset

### DIFF
--- a/collection/roles/raid_fs/tasks/create_array.yml
+++ b/collection/roles/raid_fs/tasks/create_array.yml
@@ -10,6 +10,7 @@
   ansible.builtin.command: >-
     xicli raid create -n {{ item.name }} -l {{ item.level }}
     -d {{ _devlist }} -ss {{ item.strip_size_kb }}
+    {% if item.spare_pool is defined %}-sp {{ item.spare_pool }}{% endif %}
     {% if xiraid_force_metadata | bool %}--force_metadata{% endif %}
   register: raid_create
   changed_when: raid_create.rc == 0

--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -15,6 +15,32 @@
     state: present
   tags: [raid_fs, raid]
 
+- name: Gather existing spare pools
+  ansible.builtin.command: xicli pool show -f json
+  register: xiraid_pools
+  changed_when: false
+  failed_when: xiraid_pools.rc != 0
+  tags: [raid_fs, raid]
+
+- name: Set fact – parsed pools
+  ansible.builtin.set_fact:
+    existing_pools: "{{ xiraid_pools.stdout | from_json }}"
+  tags: [raid_fs, raid]
+
+- name: Create xiRAID spare pools
+  ansible.builtin.command: >-
+    xicli pool create -n {{ item.name }} -d {{ item.devices | join(' ') }}
+  register: pool_create
+  changed_when: pool_create.rc == 0
+  failed_when:
+    - pool_create.rc != 0
+    - pool_create.stderr is not search('already exists')
+  loop: "{{ xiraid_spare_pools }}"
+  loop_control:
+    loop_var: item
+  when: item.name not in ((existing_pools | default([], true) | json_query('[].name')) | default([], true))
+  tags: [raid_fs, raid]
+
 - name: Find active MD RAID arrays
   ansible.builtin.command: lsblk -ln -o NAME,TYPE | awk '$2 ~ /^raid/ {print "/dev/"$1}'
   register: mdraid_scan

--- a/post_install_menu.sh
+++ b/post_install_menu.sh
@@ -47,6 +47,13 @@ EOF
         else
             python3 -m json.tool "$raw" >"$out" 2>/dev/null || cat "$raw" >"$out"
         fi
+        {
+            echo
+            echo "Spare Pools:"
+            if ! xicli pool show; then
+                echo "Failed to run xicli pool show"
+            fi
+        } >>"$out"
     else
         echo "Failed to run xicli raid show" >"$out"
     fi

--- a/presets/xinnorVM/netplan.yaml.j2
+++ b/presets/xinnorVM/netplan.yaml.j2
@@ -1,0 +1,7 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    ib0:
+      dhcp4: no
+      addresses: [ 100.100.100.1/24 ]

--- a/presets/xinnorVM/nfs_exports.yml
+++ b/presets/xinnorVM/nfs_exports.yml
@@ -1,0 +1,8 @@
+# List of export rules. Each item fields:
+#   path    – directory to export (will be created if missing)
+#   clients – host or network mask, or "*" for all
+#   options – NFS export options
+exports:
+  - path: /mnt/data
+    clients: "*"
+    options: "rw,sync,insecure,no_root_squash,no_subtree_check,no_wdelay"

--- a/presets/xinnorVM/playbook.yml
+++ b/presets/xinnorVM/playbook.yml
@@ -1,0 +1,13 @@
+---
+- name: Full storage-node configuration (common → OFED → xiRAID → NFS → perf)
+  hosts: storage_nodes
+  gather_facts: true
+  roles:
+    - role: common
+    - role: doca_ofed
+    - role: net_controllers
+    - role: xiraid_classic  # EULA is accepted automatically
+    - role: raid_fs
+    - role: exports       # manage /etc/exports
+    - role: nfs_server    # configure kernel NFS server
+    - role: perf_tuning

--- a/presets/xinnorVM/raid_fs.yml
+++ b/presets/xinnorVM/raid_fs.yml
@@ -8,38 +8,39 @@ xiraid_license_path: "/tmp/license"
 # Set to `false` if metadata should not be overwritten
 xiraid_force_metadata: true
 
-# Spare pool definitions. A single pool example:
-# xiraid_spare_pools:
-#   - name: sp1
-#     devices:
-#       - /dev/sdq
-xiraid_spare_pools: []
-
 # Default RAID arrays and filesystem definitions used by the xiNAS example
 # deployment. Modify these values directly rather than using group variables.
+xiraid_spare_pools:
+  - name: sp1
+    devices:
+      - /dev/sdq
+
 xiraid_arrays:
   - name: media6
     level: 6
     strip_size_kb: 128
+    spare_pool: sp1
     devices:
-      - /dev/nvme1n1
-      - /dev/nvme2n1
-      - /dev/nvme3n1
-      - /dev/nvme4n1
-      - /dev/nvme5n1
-      - /dev/nvme6n1
-      - /dev/nvme7n1
-      - /dev/nvme8n1
-      - /dev/nvme9n1
-      - /dev/nvme10n1
+      - /dev/sde
+      - /dev/sdf
+      - /dev/sdg
+      - /dev/sdh
+      - /dev/sdi
+      - /dev/sdj
+      - /dev/sdk
+      - /dev/sdl
+      - /dev/sdm
+      - /dev/sdn
+      - /dev/sdo
+      - /dev/sdp
     parity_disks: 2
 
   - name: media1
     level: 1
     strip_size_kb: 16
     devices:
-      - /dev/nvme11n1
-      - /dev/nvme12n1
+      - /dev/sdc
+      - /dev/sdd
 
 xfs_filesystems:
   - label: nfsdata


### PR DESCRIPTION
## Summary
- support spare pool creation in `raid_fs` role
- allow specifying spare pool for arrays
- show spare pool info in post-install menu
- edit spare pool devices in RAID configuration menu
- add `xinnorVM` preset using RAID6, RAID1 journal and spare disk

## Testing
- `bash -n configure_raid.sh`
- `bash -n post_install_menu.sh`


------
https://chatgpt.com/codex/tasks/task_e_685414732628832899841aca3f5dd2bc