### PR TITLE
Add drive clean step

### DIFF
--- a/collection/roles/raid_fs/README.md
+++ b/collection/roles/raid_fs/README.md
@@ -10,6 +10,10 @@ Creates xiRAID arrays and tuned XFS filesystems as per Xinnor NFS RDMA blog.
 This role requires the **mdadm** package to be installed so that any
 leftover Linux MD arrays on xiRAID devices can be stopped and wiped.
 
+All drives referenced by the array and spare pool definitions are
+cleaned using `xicli drive clean` before new pools or arrays are
+created.
+
 When mounting filesystems the role automatically appends an
 `x-systemd.wanted-by` option referencing the underlying block device so
 that the mount is handled by `systemd` at boot time. This follows the

--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -6,8 +6,20 @@
 
 - name: Build list of xiRAID devices
   ansible.builtin.set_fact:
-    xiraid_device_basenames: "{{ xiraid_arrays | map(attribute='devices') | flatten | map('basename') | list }}"
+    xiraid_device_paths: >-
+      {{
+        ((xiraid_arrays | map(attribute='devices') | flatten | list) +
+        (xiraid_spare_pools | default([]) | map(attribute='devices') | flatten | list))
+        | unique | list
+      }}
+    xiraid_device_basenames: "{{ xiraid_device_paths | map('basename') | list }}"
   tags: [raid_fs, raid]
+
+- name: Clean xiRAID drives
+  ansible.builtin.command: "xicli drive clean {{ item }}"
+  loop: "{{ xiraid_device_paths }}"
+  changed_when: false
+  tags: [raid_fs, raid, cleanup]
 
 - name: Ensure mdadm package present
   ansible.builtin.apt:


### PR DESCRIPTION
## Summary
- build unified device list for arrays and spare pools
- clean all xiRAID drives before creation
- document drive cleaning behavior

## Testing
- `ansible-lint -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b7c4b8188832886930916aa2e247b