### PR TITLE
Add device dependencies to mount units

### DIFF
--- a/collection/roles/raid_fs/tasks/create_fs.yml
+++ b/collection/roles/raid_fs/tasks/create_fs.yml
@@ -34,6 +34,8 @@
   ansible.builtin.set_fact:
     block_device_unit: >-
       dev-{{ item.data_device | regex_replace('^/','') | replace('/', '-') }}.device
+    log_device_unit: >-
+      dev-{{ item.log_device | regex_replace('^/','') | replace('/', '-') }}.device
     unit_opts: >-
       {{ 'defaults' + (',' + item.mount_opts if (item.mount_opts | default('') | length > 0) else '') }}
     mount_unit: >-

--- a/collection/roles/raid_fs/templates/mount.unit.j2
+++ b/collection/roles/raid_fs/templates/mount.unit.j2
@@ -1,6 +1,7 @@
 [Unit]
-Description=Mount filesystem on xiRAID Classic
-DefaultDependencies=no
+Description=xiRAID Classic {{ item.mountpoint | regex_replace('^.*/', '') }}
+Requires={{ block_device_unit }} {{ log_device_unit }}
+After={{ block_device_unit }} {{ log_device_unit }}
 Before=umount.target
 Conflicts=umount.target
 
@@ -11,5 +12,4 @@ Options={{ unit_opts }}
 Type=xfs
 
 [Install]
-WantedBy=multi-user.target
-WantedBy={{ block_device_unit }}
+WantedBy=local-fs.target


### PR DESCRIPTION
## Summary
- include log device unit in mount unit dependency calculations
- add After/Requires entries to mount unit template
- use `local-fs.target` for mounting

## Testing
- `ansible-playbook playbooks/site.yml --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c03243dd48328ad738749eb73c360