### PR TITLE
Remove unattended upgrades configuration

### DIFF
--- a/collection/roles/common/defaults/main.yml
+++ b/collection/roles/common/defaults/main.yml
@@ -12,7 +12,6 @@ common_packages:
   - vim
   - htop
   - chrony                # NTP daemon; change to ntp if preferred
-  - unattended-upgrades
   - ca-certificates
 chrony_service_name: chrony
 chrony_package_name: chrony

--- a/collection/roles/common/handlers/main.yml
+++ b/collection/roles/common/handlers/main.yml
@@ -5,7 +5,3 @@
 - name: reload sysctl
   ansible.builtin.command: sysctl --system
 
-- name: restart unattended-upgrades
-  ansible.builtin.service:
-    name: unattended-upgrades
-    state: restarted

--- a/collection/roles/common/tasks/main.yml
+++ b/collection/roles/common/tasks/main.yml
@@ -39,15 +39,6 @@
     selection: hold
   tags: [kernel]
 
-- name: Deploy unattended‑upgrades configuration
-  ansible.builtin.template:
-    src: unattended-upgrades.conf.j2
-    dest: /etc/apt/apt.conf.d/20auto-upgrades
-    owner: root
-    group: root
-    mode: '0644'
-  notify: restart unattended-upgrades
-  tags: [security]
 
 - name: Apply sysctl parameters
   ansible.builtin.sysctl:

--- a/collection/roles/common/templates/unattended-upgrades.conf.j2
+++ b/collection/roles/common/templates/unattended-upgrades.conf.j2
@@ -1,6 +1,0 @@
-# -------------------------------------------------------------
-# templates/unattended-upgrades.conf.j2
-# -------------------------------------------------------------
-APT::Periodic::Update-Package-Lists "1";
-APT::Periodic::Unattended-Upgrade "1";
-Unattended-Upgrade::Automatic-Reboot "true";


### PR DESCRIPTION
## Summary
- clean up baseline role by removing unattended-upgrades package
- drop template and handlers for unattended upgrades

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6857d7a34eb8832882522bb75a56b9e9