### PR TITLE
Replace Continue menu option with Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains scripts and Ansible playbooks used to provision xiNAS n
 1. Run `prepare_system.sh` on the target host (use the `-e` option for expert mode). Use `-u` to update the repository without launching any menus. This installs required packages including `yq` version 4, `whiptail`, and Ansible, then clones the repository.
    The script immediately launches a simplified start menu in default mode to enter the license and choose a preset. Use `-e` to access the full interactive menu with additional options such as updating the repository or saving the current configuration as a new preset.
 2. Execute `startup_menu.sh` separately if you need the complete configuration menu outside of the expert mode. Any presets you create in expert mode will also be available here and in the simplified menu. It also allows setting a custom hostname.
-3. To apply the configuration, choose **Continue** from the menu.
+3. To apply the configuration, choose **Install** from the menu.
    The playbook will run at that point, executing all configured roles. An **Exit** option is available if you want to leave without running the playbook.
 4. To configure an NFS client on another system, run `sudo ./client_setup.sh`. Root
    privileges are required to install packages, create the mount point and mount

--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -160,7 +160,7 @@ while true; do
     choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 15 70 6 \
         1 "Enter License" \
         2 "Presets" \
-        3 "Continue" \
+        3 "Install" \
         4 "Exit" \
         3>&1 1>&2 2>&3)
     case "$choice" in

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -137,7 +137,7 @@ configure_nfs_shares() {
         5 "Edit NFS Exports" \
         6 "Presets" \
         7 "Git Repository Configuration" \
-        8 "Continue" \
+        8 "Install" \
         9 "Exit" \
         3>&1 1>&2 2>&3)
         case "$choice" in
@@ -358,7 +358,7 @@ while true; do
         5 "Edit NFS Exports" \
         6 "Presets" \
         7 "Git Repository Configuration" \
-        8 "Continue" \
+        8 "Install" \
         9 "Exit" \
         3>&1 1>&2 2>&3)
     case "$choice" in


### PR DESCRIPTION
## Summary
- rename `Continue` to `Install` in start and expert menus
- update README instructions to match the new menu option

## Testing
- `bash -n simple_menu.sh`
- `bash -n startup_menu.sh`
- `bash -n post_install_menu.sh`


------
https://chatgpt.com/codex/tasks/task_e_685c1a7a93988328891ec807aea2a173