### PR TITLE
Use -d option for drive clean

### DIFF
--- a/collection/roles/raid_fs/README.md
+++ b/collection/roles/raid_fs/README.md
@@ -11,8 +11,8 @@ This role requires the **mdadm** package to be installed so that any
 leftover Linux MD arrays on xiRAID devices can be stopped and wiped.
 
 All drives referenced by the array and spare pool definitions are
-cleaned using `xicli drive clean` before new pools or arrays are
-created.
+cleaned using `xicli drive clean -d <device>` (or `--drives`) before
+new pools or arrays are created.
 
 When mounting filesystems the role automatically appends an
 `x-systemd.wanted-by` option referencing the underlying block device so

--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -20,7 +20,7 @@
   tags: [raid_fs, raid]
 
 - name: Clean xiRAID drives
-  ansible.builtin.command: "xicli drive clean {{ item }}"
+  ansible.builtin.command: "xicli drive clean -d {{ item }}"
   loop: "{{ xiraid_device_paths }}"
   changed_when: false
   tags: [raid_fs, raid, cleanup]


### PR DESCRIPTION
## Summary
- update the ansible role to pass `-d` to `xicli drive clean`
- document the required `-d/--drives` syntax

## Testing
- `shellcheck --version` *(fails: command not found)*
- `ansible-playbook --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8e3169c08328a8f9462b4bc40443