### PR TITLE
Skip NVMe tuning when no NVMe devices

### DIFF
--- a/collection/roles/perf_tuning/tasks/main.yml
+++ b/collection/roles/perf_tuning/tasks/main.yml
@@ -63,12 +63,19 @@
 
 - name: Increase nr_requests queue depth to {{ perf_nr_requests }} on NVMe devices
   ansible.builtin.shell: |
-    for dev in /sys/block/nvme*/queue/nr_requests; do echo {{ perf_nr_requests }} > "$dev"; done
+    for dev in /sys/block/nvme*/queue/nr_requests; do
+      [ -e "$dev" ] || continue
+      echo {{ perf_nr_requests }} > "$dev"
+    done
+  when: perf_nr_requests | int > 0
   tags: [io]
 
 - name: Set read-ahead to {{ perf_read_ahead_kb }} KB for NVMe devices
   ansible.builtin.shell: |
-    for blk in /dev/nvme*n*; do /sbin/blockdev --setra {{ perf_read_ahead_kb }} "$blk"; done
+    for blk in /dev/nvme*n*; do
+      [ -e "$blk" ] || continue
+      /sbin/blockdev --setra {{ perf_read_ahead_kb }} "$blk"
+    done
   tags: [io]
 
 # ===== Sysctl network 400 Gbit =====

--- a/presets/xinnorVM/playbook.yml
+++ b/presets/xinnorVM/playbook.yml
@@ -4,6 +4,7 @@
   gather_facts: true
   vars:
     perf_disable_cpupower: true
+    perf_nr_requests: 0
   roles:
     - role: common
     - role: doca_ofed


### PR DESCRIPTION
## Summary
- avoid errors when nvme devices are absent by checking paths
- add `perf_nr_requests: 0` in VM preset

## Testing
- `bash -c 'for dev in /sys/block/nvme*/queue/nr_requests; do [ -e "$dev" ] || continue; echo 512 > "$dev"; done'`
- `bash -c 'for blk in /dev/nvme*n*; do [ -e "$blk" ] || continue; /sbin/blockdev --setra 65536 "$blk"; done'`

------
https://chatgpt.com/codex/tasks/task_e_685939ab33f0832886e1d77fe35b3948