### PR TITLE
Add hostname configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains scripts and Ansible playbooks used to provision xiNAS n
 
 1. Run `prepare_system.sh` on the target host (use the `-e` option for expert mode). This installs required packages including `yq` version 4, `whiptail`, and Ansible, then clones the repository.
    The script immediately launches a simplified start menu in default mode to enter the license and choose a preset. Use `-e` to access the full interactive menu with additional options such as updating the repository or saving the current configuration as a new preset.
-2. Execute `startup_menu.sh` separately if you need the complete configuration menu outside of the expert mode. Any presets you create in expert mode will also be available here and in the simplified menu.
+2. Execute `startup_menu.sh` separately if you need the complete configuration menu outside of the expert mode. Any presets you create in expert mode will also be available here and in the simplified menu. It also allows setting a custom hostname.
 3. To apply the configuration, choose **Continue** from the menu.
    The playbook will run at that point, executing all configured roles. An **Exit** option is available if you want to leave without running the playbook.
 4. To configure an NFS client on another system, run `sudo ./client_setup.sh`. Root

--- a/collection/roles/common/README.md
+++ b/collection/roles/common/README.md
@@ -8,6 +8,7 @@ Baseline configuration for all storage nodes. Installs essential packages, confi
 * **`common_sysctl`** – dictionary of sysctl parameters.
 * **`chrony_service_name`** – name of the chrony service to manage (default `chrony`).
 * **`chrony_package_name`** – name of the chrony package to install (default `chrony`).
+* **`xinas_hostname`** – hostname to set. Defaults to `xiNAS-HWKEY`.
 
 ## Example
 ```yaml

--- a/collection/roles/common/defaults/main.yml
+++ b/collection/roles/common/defaults/main.yml
@@ -20,3 +20,5 @@ common_sysctl:
   net.core.rmem_max: 268435456
   net.core.wmem_max: 268435456
   vm.swappiness: 10
+# Hostname for the node. If empty, the role constructs 'xiNAS-HWKEY'.
+xinas_hostname: ""

--- a/collection/roles/common/tasks/main.yml
+++ b/collection/roles/common/tasks/main.yml
@@ -59,3 +59,24 @@
   notify: reload sysctl
   tags: [sysctl]
 
+
+- name: Retrieve xiRAID hardware key
+  ansible.builtin.command: ./hwkey
+  args:
+    chdir: "{{ playbook_dir }}/.."
+  register: hwkey_result
+  changed_when: false
+  failed_when: hwkey_result.rc != 0
+  when: xinas_hostname | length == 0
+  tags: [hostname]
+
+- name: Set default hostname fact
+  ansible.builtin.set_fact:
+    xinas_hostname: "xiNAS-{{ hwkey_result.stdout | trim | upper }}"
+  when: xinas_hostname | length == 0
+  tags: [hostname]
+
+- name: Set system hostname
+  ansible.builtin.hostname:
+    name: "{{ xinas_hostname }}"
+  tags: [hostname]

--- a/collection/roles/xiraid_exporter/README.md
+++ b/collection/roles/xiraid_exporter/README.md
@@ -8,6 +8,7 @@ connect securely without manual steps.
 ## Variables
 * `xiraid_exporter_version` – exporter release version (default `2.0.0`).
 * `xiraid_exporter_flags` – list of command line flags passed to the service.
+* Uses `xinas_hostname` to generate certificates and as the exporter server hostname.
 
 ## Example
 ```yaml

--- a/collection/roles/xiraid_exporter/defaults/main.yml
+++ b/collection/roles/xiraid_exporter/defaults/main.yml
@@ -12,7 +12,7 @@ xiraid_exporter_install_dir: "/usr/sbin"
 
 # Command line flags for the exporter service
 xiraid_exporter_flags:
-  - '--xiraid-srv-hostname=localhost'
+  - '--xiraid-srv-hostname={{ xinas_hostname }}'
   - '--xiraid-srv-port=6066'
   - '--xiraid-cert-path=/etc/xraid/crt/server-cert.crt'
   - '--metrics-endpoint=/metrics'

--- a/collection/roles/xiraid_exporter/tasks/main.yml
+++ b/collection/roles/xiraid_exporter/tasks/main.yml
@@ -57,7 +57,7 @@
 - name: Generate xiRAID server key and CSR
   ansible.builtin.command: >-
     openssl req -newkey rsa:2048 -nodes -keyout server-key.key
-    -subj '/C=US/ST=State/L=City/O=Company/OU=IT/CN=localhost'
+    -subj '/C=US/ST=State/L=City/O=Company/OU=IT/CN={{ xinas_hostname }}'
     -out server-cert.csr
   args:
     chdir: /etc/xraid/crt
@@ -66,7 +66,7 @@
 
 - name: Generate xiRAID server certificate
   ansible.builtin.shell: >-
-    openssl x509 -req -extfile <(printf 'subjectAltName=DNS:localhost,IP:127.0.0.1')
+    openssl x509 -req -extfile <(printf 'subjectAltName=DNS:{{ xinas_hostname }},IP:127.0.0.1')
     -days 365 -in server-cert.csr -CA ca-cert.crt -CAkey ca.key -CAcreateserial
     -out server-cert.crt
   args:

--- a/configure_hostname.sh
+++ b/configure_hostname.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Interactive helper to configure system hostname for xiNAS
+set -euo pipefail
+
+backup_if_changed() {
+    local file="$1" newfile="$2" ts
+    [ -f "$file" ] || return
+    if ! cmp -s "$file" "$newfile"; then
+        ts=$(date +%Y%m%d%H%M%S)
+        cp "$file" "${file}.${ts}.bak"
+    fi
+}
+
+valid_hostname() {
+    local name="$1"
+    [[ $name =~ ^[A-Za-z0-9][-A-Za-z0-9]{0,62}$ ]]
+}
+
+vars_file="collection/roles/common/defaults/main.yml"
+
+for cmd in yq whiptail; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "Error: required command '$cmd' not found. Please run prepare_system.sh or install it manually." >&2
+        exit 1
+    fi
+done
+
+if [ ! -f "$vars_file" ]; then
+    echo "Error: $vars_file not found" >&2
+    exit 1
+fi
+
+current=$(yq -r '.xinas_hostname // ""' "$vars_file")
+[ -x ./hwkey ] || chmod +x ./hwkey
+if [ -z "$current" ]; then
+    hw=$(./hwkey 2>/dev/null | tr -d '\n' | tr '[:lower:]' '[:upper:]')
+    current="xiNAS-$hw"
+fi
+
+set +e
+name=$(whiptail --inputbox "Hostname" 8 60 "$current" 3>&1 1>&2 2>&3)
+status=$?
+set -e
+[ $status -ne 0 ] && exit 0
+
+if ! valid_hostname "$name"; then
+    whiptail --msgbox "Invalid hostname format" 8 60
+    exit 1
+fi
+
+tmp=$(mktemp)
+NAME="$name" yq e '.xinas_hostname = env(NAME)' "$vars_file" > "$tmp"
+backup_if_changed "$vars_file" "$tmp"
+mv "$tmp" "$vars_file"
+
+whiptail --msgbox "Hostname set to $name" 8 60
+

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -76,6 +76,11 @@ configure_network() {
 
     whiptail --title "Ansible Netplan" --textbox "$template" 20 70
 }
+# Configure hostname for Ansible role
+configure_hostname() {
+    ./configure_hostname.sh
+}
+
 
 # Display playbook information from /opt/provision/README.md
 show_playbook_info() {
@@ -106,9 +111,18 @@ configure_nfs_shares() {
 
     while true; do
         local choice
-        choice=$(whiptail --title "NFS Share" --menu "Choose an action:" 15 70 4 \
-            1 "Edit default share" \
-            2 "Back" 3>&1 1>&2 2>&3)
+    choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 20 70 16 \
+        1 "Enter License" \
+        2 "Configure Network" \
+        3 "Set Hostname" \
+        3 "Set Hostname" \
+        4 "Configure RAID" \
+        5 "Edit NFS Exports" \
+        6 "Presets" \
+        7 "Git Repository Configuration" \
+        8 "Continue" \
+        9 "Exit" \
+        3>&1 1>&2 2>&3)
         case "$choice" in
             1) ./configure_nfs_exports.sh --edit "$default_path" ;;
             *) break ;;
@@ -279,21 +293,23 @@ while true; do
     choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 20 70 16 \
         1 "Enter License" \
         2 "Configure Network" \
-        3 "Configure RAID" \
-        4 "Edit NFS Exports" \
-        5 "Presets" \
-        6 "Git Repository Configuration" \
-        7 "Continue" \
-        8 "Exit" \
+        3 "Set Hostname" \
+        4 "Configure RAID" \
+        5 "Edit NFS Exports" \
+        6 "Presets" \
+        7 "Git Repository Configuration" \
+        8 "Continue" \
+        9 "Exit" \
         3>&1 1>&2 2>&3)
     case "$choice" in
         1) enter_license ;;
         2) configure_network ;;
-        3) configure_raid ;;
-        4) edit_nfs_exports ;;
-        5) choose_preset ;;
-        6) configure_git_repo ;;
-        7)
+        3) configure_hostname ;;
+        4) configure_raid ;;
+        5) edit_nfs_exports ;;
+        6) choose_preset ;;
+        7) configure_git_repo ;;
+        8)
             if confirm_playbook "playbooks/site.yml"; then
                 run_playbook "playbooks/site.yml"
                 chmod +x post_install_menu.sh
@@ -301,7 +317,7 @@ while true; do
                 exit 0
             fi
             ;;
-        8) exit 2 ;;
+        9) exit 2 ;;
     esac
 done
 


### PR DESCRIPTION
## Summary
- configure hostname in `common` role using hwkey
- customize hostname via new `configure_hostname.sh`
- reference hostname variable in exporter role and certificates
- expose hostname setting in expert startup menu
- document hostname option

## Testing
- `ansible-playbook --syntax-check playbooks/common.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857025729b08328b1424fc27414d060