### PR TITLE
Remove inventory prompt

### DIFF
--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -295,8 +295,7 @@ while true; do
         6) configure_git_repo ;;
         7)
             if confirm_playbook "playbooks/site.yml"; then
-                inv_file=$(whiptail --inputbox "Inventory to use for Ansible" 10 70 "inventories/lab.ini" 3>&1 1>&2 2>&3) || continue
-                run_playbook "playbooks/site.yml" "$inv_file"
+                run_playbook "playbooks/site.yml"
                 chmod +x post_install_menu.sh
                 ./post_install_menu.sh
                 exit 0


### PR DESCRIPTION
## Summary
- remove Ansible inventory input prompt from startup menu

## Testing
- `bash -n startup_menu.sh`
- `shellcheck startup_menu.sh`


------
https://chatgpt.com/codex/tasks/task_e_685435743c308328b56ffbf14c86b6a4