### PR TITLE
Fix missing tags in create_array tasks

### DIFF
--- a/collection/roles/raid_fs/tasks/create_array.yml
+++ b/collection/roles/raid_fs/tasks/create_array.yml
@@ -1,10 +1,12 @@
 - name: Build device list string
   ansible.builtin.set_fact:
     _devlist: "{{ item.devices | join(' ') }}"
+  tags: [raid_fs, raid]
 
 - name: Calculate data disk count (for RAID5/6 stripe-width)
   ansible.builtin.set_fact:
     _sw: "{{ (item.devices | length) - (item.parity_disks | default(0)) }}"
+  tags: [raid_fs, raid]
 
 - name: Create array {{ item.name }}
   ansible.builtin.command: >-


### PR DESCRIPTION
## Summary
- ensure tasks that set `_devlist` and `_sw` run when tagged

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bcd6235988328ba6edce29a425a21