### PR TITLE
Rename raid presets

### DIFF
--- a/collection/roles/raid_fs/defaults/main.yml
+++ b/collection/roles/raid_fs/defaults/main.yml
@@ -18,7 +18,7 @@ xiraid_spare_pools: []
 # Default RAID arrays and filesystem definitions used by the xiNAS example
 # deployment. Modify these values directly rather than using group variables.
 xiraid_arrays:
-  - name: media6
+  - name: data
     level: 6
     strip_size_kb: 128
     devices:
@@ -34,7 +34,7 @@ xiraid_arrays:
       - /dev/nvme10n1
     parity_disks: 2
 
-  - name: media1
+  - name: log
     level: 1
     strip_size_kb: 16
     devices:
@@ -43,11 +43,11 @@ xiraid_arrays:
 
 xfs_filesystems:
   - label: nfsdata
-    data_device: "/dev/xi_media6"
-    log_device: "/dev/xi_media1"
+    data_device: "/dev/xi_data"
+    log_device: "/dev/xi_log"
     su_kb: 128
     sw: 8
     log_size: 1G
     sector_size: 4k
     mountpoint: /mnt/data
-    mount_opts: "logdev=/dev/xi_media1,noatime,nodiratime,logbsize=256k,largeio,inode64,swalloc,allocsize=131072k"
+    mount_opts: "logdev=/dev/xi_log,noatime,nodiratime,logbsize=256k,largeio,inode64,swalloc,allocsize=131072k"

--- a/configure_raid.sh
+++ b/configure_raid.sh
@@ -76,14 +76,20 @@ show_nvme_drives() {
 
 edit_devices() {
     local level="$1"
+    local label
+    case "$level" in
+        6) label="DATA" ;;
+        1) label="LOG" ;;
+        *) label="RAID${level}" ;;
+    esac
     local current new tmp status
     current="$(get_devices "$level")"
     if [ -z "$current" ]; then
-        whiptail --msgbox "No RAID${level} array defined" 8 60
+        whiptail --msgbox "No ${label} array defined" 8 60
         return
     fi
     set +e
-    new=$(whiptail --inputbox "Space-separated devices for RAID${level}" 10 70 "$current" 3>&1 1>&2 2>&3)
+    new=$(whiptail --inputbox "Space-separated devices for ${label}" 10 70 "$current" 3>&1 1>&2 2>&3)
     status=$?
     set -e
     [ $status -ne 0 ] && return
@@ -100,8 +106,8 @@ while true; do
     spare_devices=$(get_spare_devices)
     set +e
     menu=$(whiptail --title "RAID Configuration" --menu "Select array to edit:" 15 70 6 \
-        1 "RAID6: ${raid6_devices:-none}" \
-        2 "RAID1: ${raid1_devices:-none}" \
+        1 "DATA: ${raid6_devices:-none}" \
+        2 "LOG: ${raid1_devices:-none}" \
         3 "Spare: ${spare_devices:-none}" \
         4 "Back" 3>&1 1>&2 2>&3)
     status=$?

--- a/presets/default/raid_fs.yml
+++ b/presets/default/raid_fs.yml
@@ -11,7 +11,7 @@ xiraid_force_metadata: true
 # Default RAID arrays and filesystem definitions used by the xiNAS example
 # deployment. Modify these values directly rather than using group variables.
 xiraid_arrays:
-  - name: media6
+  - name: data
     level: 6
     strip_size_kb: 128
     devices:
@@ -27,7 +27,7 @@ xiraid_arrays:
       - /dev/nvme10n1
     parity_disks: 2
 
-  - name: media1
+  - name: log
     level: 1
     strip_size_kb: 16
     devices:
@@ -36,11 +36,11 @@ xiraid_arrays:
 
 xfs_filesystems:
   - label: nfsdata
-    data_device: "/dev/xi_media6"
-    log_device: "/dev/xi_media1"
+    data_device: "/dev/xi_data"
+    log_device: "/dev/xi_log"
     su_kb: 128
     sw: 8
     log_size: 1G
     sector_size: 4k
     mountpoint: /mnt/data
-    mount_opts: "logdev=/dev/xi_media1,noatime,nodiratime,logbsize=256k,largeio,inode64,swalloc,allocsize=131072k"
+    mount_opts: "logdev=/dev/xi_log,noatime,nodiratime,logbsize=256k,largeio,inode64,swalloc,allocsize=131072k"

--- a/presets/xinnorVM/raid_fs.yml
+++ b/presets/xinnorVM/raid_fs.yml
@@ -16,7 +16,7 @@ xiraid_spare_pools:
       - /dev/sdq
 
 xiraid_arrays:
-  - name: media6
+  - name: data
     level: 6
     strip_size_kb: 128
     spare_pool: sp1
@@ -35,7 +35,7 @@ xiraid_arrays:
       - /dev/sdp
     parity_disks: 2
 
-  - name: media1
+  - name: log
     level: 1
     strip_size_kb: 16
     devices:
@@ -44,11 +44,11 @@ xiraid_arrays:
 
 xfs_filesystems:
   - label: nfsdata
-    data_device: "/dev/xi_media6"
-    log_device: "/dev/xi_media1"
+    data_device: "/dev/xi_data"
+    log_device: "/dev/xi_log"
     su_kb: 128
     sw: 8
     log_size: 1G
     sector_size: 4k
     mountpoint: /mnt/data
-    mount_opts: "logdev=/dev/xi_media1,noatime,nodiratime,logbsize=256k,largeio,inode64,swalloc,allocsize=131072k"
+    mount_opts: "logdev=/dev/xi_log,noatime,nodiratime,logbsize=256k,largeio,inode64,swalloc,allocsize=131072k"


### PR DESCRIPTION
## Summary
- rename RAID6 preset to `DATA` and RAID1 preset to `LOG`
- update related device names
- show DATA/LOG labels in RAID configuration UI

## Testing
- `bash -n configure_raid.sh`

------
https://chatgpt.com/codex/tasks/task_e_685b9054b68083289b4aece29a98e8d1