### PR TITLE
Fix strip size display in post-install menu

### DIFF
--- a/post_install_menu.sh
+++ b/post_install_menu.sh
@@ -18,7 +18,7 @@ show_raid_info() {
             jq -r '.[] |
                 "RAID Name: \(.name)\n" +
                 "RAID Level: \(.level)\n" +
-                "Strip Size: \(.strip_size_kb) KB\n" +
+                "Strip Size: \(.strip_size_kb // .strip_size) KB\n" +
                 "Spare Pool: \(.spare_pool // "-" )\n" +
                 "Size: \(.size // "-" )\n" +
                 "Volume: /dev/xi_\(.name)\n" +


### PR DESCRIPTION
## Summary
- fix jq field for strip size so arrays are shown correctly

## Testing
- `bash -n post_install_menu.sh`


------
https://chatgpt.com/codex/tasks/task_e_685c15ddd6c883289c3469270949e522