### PR TITLE
Fix spare pool name in RAID editor

### DIFF
--- a/configure_raid.sh
+++ b/configure_raid.sh
@@ -45,7 +45,8 @@ edit_spare_pool() {
     set -e
     [ $status -ne 0 ] && return
     tmp=$(mktemp)
-    NEW_LIST="$new" yq '.xiraid_spare_pools[0].devices = (env(NEW_LIST) | split(" "))' "$vars_file" > "$tmp"
+    # Ensure the spare pool has a name and update its device list
+    NEW_LIST="$new" yq '.xiraid_spare_pools[0].name //= "sp1" | .xiraid_spare_pools[0].devices = (env(NEW_LIST) | split(" "))' "$vars_file" > "$tmp"
     backup_if_changed "$vars_file" "$tmp"
     mv "$tmp" "$vars_file"
 }


### PR DESCRIPTION
## Summary
- ensure `configure_raid.sh` writes a spare pool name

## Testing
- `bash -n configure_raid.sh`
- `shellcheck configure_raid.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b75897b708328b860bdda58376a3b