### PR TITLE
Add systemd daemon reload before mount units start

### DIFF
--- a/collection/roles/raid_fs/tasks/create_fs.yml
+++ b/collection/roles/raid_fs/tasks/create_fs.yml
@@ -50,6 +50,9 @@
   notify: reload systemd
   tags: [raid_fs, fs]
 
+- name: Reload systemd before enabling mount unit
+  meta: flush_handlers
+
 - name: Enable and start mount unit for {{ item.label }}
   ansible.builtin.systemd:
     name: "{{ mount_unit }}"


### PR DESCRIPTION
## Summary
- ensure systemd daemon reload happens before enabling mount units

## Testing
- `ansible-playbook --syntax-check playbooks/site.yml`

------
https://chatgpt.com/codex/tasks/task_e_685c07e98e1883289f7598457506d890