### PR TITLE
Add package status helper with newline

### DIFF
--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -14,6 +14,12 @@ check_license() {
     return 0
 }
 
+# Display package status using dpkg-query with a trailing newline
+pkg_status() {
+    local pkg="$1"
+    dpkg-query -W -f='${Status}\n' "$pkg" 2>/dev/null || true
+}
+
 enter_license() {
     local license_file="/tmp/license"
     [ -x ./hwkey ] || chmod +x ./hwkey
@@ -59,8 +65,10 @@ run_playbook() {
 
 # Check for installed xiRAID packages and optionally remove them
 check_remove_xiraid() {
-    local pkgs found
+    local pkgs found repo_status
     pkgs=$(dpkg -l 'xiraid*' 2>/dev/null | awk '/^ii/{print $2}')
+    repo_status=$(pkg_status xiraid-repo)
+    [ -n "$repo_status" ] && echo "xiraid-repo: $repo_status"
     if [ -z "$pkgs" ]; then
         return 0
     fi

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -19,6 +19,12 @@ check_license() {
     return 0
 }
 
+# Display package status using dpkg-query with a trailing newline
+pkg_status() {
+    local pkg="$1"
+    dpkg-query -W -f='${Status}\n' "$pkg" 2>/dev/null || true
+}
+
 # Prompt user for license string and store it in /tmp/license
 # Show license prompt and save to /tmp/license
 enter_license() {
@@ -206,8 +212,10 @@ run_playbook() {
 
 # Check for installed xiRAID packages and optionally remove them
 check_remove_xiraid() {
-    local pkgs found
+    local pkgs found repo_status
     pkgs=$(dpkg -l 'xiraid*' 2>/dev/null | awk '/^ii/{print $2}')
+    repo_status=$(pkg_status xiraid-repo)
+    [ -n "$repo_status" ] && echo "xiraid-repo: $repo_status"
     if [ -z "$pkgs" ]; then
         return 0
     fi


### PR DESCRIPTION
## Summary
- add `pkg_status` to show dpkg query results with newline
- print xiRAID repo package status before checking installed packages

## Testing
- `shellcheck startup_menu.sh simple_menu.sh`


------
https://chatgpt.com/codex/tasks/task_e_68596f7b93f88328aadb2126f5e69869