### PR TITLE
Handle xiRAID repo file

### DIFF
--- a/collection/roles/xiraid_classic/README.md
+++ b/collection/roles/xiraid_classic/README.md
@@ -11,6 +11,7 @@ kernel module. The role accepts the xiRAID EULA automatically using
 * `xiraid_packages` – list of deb packages (defaults to `xiraid-core`).
 * `xiraid_auto_reboot` – reboot after install.
 * `xiraid_accept_eula` – automatically accept the xiRAID EULA (default: `true`).
+* Existing repository packages in `/tmp` are removed before download to ensure updates are installed.
 
 ## Example play snippet
 ```yaml

--- a/collection/roles/xiraid_classic/tasks/main.yml
+++ b/collection/roles/xiraid_classic/tasks/main.yml
@@ -11,6 +11,11 @@
     state: present
   tags: [xiraid, deps]
 
+- name: Remove any existing xiRAID repo package before download
+  ansible.builtin.file:
+    path: "/tmp/{{ xiraid_repo_pkg }}"
+    state: absent
+  tags: [xiraid, cleanup]
 
 - name: Download xiRAID repo package
   ansible.builtin.get_url:


### PR DESCRIPTION
## Summary
- ensure any cached xiRAID repo package is removed before download
- document the cleanup step in role README

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check`
- `ansible-lint collection/roles/xiraid_classic` *(fails: 13 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685b7247f7648328adfbc863983571b0