### PR TITLE
Temporarily disable xiraid_exporter role

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -10,5 +10,5 @@
     - role: raid_fs
     - role: exports       # manage /etc/exports
     - role: nfs_server    # configure kernel NFS server
-    - role: xiraid_exporter    # expose xiRAID metrics
+    #- role: xiraid_exporter    # expose xiRAID metrics (temporarily disabled)
     - role: perf_tuning


### PR DESCRIPTION
## Summary
- disable `xiraid_exporter` role in the main playbook

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6858fd89f4b48328906e07bc4d889837