### PR TITLE
Fix mount unit device names

### DIFF
--- a/collection/roles/raid_fs/tasks/create_fs.yml
+++ b/collection/roles/raid_fs/tasks/create_fs.yml
@@ -33,9 +33,9 @@
 - name: Compute mount unit parameters for {{ item.label }}
   ansible.builtin.set_fact:
     block_device_unit: >-
-      dev-{{ item.data_device | regex_replace('^/','') | replace('/', '-') }}.device
+      {{ item.data_device | regex_replace('^/','') | replace('/', '-') }}.device
     log_device_unit: >-
-      dev-{{ item.log_device | regex_replace('^/','') | replace('/', '-') }}.device
+      {{ item.log_device | regex_replace('^/','') | replace('/', '-') }}.device
     unit_opts: >-
       {{ 'defaults' + (',' + item.mount_opts if (item.mount_opts | default('') | length > 0) else '') }}
     mount_unit: >-


### PR DESCRIPTION
## Summary
- correct systemd device unit name construction for raid filesystems

## Testing
- `ansible-playbook -i inventories/lab.ini playbooks/site.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_685c0e1fbab48328addd95a0468ed48d