### PR TITLE
Update menu behavior

### DIFF
--- a/prepare_system.sh
+++ b/prepare_system.sh
@@ -4,12 +4,14 @@ set -e
 usage() {
     echo "Usage: $0 [-e]" >&2
     echo "  -e  Expert mode with full startup menu" >&2
+    echo "  -h  Show this help message" >&2
 }
 
 EXPERT=0
-while getopts "e" opt; do
+while getopts "eh" opt; do
     case $opt in
         e) EXPERT=1 ;;
+        h) usage; exit 0 ;;
         *) usage; exit 1 ;;
     esac
 done

--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -109,20 +109,7 @@ check_remove_xiraid() {
 }
 
 confirm_playbook() {
-    local playbook="${1:-$REPO_DIR/playbooks/site.yml}"
-    local roles role_list desc_file desc
-    roles=$(grep -E '^\s*- role:' "$playbook" | awk '{print $3}')
-    role_list=""
-    for r in $roles; do
-        desc_file="$REPO_DIR/collection/roles/${r}/README.md"
-        if [ -f "$desc_file" ]; then
-            desc=$(awk '/^#/ {next} /^[[:space:]]*$/ {if(found) exit; next} {if(found){printf " %s", $0} else {printf "%s", $0; found=1}} END{print ""}' "$desc_file")
-        else
-            desc="No description available"
-        fi
-        role_list="${role_list}\n - ${r}: ${desc}"
-    done
-    whiptail --yesno --scrolltext "Run Ansible playbook to configure the system?\n\nThis will execute the following roles:${role_list}" 20 70
+    whiptail --yesno "Run Ansible playbook to configure the system?" 8 60
 }
 
 apply_preset() {


### PR DESCRIPTION
## Summary
- skip role listing when confirming install in regular menu
- add `-h` help option in system prep script

## Testing
- `shellcheck simple_menu.sh prepare_system.sh`

------
https://chatgpt.com/codex/tasks/task_e_6859bbe85c6c8328971144f361168346