### PR TITLE
Add xiRAID exporter role

### DIFF
--- a/collection/roles/xiraid_exporter/README.md
+++ b/collection/roles/xiraid_exporter/README.md
@@ -1,0 +1,13 @@
+# Role **xiraid_exporter**
+Installs the [xiraid_exporter](https://github.com/ithilbor/xiraid_exporter) binary and runs it as a systemd service. The exporter exposes xiRAID metrics for Prometheus.
+
+## Variables
+* `xiraid_exporter_version` – exporter release version (default `2.0.0`).
+* `xiraid_exporter_flags` – list of command line flags passed to the service.
+
+## Example
+```yaml
+- hosts: storage_nodes
+  roles:
+    - role: xiraid_exporter
+```

--- a/collection/roles/xiraid_exporter/defaults/main.yml
+++ b/collection/roles/xiraid_exporter/defaults/main.yml
@@ -1,0 +1,26 @@
+# xiraid_exporter version to install
+xiraid_exporter_version: "2.0.0"
+
+# Architecture for the release asset
+xiraid_exporter_arch: "Linux_x86_64"
+
+# Download URL of the release archive
+xiraid_exporter_download_url: "https://github.com/ithilbor/xiraid_exporter/releases/download/v{{ xiraid_exporter_version }}/xiraid_exporter_v{{ xiraid_exporter_version }}_{{ xiraid_exporter_arch }}.tar.gz"
+
+# Install directory for the exporter binary
+xiraid_exporter_install_dir: "/usr/sbin"
+
+# Command line flags for the exporter service
+xiraid_exporter_flags:
+  - '--xiraid-srv-hostname=localhost'
+  - '--xiraid-srv-port=6066'
+  - '--xiraid-cert-path=/etc/xraid/crt/server-cert.crt'
+  - '--metrics-endpoint=/metrics'
+  - '--collector.xiraid_license_show'
+  - '--collector.xiraid_raid_show'
+  - '--no-prometheus-default-metrics'
+  - '--max-concurrent-requests=40'
+  - '--gomaxprocs=1'
+  - '--web.listen-address=:9505'
+  - '--log.level=info'
+  - '--log.format=logfmt'

--- a/collection/roles/xiraid_exporter/handlers/main.yml
+++ b/collection/roles/xiraid_exporter/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: reload xiraid_exporter
+  ansible.builtin.systemd:
+    daemon_reload: yes
+    name: xiraid_exporter
+    state: restarted

--- a/collection/roles/xiraid_exporter/tasks/main.yml
+++ b/collection/roles/xiraid_exporter/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+- name: Download xiraid_exporter archive
+  ansible.builtin.get_url:
+    url: "{{ xiraid_exporter_download_url }}"
+    dest: "/tmp/xiraid_exporter_{{ xiraid_exporter_version }}.tar.gz"
+    mode: '0644'
+    force: no
+  tags: [xiraid_exporter, download]
+
+- name: Extract xiraid_exporter binary
+  ansible.builtin.unarchive:
+    src: "/tmp/xiraid_exporter_{{ xiraid_exporter_version }}.tar.gz"
+    dest: "/tmp"
+    remote_src: yes
+    creates: "/tmp/xiraid_exporter_v{{ xiraid_exporter_version }}_{{ xiraid_exporter_arch }}"
+  tags: [xiraid_exporter, install]
+
+- name: Install xiraid_exporter binary
+  ansible.builtin.copy:
+    src: "/tmp/xiraid_exporter_v{{ xiraid_exporter_version }}_{{ xiraid_exporter_arch }}/xiraid_exporter"
+    dest: "{{ xiraid_exporter_install_dir }}/xiraid_exporter"
+    mode: '0755'
+  tags: [xiraid_exporter, install]
+
+- name: Install systemd service unit
+  ansible.builtin.template:
+    src: xiraid_exporter.service.j2
+    dest: /etc/systemd/system/xiraid_exporter.service
+    mode: '0644'
+  notify: reload xiraid_exporter
+  tags: [xiraid_exporter, service]
+
+- name: Enable and start xiraid_exporter service
+  ansible.builtin.service:
+    name: xiraid_exporter
+    enabled: true
+    state: started
+  tags: [xiraid_exporter, service]

--- a/collection/roles/xiraid_exporter/templates/xiraid_exporter.service.j2
+++ b/collection/roles/xiraid_exporter/templates/xiraid_exporter.service.j2
@@ -1,0 +1,20 @@
+[Unit]
+Description=xiRAID to Prometheus exporter service
+After=network-online.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+ExecStart={{ xiraid_exporter_install_dir }}/xiraid_exporter \
+{% for flag in xiraid_exporter_flags %}
+    '{{ flag }}' \
+{% endfor %}
+
+SyslogIdentifier=xiraid_exporter
+Restart=always
+RestartSec=1
+StartLimitInterval=0
+
+[Install]
+WantedBy=multi-user.target

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -10,4 +10,5 @@
     - role: raid_fs
     - role: exports       # manage /etc/exports
     - role: nfs_server    # configure kernel NFS server
+    - role: xiraid_exporter    # expose xiRAID metrics
     - role: perf_tuning


### PR DESCRIPTION
## Summary
- add new `xiraid_exporter` role to install xiRAID Prometheus exporter
- add defaults, service template and handlers for the exporter
- document role usage
- include role in `playbooks/site.yml`

## Testing
- `ansible-playbook --syntax-check playbooks/site.yml`
- `ansible-lint playbooks/site.yml` *(fails: 55 violation(s))*


------
https://chatgpt.com/codex/tasks/task_e_6856b7be606883289f5cf898d630441a