### PR TITLE
Fix crash when spare pool missing

### DIFF
--- a/configure_raid.sh
+++ b/configure_raid.sh
@@ -32,7 +32,8 @@ get_devices() {
 }
 
 get_spare_devices() {
-    yq -r '.xiraid_spare_pools[0].devices | join(" ")' "$vars_file" 2>/dev/null
+    # Gracefully handle presets without a spare pool defined
+    yq -r '(.xiraid_spare_pools[0].devices // []) | join(" ")' "$vars_file" 2>/dev/null
 }
 
 edit_spare_pool() {


### PR DESCRIPTION
## Summary
- handle missing spare pool definitions in `configure_raid.sh`

## Testing
- `yq --version`

------
https://chatgpt.com/codex/tasks/task_e_685419454b98832889c944f2216d28a6