### PR TITLE
Ensure NFS RDMA DKMS module is installed

### DIFF
--- a/collection/roles/doca_ofed/defaults/main.yml
+++ b/collection/roles/doca_ofed/defaults/main.yml
@@ -6,6 +6,7 @@ doca_repo_component: "{{ doca_version }}/{{ doca_distro_series }}/x86_64"
 doca_pkgs:
   - doca-ofed          # DKMS-driven kernel stack
   - doca-ofed-userspace
+  - mlnx-nfsrdma-dkms  # Kernel module required for NFS over RDMA
 
 doca_ofed_auto_reboot: false
 


### PR DESCRIPTION
## Summary
- ensure the doca_ofed role installs the `mlnx-nfsrdma-dkms` package so NFS over RDMA works out of the box

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f4c01ebf88832887311ad2097b4980