### PR TITLE
Fix xiRAID vars when building device list

### DIFF
--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -4,7 +4,7 @@
   changed_when: false
   tags: [raid_fs, raid]
 
-- name: Build list of xiRAID devices
+- name: Build list of xiRAID device paths
   ansible.builtin.set_fact:
     xiraid_device_paths: >-
       {{
@@ -12,6 +12,10 @@
         (xiraid_spare_pools | default([]) | map(attribute='devices') | flatten | list))
         | unique | list
       }}
+  tags: [raid_fs, raid]
+
+- name: Build list of xiRAID device basenames
+  ansible.builtin.set_fact:
     xiraid_device_basenames: "{{ xiraid_device_paths | map('basename') | list }}"
   tags: [raid_fs, raid]
 


### PR DESCRIPTION
## Summary
- separate the build of xiRAID device paths and basenames

## Testing
- `ansible-lint playbooks/site.yml` *(fails: 52 failures, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685b7fd0edf08328afeb10884f7b5aa8