### PR TITLE
Fix undefined xfs_force_mkfs

### DIFF
--- a/collection/roles/raid_fs/tasks/create_fs.yml
+++ b/collection/roles/raid_fs/tasks/create_fs.yml
@@ -15,7 +15,7 @@
     mkfs.xfs -f -L {{ item.label }} -d su={{ item.su_kb }}k,sw={{ item.sw }}
     -l logdev={{ item.log_device }},size={{ item.log_size }}
     -s size={{ item.sector_size }} {{ item.data_device }}
-  when: xfs_force_mkfs | bool or blkid_type.stdout != 'xfs' or blkid_label.stdout != item.label
+  when: (xfs_force_mkfs | default(false) | bool) or blkid_type.stdout != 'xfs' or blkid_label.stdout != item.label
   tags: [raid_fs, fs, mkfs]
 
 - name: Wait for block devices to settle


### PR DESCRIPTION
## Summary
- avoid undefined `xfs_force_mkfs` variable by providing a default in filesystem creation task

## Testing
- `ansible-playbook playbooks/site.yml -i inventories/lab.ini --syntax-check`
- `sudo apt-get install -y ansible`

------
https://chatgpt.com/codex/tasks/task_e_685b9cbc8c04832892659b2738c597ac