### PR TITLE
Enable systemd-aware mounting

### DIFF
--- a/collection/roles/raid_fs/README.md
+++ b/collection/roles/raid_fs/README.md
@@ -10,6 +10,11 @@ Creates xiRAID arrays and tuned XFS filesystems as per Xinnor NFS RDMA blog.
 This role requires the **mdadm** package to be installed so that any
 leftover Linux MD arrays on xiRAID devices can be stopped and wiped.
 
+When mounting filesystems the role automatically appends an
+`x-systemd.wanted-by` option referencing the underlying block device so
+that the mount is handled by `systemd` at boot time. This follows the
+[xiRAID documentation on file system mounting](https://xinnor.io/docs/xiRAID-4.3.0/E/en/AG/2/file_system_mounting_examples.html).
+
 Array creation is idempotent. If a RAID with the same name already
 exists in the xiRAID configuration file, the role will skip creation
 without failing.

--- a/collection/roles/raid_fs/tasks/create_fs.yml
+++ b/collection/roles/raid_fs/tasks/create_fs.yml
@@ -25,11 +25,20 @@
     mode: '0755'
   tags: [raid_fs, fs]
 
+- name: Compute mount options for {{ item.label }}
+  ansible.builtin.set_fact:
+    mount_device: >-
+      {{ item.data_device | regex_replace('^/','') | replace('/', '-') }}.device
+    mount_opts_with_wanted: >-
+      {{ item.mount_opts | default('') }}{{ ',' if item.mount_opts else '' }}
+      x-systemd.wanted-by={{ mount_device }}
+  tags: [raid_fs, fs]
+
 - name: Mount filesystem {{ item.label }} (and add to fstab)
   ansible.builtin.mount:
     path: "{{ item.mountpoint }}"
     src: "LABEL={{ item.label }}"
     fstype: xfs
-    opts: "{{ item.mount_opts }}"
+    opts: "{{ mount_opts_with_wanted }}"
     state: mounted
   tags: [raid_fs, fs]


### PR DESCRIPTION
## Summary
- ensure mounts created by the raid_fs role are handled by systemd
- document the behavior in the role README

## Testing
- `yamllint collection/roles/raid_fs/tasks/create_fs.yml`

------
https://chatgpt.com/codex/tasks/task_e_68594f86b94c83288d54b8668883471a