### PR TITLE
Install linux-tools-common for cpupower

### DIFF
--- a/collection/roles/perf_tuning/README.md
+++ b/collection/roles/perf_tuning/README.md
@@ -16,7 +16,8 @@ recommended in Xinnor blogs (2023-2025) and NVIDIA ConnectX-7 (400 Gbit) docs.
 ## Variables
 See `defaults/main.yml` for the full list; most tuning knobs can be disabled or
 altered via inventory variables. Notably, set `perf_disable_cpupower: true` to
-skip adjusting the CPU frequency governor.
+skip adjusting the CPU frequency governor. The `cpupower` tool is provided by
+the `linux-tools-common` package, which the role installs automatically.
 
 ## Example
 ```yaml

--- a/collection/roles/perf_tuning/tasks/main.yml
+++ b/collection/roles/perf_tuning/tasks/main.yml
@@ -6,6 +6,7 @@
   ansible.builtin.apt:
     name:
       - cpufrequtils
+      - linux-tools-common
       - tuned
     state: present
   tags: [packages]


### PR DESCRIPTION
## Summary
- ensure cpupower is available by installing linux-tools-common
- document cpupower package requirement in perf_tuning README

## Testing
- `apt-file search bin/cpupower | head`


------
https://chatgpt.com/codex/tasks/task_e_6863ec6fe57c8328bf7121c4ce30ff91