### PR TITLE
Use HTTP for transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains scripts and Ansible playbooks used to provision xiNAS n
 
    Example:
    ```bash
-   export TRANSFER_SERVER="https://178.253.23.152:8080"
+   export TRANSFER_SERVER="http://178.253.23.152:8080"
    ./collect_data.sh
    ```
 2. Execute `startup_menu.sh` separately if you need the complete configuration menu outside of the expert mode. Any presets you create in expert mode will also be available here and in the simplified menu. It also allows setting a custom hostname.

--- a/collect_data.sh
+++ b/collect_data.sh
@@ -60,7 +60,7 @@ main() {
     archive="/tmp/${cfg}.tgz"
     tar czf "$archive" -C "$tmp" .
 
-    server=${TRANSFER_SERVER:-"https://178.253.23.152:8080"}
+    server=${TRANSFER_SERVER:-"http://178.253.23.152:8080"}
 
     if ! curl --fail --upload-file "$archive" "$server/$(basename "$archive")"; then
         echo "Warning: transfer.sh upload failed" >&2


### PR DESCRIPTION
## Summary
- update the default upload server URL to use `http`
- document the HTTP URL in the README example

## Testing
- `bash -n collect_data.sh`

------
https://chatgpt.com/codex/tasks/task_e_686530be5f588328b9699f5b4ae47c21