### PR TITLE
Update xiRAID role to 4.3

### DIFF
--- a/collection/roles/xiraid_classic/README.md
+++ b/collection/roles/xiraid_classic/README.md
@@ -4,7 +4,7 @@ kernel module. The role accepts the xiRAID EULA automatically using
 `xicli settings eula modify -s accepted`.
 
 ## Variables
-* `xiraid_version` – set to 4.2.0, 4.1.0 ...
+* `xiraid_version` – set to 4.3.0, 4.2.0 ...
 * `xiraid_repo_version` – version of `xiraid-repo_*.deb` package.
 * `xiraid_kernel` – kernel version used for the repo package (defaults to major.minor of the current kernel).
 * `xiraid_repo_pkg_url` – full URL to download the repository package; override for offline mirror.
@@ -20,5 +20,5 @@ kernel module. The role accepts the xiRAID EULA automatically using
 ```
 
 ### References
-* Xinnor xiRAID 4.2.0 Installation Guide (Ubuntu)
-* xiRAID Classic 4.1.0 PDF – package names and repo workflow
+* Xinnor xiRAID 4.3.0 Installation Guide (Ubuntu)
+* xiRAID Classic 4.2.0 PDF – package names and repo workflow

--- a/collection/roles/xiraid_classic/defaults/main.yml
+++ b/collection/roles/xiraid_classic/defaults/main.yml
@@ -1,8 +1,8 @@
 # xiRAID version to install (use 4.x.y). The repo package is auto-derived.
-xiraid_version: "4.2.0"
+xiraid_version: "4.3.0"
 
 # Version of the repository package
-xiraid_repo_version: "1.2.0-1462"
+xiraid_repo_version: "1.3.0-1588"
 
 # Target kernel for the repo package (current kernel's major.minor by default)
 # Repository packages are named with just the major and minor kernel numbers

--- a/collection/roles/xiraid_classic/tasks/main.yml
+++ b/collection/roles/xiraid_classic/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Remove legacy /etc/xiraid directory if present
+  ansible.builtin.file:
+    path: /etc/xiraid
+    state: absent
+  tags: [xiraid, cleanup]
+
 - name: Ensure kernel headers present (xiRAID DKMS needs them)
   ansible.builtin.apt:
     name: "linux-headers-{{ ansible_kernel }}"


### PR DESCRIPTION
## Summary
- default xiRAID version is now 4.3.0
- update repo package version to 1.3.0-1588
- remove any old `/etc/xiraid` directory before installation
- refresh documentation for the new version

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_6857e69bab7483288df357e99444b4f9