### PR TITLE
Add fsid=0 to NFS exports

### DIFF
--- a/collection/roles/exports/README.md
+++ b/collection/roles/exports/README.md
@@ -1,6 +1,7 @@
 # Role **exports**
 Manages NFS export definitions in `/etc/exports` using a Jinja template so that
-access rules are easy to override.
+access rules are easy to override. To designate an export as the NFSv4 root,
+include `fsid=0` in the options field.
 
 ## Variables
 * `exports` – list of dictionaries `{ path, clients, options }`.

--- a/collection/roles/exports/defaults/main.yml
+++ b/collection/roles/exports/defaults/main.yml
@@ -5,4 +5,4 @@
 exports:
   - path: /mnt/data
     clients: "*"
-    options: "rw,sync,insecure,no_root_squash,no_subtree_check,no_wdelay"
+    options: "rw,sync,insecure,no_root_squash,no_subtree_check,no_wdelay,fsid=0"

--- a/presets/default/nfs_exports.yml
+++ b/presets/default/nfs_exports.yml
@@ -5,4 +5,4 @@
 exports:
   - path: /mnt/data
     clients: "*"
-    options: "rw,sync,insecure,no_root_squash,no_subtree_check,no_wdelay"
+    options: "rw,sync,insecure,no_root_squash,no_subtree_check,no_wdelay,fsid=0"

--- a/presets/xinnorVM/nfs_exports.yml
+++ b/presets/xinnorVM/nfs_exports.yml
@@ -5,4 +5,4 @@
 exports:
   - path: /mnt/data
     clients: "*"
-    options: "rw,sync,insecure,no_root_squash,no_subtree_check,no_wdelay"
+    options: "rw,sync,insecure,no_root_squash,no_subtree_check,no_wdelay,fsid=0"


### PR DESCRIPTION
## Summary
- add `fsid=0` to export options so the share is the NFSv4 root
- document the `fsid=0` usage

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check` *(fails: ansible-playbook not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857dde1a69c83289c2573971d7877b6