### PR TITLE
Fix mount options for raid_fs

### DIFF
--- a/collection/roles/raid_fs/tasks/create_fs.yml
+++ b/collection/roles/raid_fs/tasks/create_fs.yml
@@ -34,16 +34,26 @@
   ansible.builtin.set_fact:
     mount_device: >-
       {{ item.data_device | regex_replace('^/','') | replace('/', '-') }}.device
+    mount_opts: "{{ item.mount_opts | default('') }}"
     mount_opts_with_wanted: >-
-      {{ item.mount_opts | default('') }}{{ ',' if item.mount_opts else '' }}
+      {{ mount_opts }}{{ ',' if mount_opts else '' }}
       x-systemd.wanted-by={{ item.data_device | regex_replace('^/','') | replace('/', '-') }}.device
   tags: [raid_fs, fs]
 
-- name: Mount filesystem {{ item.label }} (and add to fstab)
+- name: Mount filesystem {{ item.label }}
+  ansible.builtin.mount:
+    path: "{{ item.mountpoint }}"
+    src: "LABEL={{ item.label }}"
+    fstype: xfs
+    opts: "{{ mount_opts }}"
+    state: mounted
+  tags: [raid_fs, fs]
+
+- name: Ensure fstab entry for {{ item.label }} with systemd dependency
   ansible.builtin.mount:
     path: "{{ item.mountpoint }}"
     src: "LABEL={{ item.label }}"
     fstype: xfs
     opts: "{{ mount_opts_with_wanted }}"
-    state: mounted
+    state: present
   tags: [raid_fs, fs]


### PR DESCRIPTION
## Summary
- avoid using systemd-only options during the initial mount
- insert x-systemd option only in fstab entry

## Testing
- `ansible-lint -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7aae1e4c83288189e163b03bc69c