### PR TITLE
Improve xiRAID 4.3 installation automation

### DIFF
--- a/collection/roles/xiraid_classic/tasks/main.yml
+++ b/collection/roles/xiraid_classic/tasks/main.yml
@@ -9,6 +9,8 @@
   ansible.builtin.apt:
     name: "linux-headers-{{ ansible_kernel }}"
     state: present
+    update_cache: true
+    cache_valid_time: 3600
   tags: [xiraid, deps]
 
 - name: Remove any existing xiRAID repo package before download
@@ -37,13 +39,15 @@
 - name: Update apt cache
   ansible.builtin.apt:
     update_cache: true
+    cache_valid_time: 3600
   tags: [xiraid, install]
 
-- name: Install xiRAID core package
-  ansible.builtin.command:
-    cmd: "apt-get install --reinstall -y {{ xiraid_packages | join(' ') }}"
+- name: Ensure xiRAID packages are installed
+  ansible.builtin.apt:
+    name: "{{ item }}"
+    state: present
+  loop: "{{ xiraid_packages }}"
   register: xiraid_pkgs
-  changed_when: false
   tags: [xiraid, install]
 
 - name: Accept xiRAID EULA


### PR DESCRIPTION
## Summary
- refresh the xiRAID Classic role to cache apt metadata while installing kernel headers and repository packages
- replace the shell-based xiRAID package install with the apt module to follow the documented 4.3 workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e64dc0bbd88328b8b42969a866d744