### PR TITLE
Fix hosts file update

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ This repository contains scripts and Ansible playbooks used to provision xiNAS n
    from there.
 
 The `prepare_system.sh` script installs dependencies required by the interactive helper scripts. The helper scripts rely on the [`mikefarah/yq`](https://github.com/mikefarah/yq) binary (v4+). If you encounter errors such as `jq: error: env/1 is not defined`, make sure this version of `yq` is installed by re-running `prepare_system.sh` or installing it manually.
+
+The `configure_hostname.sh` script updates `/etc/hosts` so that the system's hostname shares the `127.0.0.1` entry with `localhost`.

--- a/configure_hostname.sh
+++ b/configure_hostname.sh
@@ -22,10 +22,11 @@ update_hosts_file() {
     [ -w "$hosts_file" ] || return
     tmp=$(mktemp)
     if grep -q '^127\.0\.0\.1' "$hosts_file"; then
-        sed "s/^127\.0\.0\.1\s*.*/127.0.0.1\t$host/" "$hosts_file" > "$tmp"
+        # Preserve localhost alias while updating the hostname
+        sed "s/^127\.0\.0\.1\s*.*/127.0.0.1\t$host localhost/" "$hosts_file" > "$tmp"
     else
         cat "$hosts_file" > "$tmp"
-        echo -e "127.0.0.1\t$host" >> "$tmp"
+        echo -e "127.0.0.1\t$host localhost" >> "$tmp"
     fi
     backup_if_changed "$hosts_file" "$tmp"
     mv "$tmp" "$hosts_file"


### PR DESCRIPTION
## Summary
- preserve the `localhost` alias when updating `/etc/hosts`
- document hostname script behaviour in README

## Testing
- `shellcheck configure_hostname.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e2e58be08328b8a21fb5e78a1a0c