### PR TITLE
Use localhost for xiRAID certificate generation

### DIFF
--- a/collection/roles/xiraid_exporter/README.md
+++ b/collection/roles/xiraid_exporter/README.md
@@ -8,7 +8,7 @@ connect securely without manual steps.
 ## Variables
 * `xiraid_exporter_version` – exporter release version (default `2.0.0`).
 * `xiraid_exporter_flags` – list of command line flags passed to the service.
-* Uses `xinas_hostname` to generate certificates and as the exporter server hostname.
+* Generates certificates for `localhost` and connects to the xiRAID server on `localhost`.
 
 ## Example
 ```yaml

--- a/collection/roles/xiraid_exporter/defaults/main.yml
+++ b/collection/roles/xiraid_exporter/defaults/main.yml
@@ -12,7 +12,7 @@ xiraid_exporter_install_dir: "/usr/sbin"
 
 # Command line flags for the exporter service
 xiraid_exporter_flags:
-  - '--xiraid-srv-hostname={{ xinas_hostname }}'
+  - '--xiraid-srv-hostname=localhost'
   - '--xiraid-srv-port=6066'
   - '--xiraid-cert-path=/etc/xraid/crt/server-cert.crt'
   - '--metrics-endpoint=/metrics'

--- a/collection/roles/xiraid_exporter/tasks/main.yml
+++ b/collection/roles/xiraid_exporter/tasks/main.yml
@@ -71,13 +71,13 @@
     - server-cert.crt
     - server-cert.csr
     - server-key.key
-  when: server_cert_subject.stdout is defined and xinas_hostname not in server_cert_subject.stdout
+  when: server_cert_subject.stdout is defined and 'localhost' not in server_cert_subject.stdout
   tags: [xiraid_exporter, cert]
 
 - name: Generate xiRAID server key and CSR
   ansible.builtin.command: >-
     openssl req -newkey rsa:2048 -nodes -keyout server-key.key
-    -subj '/C=US/ST=State/L=City/O=Company/OU=IT/CN={{ xinas_hostname }}'
+    -subj '/C=US/ST=State/L=City/O=Company/OU=IT/CN=localhost'
     -out server-cert.csr
   args:
     chdir: /etc/xraid/crt
@@ -86,7 +86,7 @@
 
 - name: Generate xiRAID server certificate
   ansible.builtin.shell: >-
-    openssl x509 -req -extfile <(printf 'subjectAltName=DNS:{{ xinas_hostname }},IP:127.0.0.1')
+    openssl x509 -req -extfile <(printf 'subjectAltName=DNS:localhost,IP:127.0.0.1')
     -days 365 -in server-cert.csr -CA ca-cert.crt -CAkey ca.key -CAcreateserial
     -out server-cert.crt
   args:


### PR DESCRIPTION
## Summary
- generate self-signed server certificates for `localhost`
- connect exporter to xiRAID on `localhost`
- document the new behaviour

## Testing
- `ansible-playbook --syntax-check playbooks/site.yml`

------
https://chatgpt.com/codex/tasks/task_e_6857e49326c08328880f52b58493cf7a