### PR TITLE
Automate xiraid_exporter TLS setup

### DIFF
--- a/collection/roles/xiraid_exporter/README.md
+++ b/collection/roles/xiraid_exporter/README.md
@@ -1,6 +1,10 @@
 # Role **xiraid_exporter**
 Installs the [xiraid_exporter](https://github.com/ithilbor/xiraid_exporter) binary and runs it as a systemd service. The exporter exposes xiRAID metrics for Prometheus.
 
+The role now also generates self-signed TLS certificates for xiRAID in
+`/etc/xraid/crt` and restarts the `xiraid.target` unit so the exporter can
+connect securely without manual steps.
+
 ## Variables
 * `xiraid_exporter_version` – exporter release version (default `2.0.0`).
 * `xiraid_exporter_flags` – list of command line flags passed to the service.

--- a/collection/roles/xiraid_exporter/handlers/main.yml
+++ b/collection/roles/xiraid_exporter/handlers/main.yml
@@ -3,3 +3,8 @@
     daemon_reload: yes
     name: xiraid_exporter
     state: restarted
+
+- name: restart xiraid
+  ansible.builtin.systemd:
+    name: xiraid.target
+    state: restarted

--- a/collection/roles/xiraid_exporter/tasks/main.yml
+++ b/collection/roles/xiraid_exporter/tasks/main.yml
@@ -22,6 +22,60 @@
     mode: '0755'
   tags: [xiraid_exporter, install]
 
+- name: Ensure openssl package present
+  ansible.builtin.apt:
+    name: openssl
+    state: present
+  tags: [xiraid_exporter, cert]
+
+- name: Create xiRAID certificate directory
+  ansible.builtin.file:
+    path: /etc/xraid/crt
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  tags: [xiraid_exporter, cert]
+
+- name: Generate xiRAID CA key
+  ansible.builtin.command: openssl genrsa -out ca.key 2048
+  args:
+    chdir: /etc/xraid/crt
+    creates: ca.key
+  tags: [xiraid_exporter, cert]
+
+- name: Generate xiRAID CA certificate
+  ansible.builtin.command: >-
+    openssl req -new -x509 -days 365 -key ca.key
+    -subj '/C=US/ST=State/L=City/O=Company/OU=IT/CN=CA'
+    -out ca-cert.crt
+  args:
+    chdir: /etc/xraid/crt
+    creates: ca-cert.crt
+  tags: [xiraid_exporter, cert]
+
+- name: Generate xiRAID server key and CSR
+  ansible.builtin.command: >-
+    openssl req -newkey rsa:2048 -nodes -keyout server-key.key
+    -subj '/C=US/ST=State/L=City/O=Company/OU=IT/CN=localhost'
+    -out server-cert.csr
+  args:
+    chdir: /etc/xraid/crt
+    creates: server-cert.csr
+  tags: [xiraid_exporter, cert]
+
+- name: Generate xiRAID server certificate
+  ansible.builtin.shell: >-
+    openssl x509 -req -extfile <(printf 'subjectAltName=DNS:localhost,IP:127.0.0.1')
+    -days 365 -in server-cert.csr -CA ca-cert.crt -CAkey ca.key -CAcreateserial
+    -out server-cert.crt
+  args:
+    executable: /bin/bash
+    chdir: /etc/xraid/crt
+    creates: server-cert.crt
+  notify: restart xiraid
+  tags: [xiraid_exporter, cert]
+
 - name: Install systemd service unit
   ansible.builtin.template:
     src: xiraid_exporter.service.j2


### PR DESCRIPTION
## Summary
- automate TLS certificate generation for `xiraid_exporter`
- restart `xiraid.target` via handler when certificates are created
- document automatic certificate setup in role README

## Testing
- `ansible-playbook -i inventories/lab.ini playbooks/site.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_6856ba95b058832892138101324460d8