### PR TITLE
Force mkfs.xfs for raid_fs role

### DIFF
--- a/collection/roles/raid_fs/README.md
+++ b/collection/roles/raid_fs/README.md
@@ -6,7 +6,7 @@ Creates xiRAID arrays and tuned XFS filesystems as per Xinnor NFS RDMA blog.
 * `xfs_filesystems` – list defining data/log device pairs, mount point, mkfs params.
 * `xiraid_license_path` – path to license file applied before arrays are created.
 * `xiraid_force_metadata` – when `true` add `--force_metadata` to array creation.
-* `xfs_force_mkfs` – when `true` always run `mkfs.xfs` even if the filesystem and label already match.
+* `xfs_force_mkfs` – when `true` always run `mkfs.xfs` even if the filesystem and label already match. By default this is `true`, so filesystems are recreated on every run.
 
 This role requires the **mdadm** package to be installed so that any
 leftover Linux MD arrays on xiRAID devices can be stopped and wiped.

--- a/collection/roles/raid_fs/defaults/main.yml
+++ b/collection/roles/raid_fs/defaults/main.yml
@@ -9,7 +9,7 @@ xiraid_license_path: "/tmp/license"
 xiraid_force_metadata: true
 
 # When true, always format XFS filesystems even if the label already exists
-xfs_force_mkfs: false
+xfs_force_mkfs: true
 
 # Spare pool definitions. A single pool example:
 # xiraid_spare_pools:

--- a/presets/default/raid_fs.yml
+++ b/presets/default/raid_fs.yml
@@ -9,7 +9,7 @@ xiraid_license_path: "/tmp/license"
 xiraid_force_metadata: true
 
 # When true, always format XFS filesystems even if the label already exists
-xfs_force_mkfs: false
+xfs_force_mkfs: true
 
 # Default RAID arrays and filesystem definitions used by the xiNAS example
 # deployment. Modify these values directly rather than using group variables.

--- a/presets/xinnorVM/raid_fs.yml
+++ b/presets/xinnorVM/raid_fs.yml
@@ -9,7 +9,7 @@ xiraid_license_path: "/tmp/license"
 xiraid_force_metadata: true
 
 # When true, always format XFS filesystems even if the label already exists
-xfs_force_mkfs: false
+xfs_force_mkfs: true
 
 # Default RAID arrays and filesystem definitions used by the xiNAS example
 # deployment. Modify these values directly rather than using group variables.


### PR DESCRIPTION
## Summary
- always format XFS filesystems
- update presets to use the new default
- document default value in the raid_fs README

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_685bb011b398832881c7cf8d6db0685d