### PR TITLE
Add force mkfs option

### DIFF
--- a/collection/roles/raid_fs/README.md
+++ b/collection/roles/raid_fs/README.md
@@ -6,6 +6,7 @@ Creates xiRAID arrays and tuned XFS filesystems as per Xinnor NFS RDMA blog.
 * `xfs_filesystems` – list defining data/log device pairs, mount point, mkfs params.
 * `xiraid_license_path` – path to license file applied before arrays are created.
 * `xiraid_force_metadata` – when `true` add `--force_metadata` to array creation.
+* `xfs_force_mkfs` – when `true` always run `mkfs.xfs` even if the filesystem and label already match.
 
 This role requires the **mdadm** package to be installed so that any
 leftover Linux MD arrays on xiRAID devices can be stopped and wiped.

--- a/collection/roles/raid_fs/defaults/main.yml
+++ b/collection/roles/raid_fs/defaults/main.yml
@@ -8,6 +8,9 @@ xiraid_license_path: "/tmp/license"
 # Set to `false` if metadata should not be overwritten
 xiraid_force_metadata: true
 
+# When true, always format XFS filesystems even if the label already exists
+xfs_force_mkfs: false
+
 # Spare pool definitions. A single pool example:
 # xiraid_spare_pools:
 #   - name: sp1

--- a/collection/roles/raid_fs/tasks/create_fs.yml
+++ b/collection/roles/raid_fs/tasks/create_fs.yml
@@ -15,7 +15,7 @@
     mkfs.xfs -f -L {{ item.label }} -d su={{ item.su_kb }}k,sw={{ item.sw }}
     -l logdev={{ item.log_device }},size={{ item.log_size }}
     -s size={{ item.sector_size }} {{ item.data_device }}
-  when: blkid_type.stdout != 'xfs' or blkid_label.stdout != item.label
+  when: xfs_force_mkfs | bool or blkid_type.stdout != 'xfs' or blkid_label.stdout != item.label
   tags: [raid_fs, fs, mkfs]
 
 - name: Wait for block devices to settle

--- a/presets/default/raid_fs.yml
+++ b/presets/default/raid_fs.yml
@@ -8,6 +8,9 @@ xiraid_license_path: "/tmp/license"
 # Set to `false` if metadata should not be overwritten
 xiraid_force_metadata: true
 
+# When true, always format XFS filesystems even if the label already exists
+xfs_force_mkfs: false
+
 # Default RAID arrays and filesystem definitions used by the xiNAS example
 # deployment. Modify these values directly rather than using group variables.
 xiraid_arrays:

--- a/presets/xinnorVM/raid_fs.yml
+++ b/presets/xinnorVM/raid_fs.yml
@@ -8,6 +8,9 @@ xiraid_license_path: "/tmp/license"
 # Set to `false` if metadata should not be overwritten
 xiraid_force_metadata: true
 
+# When true, always format XFS filesystems even if the label already exists
+xfs_force_mkfs: false
+
 # Default RAID arrays and filesystem definitions used by the xiNAS example
 # deployment. Modify these values directly rather than using group variables.
 xiraid_spare_pools:


### PR DESCRIPTION
## Summary
- add `xfs_force_mkfs` variable to force `mkfs.xfs`
- document new variable
- default to not force reformat in presets

## Testing
- `ansible-playbook --syntax-check playbooks/site.yml`

------
https://chatgpt.com/codex/tasks/task_e_685b9a5aa8a4832892666f1d18035124