### PR TITLE
Add InfiniBand udev naming rules

### DIFF
--- a/collection/roles/doca_ofed/defaults/main.yml
+++ b/collection/roles/doca_ofed/defaults/main.yml
@@ -8,3 +8,8 @@ doca_pkgs:
   - doca-ofed-userspace
 
 doca_ofed_auto_reboot: false
+
+# Netplan template containing desired InfiniBand names
+ib_netplan_template: "/opt/provision/collection/roles/net_controllers/templates/netplan.yaml.j2"
+# Location of generated udev rules for InfiniBand
+ib_udev_rules_file: "/etc/udev/rules.d/70-ib-names.rules"

--- a/collection/roles/doca_ofed/files/configure_ib_udev.sh
+++ b/collection/roles/doca_ofed/files/configure_ib_udev.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+CONFIG_FILE="${1:-/opt/provision/collection/roles/net_controllers/templates/netplan.yaml.j2}"
+RULES_FILE="${2:-/etc/udev/rules.d/70-ib-names.rules}"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    exit 0
+fi
+
+mapfile -t names < <(grep -oE '^[[:space:]]*(ib[0-9]+):' "$CONFIG_FILE" | sed -E 's/^[[:space:]]*(ib[0-9]+):/\1/')
+
+ib_ifaces=()
+for path in /sys/class/net/*; do
+    [ -f "$path/type" ] || continue
+    if [ "$(cat "$path/type")" = "32" ]; then
+        ib_ifaces+=( "$(basename "$path")" )
+    fi
+done
+
+num_names=${#names[@]}
+num_ifaces=${#ib_ifaces[@]}
+
+if [ "$num_names" -eq 0 ] || [ "$num_ifaces" -eq 0 ]; then
+    exit 0
+fi
+
+if [ "$num_names" -le "$num_ifaces" ]; then
+    max="$num_names"
+else
+    max="$num_ifaces"
+fi
+
+tmp=$(mktemp)
+for ((i=0; i<max; i++)); do
+    iface="${ib_ifaces[$i]}"
+    name="${names[$i]}"
+    addr=$(cat "/sys/class/net/$iface/address")
+    echo "SUBSYSTEM==\"net\", ACTION==\"add\", ATTR{address}==\"$addr\", NAME=\"$name\"" >> "$tmp"
+done
+
+install -m 0644 "$tmp" "$RULES_FILE"
+rm -f "$tmp"
+
+udevadm control --reload

--- a/collection/roles/doca_ofed/tasks/main.yml
+++ b/collection/roles/doca_ofed/tasks/main.yml
@@ -37,6 +37,22 @@
   notify: restart openibd
   tags: [ofed, install]
 
+- name: Deploy InfiniBand UDEV rename script
+  ansible.builtin.copy:
+    src: configure_ib_udev.sh
+    dest: /usr/local/sbin/configure_ib_udev.sh
+    mode: '0755'
+  tags: [ofed, udev]
+
+- name: Generate UDEV rules for InfiniBand interfaces
+  ansible.builtin.command: >-
+    /usr/local/sbin/configure_ib_udev.sh
+    {{ ib_netplan_template }}
+    {{ ib_udev_rules_file }}
+  register: ib_udev_result
+  changed_when: ib_udev_result.rc == 0
+  tags: [ofed, udev]
+
 - name: Reboot if kernel modules built and reboot requested
   ansible.builtin.reboot:
     msg: "Reboot after DOCA-OFED install (role doca_ofed)"


### PR DESCRIPTION
## Summary
- configure InfiniBand interfaces with persistent names
- run script after DOCA OFED install to write udev rules

## Testing
- `ansible-playbook --syntax-check playbooks/site.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541f6156a0832897f290ed288ff48c