### PR TITLE
Add Collect Data feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains scripts and Ansible playbooks used to provision xiNAS n
 
 1. Run `prepare_system.sh` on the target host (use the `-e` option for expert mode). Use `-u` to update the repository without launching any menus. This installs required packages including `yq` version 4, `whiptail`, and Ansible, then clones the repository.
    The script immediately launches a simplified start menu in default mode to enter the license and choose a preset. Use `-e` to access the full interactive menu with additional options such as updating the repository or saving the current configuration as a new preset.
+   Both menus now include a **Collect Data** option for gathering system information into a tar archive and uploading it to xiNNOR's SharePoint.
 2. Execute `startup_menu.sh` separately if you need the complete configuration menu outside of the expert mode. Any presets you create in expert mode will also be available here and in the simplified menu. It also allows setting a custom hostname.
 3. To apply the configuration, choose **Install** from the menu.
    The playbook will run at that point, executing all configured roles. An **Exit** option is available if you want to leave without running the playbook.

--- a/collect_data.sh
+++ b/collect_data.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Collect system data and upload to SharePoint
+set -euo pipefail
+
+WHIPTAIL=$(command -v whiptail || true)
+
+ask_input() {
+    local prompt="$1" default="$2" result
+    if [ -n "$WHIPTAIL" ]; then
+        result=$(whiptail --inputbox "$prompt" 8 60 "$default" 3>&1 1>&2 2>&3) || return 1
+        echo "$result"
+    else
+        read -rp "$prompt [$default]: " result
+        echo "${result:-$default}"
+    fi
+}
+
+main() {
+    local cfg email tmp archive
+    cfg=$(ask_input "Enter config name" "config") || exit 1
+    email=$(ask_input "Enter your email" "user@example.com") || exit 1
+    tmp=$(mktemp -d)
+
+    echo "Config name: $cfg" > "$tmp/info.txt"
+    echo "Email: $email" >> "$tmp/info.txt"
+
+    lsblk -o NAME,SIZE,TYPE,MOUNTPOINT > "$tmp/lsblk.txt"
+    cat /proc/mdstat > "$tmp/mdstat.txt" 2>/dev/null || true
+    pvs > "$tmp/pvs.txt" 2>&1 || true
+    nvme list > "$tmp/nvme_list.txt" 2>&1 || true
+    lspci > "$tmp/lspci.txt" 2>&1 || true
+    [ -x ./hwkey ] || chmod +x ./hwkey
+    ./hwkey > "$tmp/hwkey.txt" 2>&1 || true
+
+    # NUMA node for each disk
+    for dev in $(lsblk -ndo NAME,TYPE | awk '$2=="disk"{print $1}'); do
+        node_file="/sys/block/$dev/device/numa_node"
+        if [ -f "$node_file" ]; then
+            echo "$dev $(cat "$node_file")" >> "$tmp/numa_nodes.txt"
+        else
+            echo "$dev unknown" >> "$tmp/numa_nodes.txt"
+        fi
+    done
+
+    archive="${cfg}.tgz"
+    tar czf "$archive" -C "$tmp" .
+
+    # Attempt upload
+    curl -T "$archive" "https://xinnor.sharepoint.com/:f:/s/XiStorage/Er7lQJlm58hJh5wjoYirZ7gBlq9Z2lyvIcBSyd8plqlL7Q?e=vgzKKM" || true
+
+    rm -rf "$tmp"
+    echo "Archive created: $archive"
+}
+
+main "$@"

--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -157,16 +157,18 @@ choose_preset() {
 }
 
 while true; do
-    choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 15 70 6 \
-        1 "Enter License" \
-        2 "Presets" \
-        3 "Install" \
-        4 "Exit" \
+    choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 15 70 7 \
+        1 "Collect Data" \
+        2 "Enter License" \
+        3 "Presets" \
+        4 "Install" \
+        5 "Exit" \
         3>&1 1>&2 2>&3)
     case "$choice" in
-        1) enter_license ;;
-        2) choose_preset ;;
-        3)
+        1) ./collect_data.sh ;;
+        2) enter_license ;;
+        3) choose_preset ;;
+        4)
             if check_license && check_remove_xiraid && confirm_playbook "playbooks/site.yml"; then
                 run_playbook "playbooks/site.yml" "inventories/lab.ini"
                 chmod +x post_install_menu.sh
@@ -174,6 +176,6 @@ while true; do
                 exit 0
             fi
             ;;
-        4) exit 2 ;;
+        5) exit 2 ;;
     esac
 done

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -350,26 +350,28 @@ save_preset() {
 
 # Main menu loop
 while true; do
-    choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 20 70 16 \
-        1 "Enter License" \
-        2 "Configure Network" \
-        3 "Set Hostname" \
-        4 "Configure RAID" \
-        5 "Edit NFS Exports" \
-        6 "Presets" \
-        7 "Git Repository Configuration" \
-        8 "Install" \
-        9 "Exit" \
+    choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 20 70 17 \
+        1 "Collect Data" \
+        2 "Enter License" \
+        3 "Configure Network" \
+        4 "Set Hostname" \
+        5 "Configure RAID" \
+        6 "Edit NFS Exports" \
+        7 "Presets" \
+        8 "Git Repository Configuration" \
+        9 "Install" \
+        10 "Exit" \
         3>&1 1>&2 2>&3)
     case "$choice" in
-        1) enter_license ;;
-        2) configure_network ;;
-        3) configure_hostname ;;
-        4) configure_raid ;;
-        5) edit_nfs_exports ;;
-        6) choose_preset ;;
-        7) configure_git_repo ;;
-        8)
+        1) ./collect_data.sh ;;
+        2) enter_license ;;
+        3) configure_network ;;
+        4) configure_hostname ;;
+        5) configure_raid ;;
+        6) edit_nfs_exports ;;
+        7) choose_preset ;;
+        8) configure_git_repo ;;
+        9)
             if check_license && check_remove_xiraid && confirm_playbook "playbooks/site.yml"; then
                 run_playbook "playbooks/site.yml"
                 chmod +x post_install_menu.sh
@@ -377,7 +379,7 @@ while true; do
                 exit 0
             fi
             ;;
-        9) exit 2 ;;
+        10) exit 2 ;;
     esac
 done
 


### PR DESCRIPTION
## Summary
- add `collect_data.sh` script to gather system details into a TGZ and attempt SharePoint upload
- expose **Collect Data** as the first entry in both interactive menus
- mention the new option in the README

## Testing
- `bash -n collect_data.sh`
- `bash -n simple_menu.sh`
- `bash -n startup_menu.sh`


------
https://chatgpt.com/codex/tasks/task_e_6864f97f0ab48328a7e6090c0e16d0a9