### PR TITLE
Install Ansible when running DOCA playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ This repository contains scripts and Ansible playbooks used to provision xiNAS n
    privileges are required to install packages, create the mount point and mount
    the exported share. If you only need the client pieces, copy the contents of
    the `client_repo` directory into a separate repository and run the script
-   from there.
+   from there. If you choose to install DOCA OFED using the provided playbook,
+   the script will automatically install Ansible packages when needed.
 
 The `prepare_system.sh` script installs dependencies required by the interactive helper scripts. The helper scripts rely on the [`mikefarah/yq`](https://github.com/mikefarah/yq) binary (v4+). If you encounter errors such as `jq: error: env/1 is not defined`, make sure this version of `yq` is installed by re-running `prepare_system.sh` or installing it manually.
 Earlier versions of the RAID configuration script failed with `'//' expects 2 args but there is 1` when no spare pool existed. The script now creates the pool automatically the first time you enter devices.

--- a/client_repo/README.md
+++ b/client_repo/README.md
@@ -13,7 +13,9 @@ Included files:
 - `ansible.cfg` – minimal Ansible configuration
 
 To use this directory as a separate repo, copy it to a new Git repository and run
-`client_setup.sh` with root privileges on the client machine:
+`client_setup.sh` with root privileges on the client machine. If you elect to
+install DOCA OFED via the included playbook, the script will install the required
+Ansible packages automatically:
 
 ```bash
 sudo ./client_setup.sh

--- a/client_repo/client_setup.sh
+++ b/client_repo/client_setup.sh
@@ -57,6 +57,19 @@ select_protocol() {
 run_playbook() {
     local pb="$1" log
     log=$(mktemp)
+
+    if ! command -v ansible-playbook >/dev/null 2>&1; then
+        if command -v apt-get >/dev/null 2>&1; then
+            apt-get update -y
+            apt-get install -y ansible
+        elif command -v yum >/dev/null 2>&1; then
+            yum install -y ansible
+        else
+            echo "Ansible not found and automatic installation is unsupported." >&2
+            return 1
+        fi
+    fi
+
     if [ -n "$WHIPTAIL" ]; then
         whiptail --title "Ansible" --infobox "Running $pb" 8 60
     fi

--- a/client_setup.sh
+++ b/client_setup.sh
@@ -57,6 +57,19 @@ select_protocol() {
 run_playbook() {
     local pb="$1" log
     log=$(mktemp)
+
+    if ! command -v ansible-playbook >/dev/null 2>&1; then
+        if command -v apt-get >/dev/null 2>&1; then
+            apt-get update -y
+            apt-get install -y ansible
+        elif command -v yum >/dev/null 2>&1; then
+            yum install -y ansible
+        else
+            echo "Ansible not found and automatic installation is unsupported." >&2
+            return 1
+        fi
+    fi
+
     if [ -n "$WHIPTAIL" ]; then
         whiptail --title "Ansible" --infobox "Running $pb" 8 60
     fi


### PR DESCRIPTION
## Summary
- ensure `client_setup.sh` installs Ansible before running the optional DOCA playbook
- apply the same change to the standalone `client_repo` copy
- note automatic Ansible installation in documentation

## Testing
- `git diff --check`

------
https://chatgpt.com/codex/tasks/task_e_686404b760e48328897cba5019fd7a22