### PR TITLE
Use fixed transfer server and temp archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ This repository contains scripts and Ansible playbooks used to provision xiNAS n
 
 1. Run `prepare_system.sh` on the target host (use the `-e` option for expert mode). Use `-u` to update the repository without launching any menus. This installs required packages including `yq` version 4, `whiptail`, and Ansible, then clones the repository.
    The script immediately launches a simplified start menu in default mode to enter the license and choose a preset. Use `-e` to access the full interactive menu with additional options such as updating the repository or saving the current configuration as a new preset.
-   Both menus now include a **Collect Data** option for gathering system information into a tar archive and uploading it via `transfer.sh`. You can specify the server URL non-interactively using the `--server` option or the `TRANSFER_SERVER` environment variable.
+   Both menus now include a **Collect Data** option for gathering system information into a tar archive and uploading it via `transfer.sh`. The upload server is configured automatically and listens on port 8080. You can override it by setting the `TRANSFER_SERVER` environment variable if needed.
 
    Example:
    ```bash
-   export TRANSFER_SERVER="https://178.253.23.152"
-   ./collect_data.sh --server "$TRANSFER_SERVER"
+   export TRANSFER_SERVER="https://178.253.23.152:8080"
+   ./collect_data.sh
    ```
 2. Execute `startup_menu.sh` separately if you need the complete configuration menu outside of the expert mode. Any presets you create in expert mode will also be available here and in the simplified menu. It also allows setting a custom hostname.
 3. To apply the configuration, choose **Install** from the menu.

--- a/collect_data.sh
+++ b/collect_data.sh
@@ -16,24 +16,17 @@ ask_input() {
 }
 
 main() {
-    local cfg email tmp archive server_arg server
+    local cfg email tmp archive server
 
-    server_arg=${TRANSFER_SERVER:-}
     while [ $# -gt 0 ]; do
         case $1 in
-            --server)
-                [ $# -gt 1 ] || { echo "Missing argument for --server" >&2; return 1; }
-                server_arg=$2
-                shift 2
-                continue
-                ;;
             -h|--help)
-                echo "Usage: $0 [--server url]" >&2
+                echo "Usage: $0" >&2
                 return 0
                 ;;
             *)
                 echo "Unknown option: $1" >&2
-                echo "Usage: $0 [--server url]" >&2
+                echo "Usage: $0" >&2
                 return 1
                 ;;
         esac
@@ -64,13 +57,12 @@ main() {
         fi
     done
 
-    archive="${cfg}.tgz"
+    archive="/tmp/${cfg}.tgz"
     tar czf "$archive" -C "$tmp" .
 
-    server=${server_arg:-$(ask_input "transfer.sh server" "https://178.253.23.152")}
-    [ -n "$server" ] || exit 1
+    server=${TRANSFER_SERVER:-"https://178.253.23.152:8080"}
 
-    if ! curl --fail --upload-file "$archive" "$server/$archive"; then
+    if ! curl --fail --upload-file "$archive" "$server/$(basename "$archive")"; then
         echo "Warning: transfer.sh upload failed" >&2
     fi
 


### PR DESCRIPTION
## Summary
- keep generated archives in `/tmp`
- remove server prompt and default to a fixed server on port 8080
- document new transfer server configuration

## Testing
- `bash -n collect_data.sh`


------
https://chatgpt.com/codex/tasks/task_e_68652d4a8be08328aa33af5afa78ceaa