### PR TITLE
Fix mount options calculation in raid_fs

### DIFF
--- a/collection/roles/raid_fs/tasks/create_fs.yml
+++ b/collection/roles/raid_fs/tasks/create_fs.yml
@@ -35,9 +35,12 @@
     mount_device: >-
       {{ item.data_device | regex_replace('^/','') | replace('/', '-') }}.device
     mount_opts: "{{ item.mount_opts | default('') }}"
+  tags: [raid_fs, fs]
+
+- name: Build mount options with systemd dependency for {{ item.label }}
+  ansible.builtin.set_fact:
     mount_opts_with_wanted: >-
-      {{ mount_opts }}{{ ',' if mount_opts else '' }}
-      x-systemd.wanted-by={{ item.data_device | regex_replace('^/','') | replace('/', '-') }}.device
+      {{ mount_opts }}{{ ',' if mount_opts else '' }}x-systemd.wanted-by={{ item.data_device | regex_replace('^/','') | replace('/', '-') }}.device
   tags: [raid_fs, fs]
 
 - name: Mount filesystem {{ item.label }}


### PR DESCRIPTION
## Summary
- fix mount_opts computation in `raid_fs` role
- add a separate task to build mount options with systemd dependency

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_685a81395d308328891837b6c14eff37