### PR TITLE
Add FS force option to inventory

### DIFF
--- a/inventories/lab.ini
+++ b/inventories/lab.ini
@@ -1,2 +1,2 @@
 [storage_nodes]
-localhost ansible_connection=local
+localhost ansible_connection=local xfs_force_mkfs=true


### PR DESCRIPTION
## Summary
- add `xfs_force_mkfs=true` in the lab inventory to recreate filesystems on every run

## Testing
- `ansible-playbook -i inventories/lab.ini playbooks/site.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_685bbb6d1e248328a025a934e462f9d9