### PR TITLE
Add udevadm settle after mkfs

### DIFF
--- a/collection/roles/raid_fs/tasks/create_fs.yml
+++ b/collection/roles/raid_fs/tasks/create_fs.yml
@@ -18,6 +18,11 @@
   when: blkid_type.stdout != 'xfs' or blkid_label.stdout != item.label
   tags: [raid_fs, fs, mkfs]
 
+- name: Wait for block devices to settle
+  ansible.builtin.command: udevadm settle
+  changed_when: false
+  tags: [raid_fs, fs, mkfs]
+
 - name: Create mountpoint {{ item.mountpoint }}
   ansible.builtin.file:
     path: "{{ item.mountpoint }}"


### PR DESCRIPTION
## Summary
- call `udevadm settle` after creating the filesystem

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check`
- `ansible-lint playbooks/site.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6dbf76e083288e761f17cdd975fb