### PR TITLE
Ensure spare pools connect to arrays

### DIFF
--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -118,6 +118,20 @@
   when: item.name not in ((existing_arrays | default([], true) | json_query('[].name')) | default([], true))
   tags: [raid_fs, raid]
 
+- name: Attach spare pools to existing arrays
+  ansible.builtin.command: >-
+    xicli raid modify --name {{ item.name }} -sp {{ item.spare_pool }}
+  register: raid_mod
+  changed_when: raid_mod.rc == 0
+  failed_when:
+    - raid_mod.rc != 0
+    - raid_mod.stderr is not search('already')
+  loop: "{{ xiraid_arrays }}"
+  loop_control:
+    loop_var: item
+  when: item.spare_pool is defined
+  tags: [raid_fs, raid]
+
 # ----------------------- Filesystem section -------------------
 - name: Ensure XFS utils present
   ansible.builtin.apt:


### PR DESCRIPTION
## Summary
- guarantee spare pools attach to arrays after creation

## Testing
- `ansible-lint` *(fails: Listing 91 violations)*
- `ansible-playbook playbooks/site.yml --syntax-check` *(fails: couldn't resolve module/community.general.timezone)*

------
https://chatgpt.com/codex/tasks/task_e_685bc5844f1c8328804a9aa00cdac819