### PR TITLE
Handle cpupower on VMs

### DIFF
--- a/collection/roles/perf_tuning/README.md
+++ b/collection/roles/perf_tuning/README.md
@@ -15,7 +15,8 @@ recommended in Xinnor blogs (2023-2025) and NVIDIA ConnectX-7 (400 Gbit) docs.
 
 ## Variables
 See `defaults/main.yml` for the full list; most tuning knobs can be disabled or
-altered via inventory variables.
+altered via inventory variables. Notably, set `perf_disable_cpupower: true` to
+skip adjusting the CPU frequency governor.
 
 ## Example
 ```yaml

--- a/collection/roles/perf_tuning/defaults/main.yml
+++ b/collection/roles/perf_tuning/defaults/main.yml
@@ -7,6 +7,7 @@
 perf_disable_mitigations: true         # add Spectre/Meltdown mitigations=off, etc.
 perf_nvme_poll_queues: 4               # echo "options nvme poll_queues=4"
 perf_stop_irqbalance: false            # stop irqbalance
+perf_disable_cpupower: false          # skip cpupower governor adjustment
 perf_cpu_governor: "performance"       # cpupower governor
 perf_disable_thp: true                 # transparent hugepages=never
 perf_disable_ksm: true

--- a/collection/roles/perf_tuning/tasks/main.yml
+++ b/collection/roles/perf_tuning/tasks/main.yml
@@ -32,7 +32,9 @@
 # ===== CPU governor & irqbalance =====
 - name: Set CPU frequency governor to {{ perf_cpu_governor }}
   ansible.builtin.command: "cpupower frequency-set -g {{ perf_cpu_governor }}"
-  when: ansible_facts['architecture'] == 'x86_64'
+  when:
+    - ansible_facts['architecture'] == 'x86_64'
+    - not perf_disable_cpupower
   tags: [cpu]
 
 - name: Stop and disable irqbalance if requested

--- a/presets/xinnorVM/playbook.yml
+++ b/presets/xinnorVM/playbook.yml
@@ -2,6 +2,8 @@
 - name: Full storage-node configuration (common → OFED → xiRAID → NFS → perf)
   hosts: storage_nodes
   gather_facts: true
+  vars:
+    perf_disable_cpupower: true
   roles:
     - role: common
     - role: doca_ofed


### PR DESCRIPTION
## Summary
- allow disabling cpupower frequency governor change in the perf_tuning role
- skip cpupower governor adjustment in the xinnorVM preset

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check`
- `ansible-playbook presets/xinnorVM/playbook.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_68593429110c83288d43f6932df2d399