### PR TITLE
Hide device count in post-install RAID info

### DIFF
--- a/post_install_menu.sh
+++ b/post_install_menu.sh
@@ -29,8 +29,8 @@ elif isinstance(data, dict):
     if not arrays:
         arrays = [dict(v, name=k) if isinstance(v, dict) else {"name": k}
                   for k, v in data.items()]
-print("{:<15} {:>12} {:>10} {:<20} {:>5} {:>7}".format(
-    'Name', 'Size', 'Strip', 'Status', 'Lvl', 'Devs'))
+print("{:<15} {:>12} {:>10} {:<20} {:>5}".format(
+    'Name', 'Size', 'Strip', 'Status', 'Lvl'))
 for arr in arrays:
     name = arr.get('name', '')
     size = arr.get('size', '')
@@ -39,9 +39,8 @@ for arr in arrays:
     if isinstance(status, list):
         status = ' '.join(status)
     level = arr.get('level', '')
-    num = len(arr.get('devices', []))
-    print("{:<15} {:>12} {:>10} {:<20} {:>5} {:>7}".format(
-        name, size, strip, status, level, num))
+    print("{:<15} {:>12} {:>10} {:<20} {:>5}".format(
+        name, size, strip, status, level))
 EOF
             :
         else


### PR DESCRIPTION
## Summary
- omit the devices count when printing RAID array information in the post install menu

## Testing
- `bash -n post_install_menu.sh`
- `shellcheck post_install_menu.sh`

------
https://chatgpt.com/codex/tasks/task_e_6859b2aad9a483289fd616dde26e5d55