### PR TITLE
Add spare pool info to raid display

### DIFF
--- a/post_install_menu.sh
+++ b/post_install_menu.sh
@@ -18,7 +18,9 @@ show_raid_info() {
             jq -r '.[] |
                 "RAID Name: \(.name)\n" +
                 "RAID Level: \(.level)\n" +
-                "Stripe Size: \(.strip_size_kb) KB\n" +
+                "Strip Size: \(.strip_size_kb) KB\n" +
+                "Spare Pool: \(.spare_pool // "-" )\n" +
+                "Size: \(.size // "-" )\n" +
                 "Volume: /dev/xi_\(.name)\n" +
                 ""' "$raw" >"$out"
         else


### PR DESCRIPTION
## Summary
- fix label to 'Strip Size'
- display spare pool in RAID info
- show array size in RAID info

## Testing
- `shellcheck post_install_menu.sh`
- `bash -n post_install_menu.sh`


------
https://chatgpt.com/codex/tasks/task_e_685a9677e3c88328bbb7f8e80d816e8b