### PR TITLE
Revert security options and restore unattended upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ This repository contains scripts and Ansible playbooks used to provision xiNAS n
    The playbook will run at that point, executing all configured roles. An **Exit** option is available if you want to leave without running the playbook.
 4. To configure an NFS client on another system, run `sudo ./client_setup.sh`. Root
    privileges are required to install packages, create the mount point and mount
-   the exported share. During the setup you can choose the desired NFS security
-   mode such as `sys` or Kerberos. If you only need the client pieces, copy the
-   contents of the `client_repo` directory into a separate repository and run
-   the script from there.
+   the exported share. If you only need the client pieces, copy the contents of
+   the `client_repo` directory into a separate repository and run the script
+   from there.
 
 The `prepare_system.sh` script installs dependencies required by the interactive helper scripts. The helper scripts rely on the [`mikefarah/yq`](https://github.com/mikefarah/yq) binary (v4+). If you encounter errors such as `jq: error: env/1 is not defined`, make sure this version of `yq` is installed by re-running `prepare_system.sh` or installing it manually.

--- a/client_repo/README.md
+++ b/client_repo/README.md
@@ -13,8 +13,7 @@ Included files:
 - `ansible.cfg` – minimal Ansible configuration
 
 To use this directory as a separate repo, copy it to a new Git repository and run
-`client_setup.sh` with root privileges on the client machine. The script allows
-you to choose NFS security modes such as `sys` or Kerberos during setup:
+`client_setup.sh` with root privileges on the client machine:
 
 ```bash
 sudo ./client_setup.sh

--- a/client_repo/client_setup.sh
+++ b/client_repo/client_setup.sh
@@ -54,30 +54,6 @@ select_protocol() {
     echo "${choice:-$default}"
 }
 
-# Present a choice for NFS security mode
-select_security() {
-    local default="${1:-sys}" choice status
-    if [ -n "$WHIPTAIL" ]; then
-        set +e
-        choice=$(whiptail --title "Select Security" --menu "Choose NFS security mode:" 15 60 4 \
-            sys "AUTH_SYS" \
-            krb5 "Kerberos" \
-            krb5i "Kerberos+Integrity" \
-            krb5p "Kerberos+Privacy" 3>&1 1>&2 2>&3)
-        status=$?
-        set -e
-        if [ $status -ne 0 ]; then
-            choice="$default"
-        fi
-    else
-        PS3="Select security mode [1-4]: "
-        select choice in sys krb5 krb5i krb5p; do
-            [ -n "$choice" ] && break
-        done
-    fi
-    echo "${choice:-$default}"
-}
-
 run_playbook() {
     local pb="$1" log
     log=$(mktemp)
@@ -103,7 +79,6 @@ main() {
     server_ip=$(ask_input "Server IP address" "10.239.239.100")
     share=$(ask_input "NFS share" "/mnt/data")
     mount_point=$(ask_input "Local mount point" "/mnt/nfs")
-    sec_mode=$(select_security "sys")
 
     if command -v apt-get >/dev/null 2>&1; then
         apt-get update -y
@@ -116,9 +91,9 @@ main() {
 
     mkdir -p "$mount_point"
     if [[ "$proto" == "RDMA" ]]; then
-        opts="rdma,port=20049,nconnect=16,vers=4.2,sync,sec=$sec_mode"
+        opts="rdma,port=20049,nconnect=16,vers=4.2,sync"
     else
-        opts="nconnect=16,vers=4.2,sync,sec=$sec_mode"
+        opts="nconnect=16,vers=4.2,sync"
     fi
     if ! mountpoint -q "$mount_point"; then
         mount -t nfs -o "$opts" "$server_ip:$share" "$mount_point" || \

--- a/client_setup.sh
+++ b/client_setup.sh
@@ -54,30 +54,6 @@ select_protocol() {
     echo "${choice:-$default}"
 }
 
-# Present a choice for NFS security mode
-select_security() {
-    local default="${1:-sys}" choice status
-    if [ -n "$WHIPTAIL" ]; then
-        set +e
-        choice=$(whiptail --title "Select Security" --menu "Choose NFS security mode:" 15 60 4 \
-            sys "AUTH_SYS" \
-            krb5 "Kerberos" \
-            krb5i "Kerberos+Integrity" \
-            krb5p "Kerberos+Privacy" 3>&1 1>&2 2>&3)
-        status=$?
-        set -e
-        if [ $status -ne 0 ]; then
-            choice="$default"
-        fi
-    else
-        PS3="Select security mode [1-4]: "
-        select choice in sys krb5 krb5i krb5p; do
-            [ -n "$choice" ] && break
-        done
-    fi
-    echo "${choice:-$default}"
-}
-
 run_playbook() {
     local pb="$1" log
     log=$(mktemp)
@@ -103,7 +79,6 @@ main() {
     server_ip=$(ask_input "Server IP address" "10.239.239.100")
     share=$(ask_input "NFS share" "/mnt/data")
     mount_point=$(ask_input "Local mount point" "/mnt/nfs")
-    sec_mode=$(select_security "sys")
 
     if command -v apt-get >/dev/null 2>&1; then
         apt-get update -y
@@ -116,9 +91,9 @@ main() {
 
     mkdir -p "$mount_point"
     if [[ "$proto" == "RDMA" ]]; then
-        opts="rdma,port=20049,nconnect=16,vers=4.2,sync,sec=$sec_mode"
+        opts="rdma,port=20049,nconnect=16,vers=4.2,sync"
     else
-        opts="nconnect=16,vers=4.2,sync,sec=$sec_mode"
+        opts="nconnect=16,vers=4.2,sync"
     fi
     if ! mountpoint -q "$mount_point"; then
         mount -t nfs -o "$opts" "$server_ip:$share" "$mount_point" || \

--- a/collection/roles/common/defaults/main.yml
+++ b/collection/roles/common/defaults/main.yml
@@ -12,6 +12,7 @@ common_packages:
   - vim
   - htop
   - chrony                # NTP daemon; change to ntp if preferred
+  - unattended-upgrades
   - ca-certificates
 chrony_service_name: chrony
 chrony_package_name: chrony

--- a/collection/roles/common/handlers/main.yml
+++ b/collection/roles/common/handlers/main.yml
@@ -5,3 +5,7 @@
 - name: reload sysctl
   ansible.builtin.command: sysctl --system
 
+- name: restart unattended-upgrades
+  ansible.builtin.service:
+    name: unattended-upgrades
+    state: restarted

--- a/collection/roles/common/tasks/main.yml
+++ b/collection/roles/common/tasks/main.yml
@@ -39,6 +39,15 @@
     selection: hold
   tags: [kernel]
 
+- name: Deploy unattended‑upgrades configuration
+  ansible.builtin.template:
+    src: unattended-upgrades.conf.j2
+    dest: /etc/apt/apt.conf.d/20auto-upgrades
+    owner: root
+    group: root
+    mode: '0644'
+  notify: restart unattended-upgrades
+  tags: [security]
 
 - name: Apply sysctl parameters
   ansible.builtin.sysctl:

--- a/collection/roles/common/templates/unattended-upgrades.conf.j2
+++ b/collection/roles/common/templates/unattended-upgrades.conf.j2
@@ -1,0 +1,6 @@
+# -------------------------------------------------------------
+# templates/unattended-upgrades.conf.j2
+# -------------------------------------------------------------
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Unattended-Upgrade "1";
+Unattended-Upgrade::Automatic-Reboot "true";


### PR DESCRIPTION
## Summary
- revert the addition of security mode selection for the NFS client
- restore unattended-upgrades configuration to protect from accidental updates

## Testing
- `bash -n client_setup.sh`
- `bash -n client_repo/client_setup.sh`
- ❌ `ansible-playbook --syntax-check playbooks/full_install.yml` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d8fae2008328b372672422d99983