### PR TITLE
Update default NFS share path

### DIFF
--- a/client_repo/client_setup.sh
+++ b/client_repo/client_setup.sh
@@ -87,7 +87,7 @@ main() {
         proto=$(select_protocol "RDMA")
         proto=${proto^^}
         server_ip=$(ask_input "Server IP address" "10.239.239.100")
-        share=$(ask_input "NFS share" "/mnt/data")
+        share=$(ask_input "NFS share" "/")
         mount_point=$(ask_input "Local mount point" "/mnt/nfs")
 
         mkdir -p "$mount_point"

--- a/client_setup.sh
+++ b/client_setup.sh
@@ -87,7 +87,7 @@ main() {
         proto=$(select_protocol "RDMA")
         proto=${proto^^}
         server_ip=$(ask_input "Server IP address" "10.239.239.100")
-        share=$(ask_input "NFS share" "/mnt/data")
+        share=$(ask_input "NFS share" "/")
         mount_point=$(ask_input "Local mount point" "/mnt/nfs")
 
         mkdir -p "$mount_point"


### PR DESCRIPTION
## Summary
- set `/` as the default NFS share in client setup scripts

## Testing
- `bash -n client_setup.sh`
- `bash -n client_repo/client_setup.sh`
- `shellcheck client_setup.sh client_repo/client_setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68628c34f3c48328b4b9dcd030392a89