### PR TITLE
Fix hwkey permissions in prepare script

### DIFF
--- a/prepare_system.sh
+++ b/prepare_system.sh
@@ -33,6 +33,9 @@ else
     cd "$REPO_DIR"
 fi
 
+# Ensure the hardware key utility is executable
+[ -x ./hwkey ] || chmod +x ./hwkey
+
 # In expert mode allow updating the repository from GitHub
 if [ "$EXPERT" -eq 1 ]; then
     if whiptail --yesno "Update xiNAS code from GitHub?" 8 60; then


### PR DESCRIPTION
## Summary
- make `hwkey` executable in `prepare_system.sh`

## Testing
- `shellcheck prepare_system.sh`
- `bash -n prepare_system.sh`


------
https://chatgpt.com/codex/tasks/task_e_685870ed44508328bcbc12040813a9cf