### PR TITLE
Fix mount options variable

### DIFF
--- a/collection/roles/raid_fs/tasks/create_fs.yml
+++ b/collection/roles/raid_fs/tasks/create_fs.yml
@@ -31,7 +31,7 @@
       {{ item.data_device | regex_replace('^/','') | replace('/', '-') }}.device
     mount_opts_with_wanted: >-
       {{ item.mount_opts | default('') }}{{ ',' if item.mount_opts else '' }}
-      x-systemd.wanted-by={{ mount_device }}
+      x-systemd.wanted-by={{ item.data_device | regex_replace('^/','') | replace('/', '-') }}.device
   tags: [raid_fs, fs]
 
 - name: Mount filesystem {{ item.label }} (and add to fstab)


### PR DESCRIPTION
## Summary
- fix mount options set_fact so mount_device is defined

## Testing
- `ansible-lint --version` *(fails: command not found)*
- `ansible-playbook playbooks/site.yml --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6a4d9c248328ae91caf3f9712028