### PR TITLE
Add non-interactive rclone upload option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ This repository contains scripts and Ansible playbooks used to provision xiNAS n
 
 1. Run `prepare_system.sh` on the target host (use the `-e` option for expert mode). Use `-u` to update the repository without launching any menus. This installs required packages including `yq` version 4, `whiptail`, and Ansible, then clones the repository.
    The script immediately launches a simplified start menu in default mode to enter the license and choose a preset. Use `-e` to access the full interactive menu with additional options such as updating the repository or saving the current configuration as a new preset.
-   Both menus now include a **Collect Data** option for gathering system information into a tar archive and uploading it via `rclone` to xiNNOR's SharePoint. The script installs `rclone` automatically if needed and will prompt for remote configuration on the first run.
+   Both menus now include a **Collect Data** option for gathering system information into a tar archive and uploading it via `rclone` to xiNNOR's SharePoint. The script installs `rclone` automatically if needed and will prompt for remote configuration on the first run. You can specify the destination non-interactively using the `--dest` option or the `RCLONE_DEST` environment variable.
+
+   Example:
+   ```bash
+   export RCLONE_DEST="sharepoint:/sites/XiStorage/Shared Documents/Logs"
+   ./collect_data.sh --dest "$RCLONE_DEST"
+   ```
 2. Execute `startup_menu.sh` separately if you need the complete configuration menu outside of the expert mode. Any presets you create in expert mode will also be available here and in the simplified menu. It also allows setting a custom hostname.
 3. To apply the configuration, choose **Install** from the menu.
    The playbook will run at that point, executing all configured roles. An **Exit** option is available if you want to leave without running the playbook.

--- a/collect_data.sh
+++ b/collect_data.sh
@@ -16,7 +16,29 @@ ask_input() {
 }
 
 main() {
-    local cfg email tmp archive
+    local cfg email tmp archive dest_arg dest
+
+    dest_arg=${RCLONE_DEST:-}
+    while [ $# -gt 0 ]; do
+        case $1 in
+            --dest)
+                [ $# -gt 1 ] || { echo "Missing argument for --dest" >&2; return 1; }
+                dest_arg=$2
+                shift 2
+                continue
+                ;;
+            -h|--help)
+                echo "Usage: $0 [--dest remote:path]" >&2
+                return 0
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                echo "Usage: $0 [--dest remote:path]" >&2
+                return 1
+                ;;
+        esac
+    done
+
     cfg=$(ask_input "Enter config name" "config") || exit 1
     email=$(ask_input "Enter your email" "user@example.com") || exit 1
     tmp=$(mktemp -d)
@@ -57,7 +79,8 @@ main() {
         fi
     fi
 
-    dest=$(ask_input "rclone destination (remote:path)" "sharepoint:") || exit 1
+    dest=${dest_arg:-$(ask_input "rclone destination (remote:path)" "sharepoint:")}
+    [ -n "$dest" ] || exit 1
     remote_name=${dest%%:*}:
     if ! rclone listremotes | grep -qx "$remote_name"; then
         echo "rclone remote $remote_name not found. Launching rclone config..." >&2


### PR DESCRIPTION
## Summary
- add `--dest` option in `collect_data.sh` so uploads can run non-interactively
- document using `RCLONE_DEST` in README

## Testing
- `bash -n collect_data.sh`
- `./collect_data.sh --help`

------
https://chatgpt.com/codex/tasks/task_e_686514de52848328b14d7b52f37f2422