### PR TITLE
Add hostname management

### DIFF
--- a/post_install_menu.sh
+++ b/post_install_menu.sh
@@ -89,7 +89,10 @@ show_nfs_info() {
 
 manage_network() {
     local out="$TMP_DIR/net_info"
-    ip -o -4 addr show | awk '{print $2, $4}' >"$out"
+    {
+        echo "Hostname: $(hostname)"
+        ip -o -4 addr show | awk '{print $2, $4}'
+    } >"$out"
     whiptail --title "Network Interfaces" --textbox "$out" 20 70
     if whiptail --yesno "Modify network configuration?" 8 60; then
         ROLE_TEMPLATE_OVERRIDE=/etc/netplan/99-xinas.yaml ./configure_network.sh


### PR DESCRIPTION
## Summary
- write the chosen hostname to `/etc/hosts`
- display the hostname in the post-install network menu

## Testing
- `bash -n configure_hostname.sh post_install_menu.sh`

------
https://chatgpt.com/codex/tasks/task_e_6857066bc98483288b044672d5a30cad