### PR TITLE
chore(api): run biome format across xiNAS-MCP tree

### DIFF
--- a/xiNAS-MCP/src/__tests__/api/errors.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/errors.test.ts
@@ -23,7 +23,12 @@ describe('errors', () => {
   });
 
   it('makeError accepts a remediation hint', () => {
-    const err = makeError('INTERNAL', 'audit write failed', undefined, 'check disk space on /var/log');
+    const err = makeError(
+      'INTERNAL',
+      'audit write failed',
+      undefined,
+      'check disk space on /var/log',
+    );
     expect(err.remediation).toBe('check disk space on /var/log');
   });
 });

--- a/xiNAS-MCP/src/__tests__/api/integration.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/integration.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
-import { buildTestApp, ADMIN_TOKEN, seedCluster, seedNode, seedShare, seedNfsProfile } from './_helpers.js';
+import {
+  buildTestApp,
+  ADMIN_TOKEN,
+  seedCluster,
+  seedNode,
+  seedShare,
+  seedNfsProfile,
+} from './_helpers.js';
 
 /**
  * All 30 GET operations from api-v1.yaml. Each entry: [path, expectedStatus].
@@ -74,28 +81,41 @@ describe('GET integration — envelope shape per endpoint', () => {
     seedShare(setup.state, 's1');
     seedNfsProfile(setup.state);
     setup.state.kv.put('/xinas/v1/observed/XiraidArray/seeded-array', {
-      kind: 'XiraidArray', id: 'seeded-array',
+      kind: 'XiraidArray',
+      id: 'seeded-array',
       spec: { name: 'seeded-array', level: 'raid5', member_disk_ids: [] },
       status: { state: 'optimal', volume_path: '/dev/x', usable_capacity_bytes: 0 },
     });
     setup.state.kv.put('/xinas/v1/observed/Filesystem/seeded-fs', {
-      kind: 'Filesystem', id: 'seeded-fs',
+      kind: 'Filesystem',
+      id: 'seeded-fs',
       spec: { fs_type: 'xfs', backing_device: '/dev/x', mountpoint: '/srv/fs' },
       status: { mounted: true, uuid: 'u', size_bytes: 1, free_bytes: 1 },
     });
     setup.state.kv.put('/xinas/v1/observed/NetworkInterface/seeded-if', {
-      kind: 'NetworkInterface', id: 'seeded-if',
+      kind: 'NetworkInterface',
+      id: 'seeded-if',
       spec: { managed_by_xinas: true },
       status: { driver: 'mlx5_ib', rdma_capable: true, link_state: 'up', current_addresses: [] },
     });
     setup.state.kv.put('/xinas/v1/tasks/01902f25-7c54-7c10-b1f0-aaaabbbbcccc', {
       task_id: '01902f25-7c54-7c10-b1f0-aaaabbbbcccc',
-      kind: 'k', state: 'running', principal: 'admin:test', client_type: 'rest',
-      request_id: 'r', correlation_id: 'c', input_hash: 'h', risk_level: 'non_disruptive',
-      affected_resources: [], created_at: '2026-05-27T11:00:00Z', updated_at: '2026-05-27T11:00:00Z',
+      kind: 'k',
+      state: 'running',
+      principal: 'admin:test',
+      client_type: 'rest',
+      request_id: 'r',
+      correlation_id: 'c',
+      input_hash: 'h',
+      risk_level: 'non_disruptive',
+      affected_resources: [],
+      created_at: '2026-05-27T11:00:00Z',
+      updated_at: '2026-05-27T11:00:00Z',
     });
   });
-  afterEach(async () => { await setup.cleanup(); });
+  afterEach(async () => {
+    await setup.cleanup();
+  });
 
   for (const [path, expectedStatus] of GET_OPS) {
     it(`${path} returns ${expectedStatus} with an Envelope-shaped response`, async () => {

--- a/xiNAS-MCP/src/__tests__/api/mutating.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/mutating.test.ts
@@ -21,18 +21,23 @@ const MUTATING_PATHS: Array<[string, string]> = [
 
 describe('mutating endpoints', () => {
   let setup: Awaited<ReturnType<typeof buildTestApp>>;
-  beforeEach(async () => { setup = await buildTestApp(); });
-  afterEach(async () => { await setup.cleanup(); });
+  beforeEach(async () => {
+    setup = await buildTestApp();
+  });
+  afterEach(async () => {
+    await setup.cleanup();
+  });
 
   for (const [method, path] of MUTATING_PATHS) {
     it(`${method} ${path} returns INTERNAL/EXECUTOR_UNAVAILABLE`, async () => {
-      const req = method === 'POST'
-        ? request(setup.app).post(path)
-        : method === 'PATCH'
-        ? request(setup.app).patch(path)
-        : method === 'PUT'
-        ? request(setup.app).put(path)
-        : request(setup.app).delete(path);
+      const req =
+        method === 'POST'
+          ? request(setup.app).post(path)
+          : method === 'PATCH'
+            ? request(setup.app).patch(path)
+            : method === 'PUT'
+              ? request(setup.app).put(path)
+              : request(setup.app).delete(path);
       const res = await req
         .set('Authorization', ADMIN_TOKEN)
         .set('Content-Type', 'application/json')

--- a/xiNAS-MCP/src/__tests__/api/query-contracts.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/query-contracts.test.ts
@@ -4,17 +4,25 @@ import { buildTestApp, ADMIN_TOKEN } from './_helpers.js';
 
 describe('query contract: /health?profile', () => {
   let setup: Awaited<ReturnType<typeof buildTestApp>>;
-  beforeEach(async () => { setup = await buildTestApp(); });
-  afterEach(async () => { await setup.cleanup(); });
+  beforeEach(async () => {
+    setup = await buildTestApp();
+  });
+  afterEach(async () => {
+    await setup.cleanup();
+  });
 
   it.each(['quick', 'standard', 'deep'])('accepts profile=%s', async (p) => {
-    const res = await request(setup.app).get(`/api/v1/health?profile=${p}`).set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get(`/api/v1/health?profile=${p}`)
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(200);
     expect(res.body.result.profile).toBe(p);
   });
 
   it('rejects an unknown profile with INVALID_ARGUMENT/400', async () => {
-    const res = await request(setup.app).get('/api/v1/health?profile=bogus').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/health?profile=bogus')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(400);
     expect(res.body.errors?.[0]?.code).toBe('INVALID_ARGUMENT');
   });
@@ -25,15 +33,31 @@ describe('query contract: /disks?safe_for_use', () => {
   beforeEach(async () => {
     setup = await buildTestApp();
     setup.state.kv.put('/xinas/v1/observed/Disk/safe1', {
-      kind: 'Disk', id: 'safe1',
-      status: { device_path: '/dev/nvme0n1', serial: 's1', model: 'm', capacity_bytes: 1, safe_for_use: true },
+      kind: 'Disk',
+      id: 'safe1',
+      status: {
+        device_path: '/dev/nvme0n1',
+        serial: 's1',
+        model: 'm',
+        capacity_bytes: 1,
+        safe_for_use: true,
+      },
     });
     setup.state.kv.put('/xinas/v1/observed/Disk/unsafe1', {
-      kind: 'Disk', id: 'unsafe1',
-      status: { device_path: '/dev/nvme1n1', serial: 's2', model: 'm', capacity_bytes: 1, safe_for_use: false },
+      kind: 'Disk',
+      id: 'unsafe1',
+      status: {
+        device_path: '/dev/nvme1n1',
+        serial: 's2',
+        model: 'm',
+        capacity_bytes: 1,
+        safe_for_use: false,
+      },
     });
   });
-  afterEach(async () => { await setup.cleanup(); });
+  afterEach(async () => {
+    await setup.cleanup();
+  });
 
   it('no filter → returns all disks', async () => {
     const res = await request(setup.app).get('/api/v1/disks').set('Authorization', ADMIN_TOKEN);
@@ -41,19 +65,25 @@ describe('query contract: /disks?safe_for_use', () => {
   });
 
   it('safe_for_use=true → returns only safe disks', async () => {
-    const res = await request(setup.app).get('/api/v1/disks?safe_for_use=true').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/disks?safe_for_use=true')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.body.result).toHaveLength(1);
     expect(res.body.result[0].id).toBe('safe1');
   });
 
   it('safe_for_use=false → returns only unsafe disks', async () => {
-    const res = await request(setup.app).get('/api/v1/disks?safe_for_use=false').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/disks?safe_for_use=false')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.body.result).toHaveLength(1);
     expect(res.body.result[0].id).toBe('unsafe1');
   });
 
   it('safe_for_use=garbage → 400 INVALID_ARGUMENT', async () => {
-    const res = await request(setup.app).get('/api/v1/disks?safe_for_use=garbage').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/disks?safe_for_use=garbage')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(400);
     expect(res.body.errors?.[0]?.code).toBe('INVALID_ARGUMENT');
   });
@@ -64,25 +94,37 @@ describe('query contract: /tasks state/kind/limit', () => {
   beforeEach(async () => {
     setup = await buildTestApp();
     setup.state.kv.put('/xinas/v1/tasks/t-running-create', {
-      task_id: 't-running-create', kind: 'share.create', state: 'running',
+      task_id: 't-running-create',
+      kind: 'share.create',
+      state: 'running',
     });
     setup.state.kv.put('/xinas/v1/tasks/t-done-delete', {
-      task_id: 't-done-delete', kind: 'share.delete', state: 'succeeded',
+      task_id: 't-done-delete',
+      kind: 'share.delete',
+      state: 'succeeded',
     });
     setup.state.kv.put('/xinas/v1/tasks/t-running-delete', {
-      task_id: 't-running-delete', kind: 'share.delete', state: 'running',
+      task_id: 't-running-delete',
+      kind: 'share.delete',
+      state: 'running',
     });
   });
-  afterEach(async () => { await setup.cleanup(); });
+  afterEach(async () => {
+    await setup.cleanup();
+  });
 
   it('state=running filters to running tasks', async () => {
-    const res = await request(setup.app).get('/api/v1/tasks?state=running').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/tasks?state=running')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.body.result).toHaveLength(2);
     expect(res.body.result.every((t: { state: string }) => t.state === 'running')).toBe(true);
   });
 
   it('kind=share.delete filters to delete tasks', async () => {
-    const res = await request(setup.app).get('/api/v1/tasks?kind=share.delete').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/tasks?kind=share.delete')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.body.result).toHaveLength(2);
   });
 
@@ -95,39 +137,55 @@ describe('query contract: /tasks state/kind/limit', () => {
   });
 
   it('limit=1 truncates', async () => {
-    const res = await request(setup.app).get('/api/v1/tasks?limit=1').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/tasks?limit=1')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.body.result).toHaveLength(1);
   });
 
   it('limit=0 → 400 INVALID_ARGUMENT', async () => {
-    const res = await request(setup.app).get('/api/v1/tasks?limit=0').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/tasks?limit=0')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(400);
   });
 
   it('limit=10000 → 400 INVALID_ARGUMENT', async () => {
-    const res = await request(setup.app).get('/api/v1/tasks?limit=10000').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/tasks?limit=10000')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(400);
   });
 
   it('limit=not-an-int → 400 INVALID_ARGUMENT', async () => {
-    const res = await request(setup.app).get('/api/v1/tasks?limit=abc').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/tasks?limit=abc')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(400);
   });
 });
 
 describe('query contract: /config-history/diff requires from + to', () => {
   let setup: Awaited<ReturnType<typeof buildTestApp>>;
-  beforeEach(async () => { setup = await buildTestApp(); });
-  afterEach(async () => { await setup.cleanup(); });
+  beforeEach(async () => {
+    setup = await buildTestApp();
+  });
+  afterEach(async () => {
+    await setup.cleanup();
+  });
 
   it('missing both → 400 INVALID_ARGUMENT', async () => {
-    const res = await request(setup.app).get('/api/v1/config-history/diff').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/config-history/diff')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(400);
     expect(res.body.errors?.[0]?.code).toBe('INVALID_ARGUMENT');
   });
 
   it('missing to → 400 INVALID_ARGUMENT', async () => {
-    const res = await request(setup.app).get('/api/v1/config-history/diff?from=a').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/config-history/diff?from=a')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(400);
   });
 
@@ -138,6 +196,8 @@ describe('query contract: /config-history/diff requires from + to', () => {
     expect(res.status).toBe(200);
     expect(res.body.result.from).toBe('a');
     expect(res.body.result.to).toBe('b');
-    expect(res.body.warnings.some((w: { code: string }) => w.code === 'CONFIG_HISTORY_NOT_INTEGRATED')).toBe(true);
+    expect(
+      res.body.warnings.some((w: { code: string }) => w.code === 'CONFIG_HISTORY_NOT_INTEGRATED'),
+    ).toBe(true);
   });
 });

--- a/xiNAS-MCP/src/__tests__/api/routes-catchall.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/routes-catchall.test.ts
@@ -4,8 +4,12 @@ import { buildTestApp, ADMIN_TOKEN } from './_helpers.js';
 
 describe('/api/v1/* catch-all', () => {
   let setup: Awaited<ReturnType<typeof buildTestApp>>;
-  beforeEach(async () => { setup = await buildTestApp(); });
-  afterEach(async () => { await setup.cleanup(); });
+  beforeEach(async () => {
+    setup = await buildTestApp();
+  });
+  afterEach(async () => {
+    await setup.cleanup();
+  });
 
   it('unknown GET under /api/v1 returns 404 with NOT_FOUND envelope (not Express HTML)', async () => {
     const res = await request(setup.app)

--- a/xiNAS-MCP/src/__tests__/api/routes-health.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/routes-health.test.ts
@@ -4,11 +4,17 @@ import { buildTestApp, ADMIN_TOKEN } from './_helpers.js';
 
 describe('GET /api/v1/health', () => {
   let setup: Awaited<ReturnType<typeof buildTestApp>>;
-  beforeEach(async () => { setup = await buildTestApp(); });
-  afterEach(async () => { await setup.cleanup(); });
+  beforeEach(async () => {
+    setup = await buildTestApp();
+  });
+  afterEach(async () => {
+    await setup.cleanup();
+  });
 
   it('returns a minimal one-check HealthReport for the quick profile', async () => {
-    const res = await request(setup.app).get('/api/v1/health?profile=quick').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/health?profile=quick')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(200);
     expect(res.body.result.profile).toBe('quick');
     expect(res.body.result.overall).toBe('ok');

--- a/xiNAS-MCP/src/__tests__/api/routes-network.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/routes-network.test.ts
@@ -5,24 +5,40 @@ import { buildTestApp, ADMIN_TOKEN } from './_helpers.js';
 describe('network routes', () => {
   let setup: Awaited<ReturnType<typeof buildTestApp>>;
 
-  beforeEach(async () => { setup = await buildTestApp(); });
-  afterEach(async () => { await setup.cleanup(); });
+  beforeEach(async () => {
+    setup = await buildTestApp();
+  });
+  afterEach(async () => {
+    await setup.cleanup();
+  });
 
   it('GET /network/interfaces lists interfaces', async () => {
     setup.state.kv.put('/xinas/v1/observed/NetworkInterface/ibp0s4', {
       kind: 'NetworkInterface',
       id: 'ibp0s4',
       spec: { managed_by_xinas: true, addresses: ['10.0.0.1/24'] },
-      status: { driver: 'mlx5_ib', rdma_capable: true, link_state: 'up', current_addresses: ['10.0.0.1/24'] },
+      status: {
+        driver: 'mlx5_ib',
+        rdma_capable: true,
+        link_state: 'up',
+        current_addresses: ['10.0.0.1/24'],
+      },
     });
-    const res = await request(setup.app).get('/api/v1/network/interfaces').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/network/interfaces')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(200);
     expect(res.body.result).toHaveLength(1);
   });
 
   it('GET /network/interfaces/{id} returns the interface', async () => {
-    setup.state.kv.put('/xinas/v1/observed/NetworkInterface/ibp0s4', { kind: 'NetworkInterface', id: 'ibp0s4' });
-    const res = await request(setup.app).get('/api/v1/network/interfaces/ibp0s4').set('Authorization', ADMIN_TOKEN);
+    setup.state.kv.put('/xinas/v1/observed/NetworkInterface/ibp0s4', {
+      kind: 'NetworkInterface',
+      id: 'ibp0s4',
+    });
+    const res = await request(setup.app)
+      .get('/api/v1/network/interfaces/ibp0s4')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(200);
     expect(res.body.result.id).toBe('ibp0s4');
   });
@@ -34,7 +50,9 @@ describe('network routes', () => {
   });
 
   it('GET /service-ips returns empty in Phase 0', async () => {
-    const res = await request(setup.app).get('/api/v1/service-ips').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/service-ips')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(200);
     expect(res.body.result).toEqual([]);
   });

--- a/xiNAS-MCP/src/__tests__/api/routes-nfs.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/routes-nfs.test.ts
@@ -29,20 +29,26 @@ describe('NFS routes', () => {
   });
 
   it('GET /shares/{id} 404s when missing', async () => {
-    const res = await request(setup.app).get('/api/v1/shares/missing').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/shares/missing')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(404);
   });
 
   it('GET /shares/{id}/sessions returns empty array', async () => {
     seedShare(setup.state, 's1');
-    const res = await request(setup.app).get('/api/v1/shares/s1/sessions').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/shares/s1/sessions')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(200);
     expect(res.body.result).toEqual([]);
   });
 
   it('GET /nfs-profiles lists profiles', async () => {
     seedNfsProfile(setup.state);
-    const res = await request(setup.app).get('/api/v1/nfs-profiles').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/nfs-profiles')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(200);
     expect(res.body.result).toHaveLength(1);
     expect(res.body.result[0].id).toBe('default');
@@ -50,13 +56,17 @@ describe('NFS routes', () => {
 
   it('GET /nfs-profiles/{id} returns the profile', async () => {
     seedNfsProfile(setup.state);
-    const res = await request(setup.app).get('/api/v1/nfs-profiles/default').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/nfs-profiles/default')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(200);
     expect(res.body.result.spec.threads.count).toBe(64);
   });
 
   it('GET /export-groups returns empty on fresh install', async () => {
-    const res = await request(setup.app).get('/api/v1/export-groups').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/export-groups')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(200);
     expect(res.body.result).toEqual([]);
   });

--- a/xiNAS-MCP/src/__tests__/api/routes-storage.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/routes-storage.test.ts
@@ -7,7 +7,13 @@ function seedDisk(state: OpenedStateStore, id: string): void {
   state.kv.put(`/xinas/v1/observed/Disk/${id}`, {
     kind: 'Disk',
     id,
-    status: { device_path: `/dev/${id}`, serial: `S-${id}`, model: 'X', capacity_bytes: 1_000_000_000_000, safe_for_use: true },
+    status: {
+      device_path: `/dev/${id}`,
+      serial: `S-${id}`,
+      model: 'X',
+      capacity_bytes: 1_000_000_000_000,
+      safe_for_use: true,
+    },
   });
 }
 
@@ -16,7 +22,11 @@ function seedArray(state: OpenedStateStore, id: string): void {
     kind: 'XiraidArray',
     id,
     spec: { name: id, level: 'raid5', member_disk_ids: ['d1', 'd2', 'd3'] },
-    status: { state: 'optimal', volume_path: `/dev/xi_${id}`, usable_capacity_bytes: 2_000_000_000_000 },
+    status: {
+      state: 'optimal',
+      volume_path: `/dev/xi_${id}`,
+      usable_capacity_bytes: 2_000_000_000_000,
+    },
   });
 }
 
@@ -55,7 +65,9 @@ describe('storage routes', () => {
   });
 
   it('GET /arrays/{id} returns 404 when missing', async () => {
-    const res = await request(setup.app).get('/api/v1/arrays/missing').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/arrays/missing')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(404);
     expect(res.body.errors[0].code).toBe('NOT_FOUND');
   });
@@ -67,7 +79,9 @@ describe('storage routes', () => {
       spec: { fs_type: 'xfs', backing_device: '/dev/xi_a1', mountpoint: '/srv/fs1' },
       status: { mounted: true, uuid: 'u', size_bytes: 1, free_bytes: 1 },
     });
-    const res = await request(setup.app).get('/api/v1/filesystems').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/filesystems')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(200);
     expect(res.body.result).toHaveLength(1);
   });

--- a/xiNAS-MCP/src/__tests__/api/routes-stubs.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/routes-stubs.test.ts
@@ -4,8 +4,12 @@ import { buildTestApp, ADMIN_TOKEN } from './_helpers.js';
 
 describe('stub routes', () => {
   let setup: Awaited<ReturnType<typeof buildTestApp>>;
-  beforeEach(async () => { setup = await buildTestApp(); });
-  afterEach(async () => { await setup.cleanup(); });
+  beforeEach(async () => {
+    setup = await buildTestApp();
+  });
+  afterEach(async () => {
+    await setup.cleanup();
+  });
 
   it('GET /events returns empty', async () => {
     const res = await request(setup.app).get('/api/v1/events').set('Authorization', ADMIN_TOKEN);
@@ -16,22 +20,32 @@ describe('stub routes', () => {
   it('GET /audit returns empty + warning', async () => {
     const res = await request(setup.app).get('/api/v1/audit').set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(200);
-    expect(res.body.warnings.some((w: { code: string }) => w.code === 'AUDIT_QUERY_NOT_IMPLEMENTED')).toBe(true);
+    expect(
+      res.body.warnings.some((w: { code: string }) => w.code === 'AUDIT_QUERY_NOT_IMPLEMENTED'),
+    ).toBe(true);
   });
 
   it('GET /config-history/snapshots returns empty + warning', async () => {
-    const res = await request(setup.app).get('/api/v1/config-history/snapshots').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/config-history/snapshots')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(200);
-    expect(res.body.warnings.some((w: { code: string }) => w.code === 'CONFIG_HISTORY_NOT_INTEGRATED')).toBe(true);
+    expect(
+      res.body.warnings.some((w: { code: string }) => w.code === 'CONFIG_HISTORY_NOT_INTEGRATED'),
+    ).toBe(true);
   });
 
   it('GET /config-history/snapshots/{id} 404s', async () => {
-    const res = await request(setup.app).get('/api/v1/config-history/snapshots/abc').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .get('/api/v1/config-history/snapshots/abc')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(404);
   });
 
   it('POST /support-bundle returns EXECUTOR_UNAVAILABLE', async () => {
-    const res = await request(setup.app).post('/api/v1/support-bundle').set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app)
+      .post('/api/v1/support-bundle')
+      .set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(500);
     expect(res.body.errors[0].details?.code).toBe('EXECUTOR_UNAVAILABLE');
   });

--- a/xiNAS-MCP/src/__tests__/api/routes-system.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/routes-system.test.ts
@@ -16,9 +16,7 @@ describe('GET /api/v1/system', () => {
   });
 
   it('returns envelope-wrapped Cluster + Node', async () => {
-    const res = await request(setup.app)
-      .get('/api/v1/system')
-      .set('Authorization', ADMIN_TOKEN);
+    const res = await request(setup.app).get('/api/v1/system').set('Authorization', ADMIN_TOKEN);
     expect(res.status).toBe(200);
     expect(res.body.request_id).toMatch(/^[0-9a-f-]{36}$/);
     expect(res.body.result.cluster.id).toBe('default');

--- a/xiNAS-MCP/src/__tests__/api/routes-tasks.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/routes-tasks.test.ts
@@ -4,8 +4,12 @@ import { buildTestApp, ADMIN_TOKEN } from './_helpers.js';
 
 describe('tasks routes', () => {
   let setup: Awaited<ReturnType<typeof buildTestApp>>;
-  beforeEach(async () => { setup = await buildTestApp(); });
-  afterEach(async () => { await setup.cleanup(); });
+  beforeEach(async () => {
+    setup = await buildTestApp();
+  });
+  afterEach(async () => {
+    await setup.cleanup();
+  });
 
   it('GET /tasks returns empty array on fresh install', async () => {
     const res = await request(setup.app).get('/api/v1/tasks').set('Authorization', ADMIN_TOKEN);

--- a/xiNAS-MCP/src/__tests__/contracts/contracts.test.ts
+++ b/xiNAS-MCP/src/__tests__/contracts/contracts.test.ts
@@ -17,16 +17,7 @@ const Ajv = AjvImport as any;
 const addFormats = addFormatsImport as any;
 
 const here = dirname(fileURLToPath(import.meta.url));
-const specPath = resolve(
-  here,
-  '..',
-  '..',
-  '..',
-  '..',
-  'docs',
-  'control-path',
-  'api-v1.yaml',
-);
+const specPath = resolve(here, '..', '..', '..', '..', 'docs', 'control-path', 'api-v1.yaml');
 const fixturesDir = resolve(here, 'fixtures');
 
 describe('OpenAPI schema contract', () => {

--- a/xiNAS-MCP/src/__tests__/sanity.test.ts
+++ b/xiNAS-MCP/src/__tests__/sanity.test.ts
@@ -6,9 +6,7 @@ import { describe, expect, it } from 'vitest';
 describe('package sanity', () => {
   it('package.json declares a semver version', () => {
     const here = dirname(fileURLToPath(import.meta.url));
-    const pkg = JSON.parse(
-      readFileSync(resolve(here, '..', '..', 'package.json'), 'utf8'),
-    );
+    const pkg = JSON.parse(readFileSync(resolve(here, '..', '..', 'package.json'), 'utf8'));
     expect(pkg.version).toMatch(/^\d+\.\d+\.\d+/);
     expect(pkg.name).toBe('xinas-mcp');
   });

--- a/xiNAS-MCP/src/__tests__/state/audit-drainer.test.ts
+++ b/xiNAS-MCP/src/__tests__/state/audit-drainer.test.ts
@@ -66,7 +66,11 @@ describe('AuditDrainer', () => {
     audit.queue(entry());
     await drainer.drainNow();
 
-    const row = db.prepare('SELECT drain_state, durable_file, durable_offset FROM audit_outbox WHERE audit_seq = 1').get() as {
+    const row = db
+      .prepare(
+        'SELECT drain_state, durable_file, durable_offset FROM audit_outbox WHERE audit_seq = 1',
+      )
+      .get() as {
       drain_state: string;
       durable_file: string;
       durable_offset: number;
@@ -75,7 +79,9 @@ describe('AuditDrainer', () => {
     expect(row.durable_file).toBe('audit.jsonl');
     expect(typeof row.durable_offset).toBe('number');
 
-    const idx = db.prepare('SELECT durable_file, durable_offset FROM audit_index WHERE audit_seq = 1').get() as {
+    const idx = db
+      .prepare('SELECT durable_file, durable_offset FROM audit_index WHERE audit_seq = 1')
+      .get() as {
       durable_file: string;
       durable_offset: number;
     };
@@ -108,19 +114,20 @@ describe('AuditDrainer', () => {
     const e1 = audit.queue(entry({ kind: 'a' }));
     const e2 = audit.queue(entry({ kind: 'b' }));
 
-    const line2 = JSON.stringify({
-      audit_seq: e2.audit_seq,
-      prev_hash: e2.prev_hash.toString('hex'),
-      hash: e2.hash.toString('hex'),
-      kind: 'b',
-      timestamp: Date.now(),
-      node_id: 'node-1',
-      principal: 'p',
-      client_type: 'rest',
-      request_id: 'r',
-      parameters_hash: 'sha256:p',
-      result_hash: 'sha256:r',
-    }) + '\n';
+    const line2 =
+      JSON.stringify({
+        audit_seq: e2.audit_seq,
+        prev_hash: e2.prev_hash.toString('hex'),
+        hash: e2.hash.toString('hex'),
+        kind: 'b',
+        timestamp: Date.now(),
+        node_id: 'node-1',
+        principal: 'p',
+        client_type: 'rest',
+        request_id: 'r',
+        parameters_hash: 'sha256:p',
+        result_hash: 'sha256:r',
+      }) + '\n';
     writeFileSync(join(dir, 'audit-gap.jsonl'), line2);
 
     const gappedDrainer = new AuditDrainer(db, {

--- a/xiNAS-MCP/src/__tests__/state/audit-recovery.test.ts
+++ b/xiNAS-MCP/src/__tests__/state/audit-recovery.test.ts
@@ -43,7 +43,9 @@ describe('AuditDrainer — crash recovery', () => {
 
     const content = readFileSync(join(dir, 'audit.jsonl'), 'utf8');
     expect(content.trim().split('\n')).toHaveLength(2);
-    const remaining = db.prepare("SELECT COUNT(*) AS n FROM audit_outbox WHERE drain_state = 'pending'").get() as { n: number };
+    const remaining = db
+      .prepare("SELECT COUNT(*) AS n FROM audit_outbox WHERE drain_state = 'pending'")
+      .get() as { n: number };
     expect(remaining.n).toBe(0);
   });
 
@@ -52,19 +54,20 @@ describe('AuditDrainer — crash recovery', () => {
     const queued = audit.queue(entry({ kind: 'a' }));
 
     // Simulate the crash-after-fsync-before-mark window.
-    const fakeLine = JSON.stringify({
-      audit_seq: queued.audit_seq,
-      prev_hash: queued.prev_hash.toString('hex'),
-      hash: queued.hash.toString('hex'),
-      kind: 'a',
-      timestamp: Date.now(),
-      node_id: 'node-1',
-      principal: 'p',
-      client_type: 'rest',
-      request_id: 'r',
-      parameters_hash: 'sha256:p',
-      result_hash: 'sha256:r',
-    }) + '\n';
+    const fakeLine =
+      JSON.stringify({
+        audit_seq: queued.audit_seq,
+        prev_hash: queued.prev_hash.toString('hex'),
+        hash: queued.hash.toString('hex'),
+        kind: 'a',
+        timestamp: Date.now(),
+        node_id: 'node-1',
+        principal: 'p',
+        client_type: 'rest',
+        request_id: 'r',
+        parameters_hash: 'sha256:p',
+        result_hash: 'sha256:r',
+      }) + '\n';
     writeFileSync(join(dir, 'audit.jsonl'), fakeLine);
 
     const drainer = new AuditDrainer(db, { path: join(dir, 'audit.jsonl') });
@@ -72,7 +75,9 @@ describe('AuditDrainer — crash recovery', () => {
 
     const content = readFileSync(join(dir, 'audit.jsonl'), 'utf8');
     expect(content.trim().split('\n')).toHaveLength(1);
-    const row = db.prepare("SELECT drain_state FROM audit_outbox WHERE audit_seq = ?").get(queued.audit_seq) as { drain_state: string };
+    const row = db
+      .prepare('SELECT drain_state FROM audit_outbox WHERE audit_seq = ?')
+      .get(queued.audit_seq) as { drain_state: string };
     expect(row.drain_state).toBe('durable');
   });
 

--- a/xiNAS-MCP/src/__tests__/state/audit.test.ts
+++ b/xiNAS-MCP/src/__tests__/state/audit.test.ts
@@ -51,7 +51,9 @@ describe('AuditAppender', () => {
   it('chains hashes: second prev_hash equals first hash', () => {
     const first = audit.queue(makeEntry({ request_id: 'r1' }));
     const second = audit.queue(makeEntry({ request_id: 'r2' }));
-    const secondRow = db.prepare('SELECT prev_hash FROM audit_outbox WHERE audit_seq = ?').get(2) as {
+    const secondRow = db
+      .prepare('SELECT prev_hash FROM audit_outbox WHERE audit_seq = ?')
+      .get(2) as {
       prev_hash: Buffer;
     };
     expect(secondRow.prev_hash).toEqual(first.hash);
@@ -90,7 +92,7 @@ describe('AuditAppender', () => {
     });
     expect(() => txn()).toThrow('boom');
 
-    const after = db.prepare("SELECT COUNT(*) AS n FROM audit_outbox").get() as { n: number };
+    const after = db.prepare('SELECT COUNT(*) AS n FROM audit_outbox').get() as { n: number };
     expect(after.n).toBe(0);
 
     const next = audit.queue(makeEntry({ request_id: 'survives' }));

--- a/xiNAS-MCP/src/__tests__/state/gc.test.ts
+++ b/xiNAS-MCP/src/__tests__/state/gc.test.ts
@@ -6,7 +6,12 @@ import Database from 'better-sqlite3';
 import { runMigrations } from '../../state/migrations.js';
 import { GcSweeper } from '../../state/gc.js';
 
-function seedTask(db: Database.Database, task_id: string, state: string, terminal_at: number | null) {
+function seedTask(
+  db: Database.Database,
+  task_id: string,
+  state: string,
+  terminal_at: number | null,
+) {
   db.prepare(
     `INSERT INTO tasks (task_id, kind, state, principal, client_type, request_id, correlation_id,
                         input_hash, risk_level, affected_resources, created_at, updated_at, terminal_at)
@@ -14,7 +19,13 @@ function seedTask(db: Database.Database, task_id: string, state: string, termina
   ).run(task_id, state, `r-${task_id}`, `c-${task_id}`, Date.now(), Date.now(), terminal_at);
 }
 
-function seedLease(db: Database.Database, resource_id: string, task_id: string, heartbeat_at: number, ttl: number) {
+function seedLease(
+  db: Database.Database,
+  resource_id: string,
+  task_id: string,
+  heartbeat_at: number,
+  ttl: number,
+) {
   db.prepare(
     `INSERT INTO leases (lease_id, resource_kind, resource_id, task_id, acquired_at, ttl_seconds, heartbeat_at)
      VALUES (?, 'array', ?, ?, ?, ?, ?)`,
@@ -52,7 +63,9 @@ describe('GcSweeper', () => {
     expect(result.archived).toBe(1);
     expect(result.deleted).toBe(1);
 
-    const remaining = (db.prepare('SELECT task_id FROM tasks ORDER BY task_id').all() as { task_id: string }[]).map((r) => r.task_id);
+    const remaining = (
+      db.prepare('SELECT task_id FROM tasks ORDER BY task_id').all() as { task_id: string }[]
+    ).map((r) => r.task_id);
     expect(remaining).toEqual(['t-recent', 't-running']);
 
     const files = readdirSync(dir);
@@ -62,9 +75,14 @@ describe('GcSweeper', () => {
   it('does not remove non-terminal tasks regardless of age', async () => {
     const now = Date.now();
     seedTask(db, 't-old-running', 'running', null);
-    db.prepare('UPDATE tasks SET created_at = ? WHERE task_id = ?').run(now - 1000 * 86400, 't-old-running');
+    db.prepare('UPDATE tasks SET created_at = ? WHERE task_id = ?').run(
+      now - 1000 * 86400,
+      't-old-running',
+    );
     await gc.sweepTasks();
-    expect(db.prepare("SELECT COUNT(*) AS n FROM tasks WHERE task_id = 't-old-running'").get()).toEqual({ n: 1 });
+    expect(
+      db.prepare("SELECT COUNT(*) AS n FROM tasks WHERE task_id = 't-old-running'").get(),
+    ).toEqual({ n: 1 });
   });
 
   it('sweepLeases delegates to LeaseManager and returns its result shape', () => {

--- a/xiNAS-MCP/src/__tests__/state/index.test.ts
+++ b/xiNAS-MCP/src/__tests__/state/index.test.ts
@@ -36,11 +36,19 @@ describe('openStateStore factory', () => {
     const dbPath = join(dir, 'xinas.db');
     const auditPath = join(dir, 'audit.jsonl');
 
-    const s1 = await openStateStore({ databasePath: dbPath, auditJsonlPath: auditPath, nodeId: 'node-1' });
+    const s1 = await openStateStore({
+      databasePath: dbPath,
+      auditJsonlPath: auditPath,
+      nodeId: 'node-1',
+    });
     s1.kv.put('/k', { x: 1 });
     await s1.close();
 
-    const s2 = await openStateStore({ databasePath: dbPath, auditJsonlPath: auditPath, nodeId: 'node-1' });
+    const s2 = await openStateStore({
+      databasePath: dbPath,
+      auditJsonlPath: auditPath,
+      nodeId: 'node-1',
+    });
     expect(s2.kv.get<{ x: number }>('/k')?.value).toEqual({ x: 1 });
     await s2.close();
   });
@@ -63,9 +71,9 @@ describe('openStateStore factory', () => {
       parameters_hash: 'sha256:p',
       result_hash: 'sha256:r',
     });
-    const pendingBefore = seedDb.prepare(
-      "SELECT COUNT(*) AS n FROM audit_outbox WHERE drain_state = 'pending'",
-    ).get() as { n: number };
+    const pendingBefore = seedDb
+      .prepare("SELECT COUNT(*) AS n FROM audit_outbox WHERE drain_state = 'pending'")
+      .get() as { n: number };
     expect(pendingBefore.n).toBe(1);
     seedDb.close();
 
@@ -83,13 +91,13 @@ describe('openStateStore factory', () => {
       expect(JSON.parse(lines[0]!).kind).toBe('k');
 
       const readDb = new Database(dbPath, { readonly: true });
-      const pendingAfter = readDb.prepare(
-        "SELECT COUNT(*) AS n FROM audit_outbox WHERE drain_state = 'pending'",
-      ).get() as { n: number };
+      const pendingAfter = readDb
+        .prepare("SELECT COUNT(*) AS n FROM audit_outbox WHERE drain_state = 'pending'")
+        .get() as { n: number };
       expect(pendingAfter.n).toBe(0);
-      const durable = readDb.prepare(
-        "SELECT drain_state, durable_file, durable_offset FROM audit_outbox",
-      ).get() as { drain_state: string; durable_file: string; durable_offset: number };
+      const durable = readDb
+        .prepare('SELECT drain_state, durable_file, durable_offset FROM audit_outbox')
+        .get() as { drain_state: string; durable_file: string; durable_offset: number };
       expect(durable.drain_state).toBe('durable');
       expect(durable.durable_file).toBe('audit.jsonl');
       expect(durable.durable_offset).toBeGreaterThanOrEqual(0);

--- a/xiNAS-MCP/src/__tests__/state/leases.test.ts
+++ b/xiNAS-MCP/src/__tests__/state/leases.test.ts
@@ -26,7 +26,12 @@ describe('LeaseManager', () => {
   });
 
   it('acquires a lease for a resource', () => {
-    const result = leases.acquire({ resource_kind: 'array', resource_id: 'arr1', task_id: 't1', ttl_seconds: 60 });
+    const result = leases.acquire({
+      resource_kind: 'array',
+      resource_id: 'arr1',
+      task_id: 't1',
+      ttl_seconds: 60,
+    });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.lease_id).toMatch(/^[0-9a-f-]{36}$/);
@@ -34,7 +39,12 @@ describe('LeaseManager', () => {
 
   it('refuses a second acquire on the same resource', () => {
     leases.acquire({ resource_kind: 'array', resource_id: 'arr1', task_id: 't1', ttl_seconds: 60 });
-    const second = leases.acquire({ resource_kind: 'array', resource_id: 'arr1', task_id: 't2', ttl_seconds: 60 });
+    const second = leases.acquire({
+      resource_kind: 'array',
+      resource_id: 'arr1',
+      task_id: 't2',
+      ttl_seconds: 60,
+    });
     expect(second.ok).toBe(false);
     if (second.ok) return;
     expect(second.reason).toBe('held_by_other');
@@ -42,35 +52,74 @@ describe('LeaseManager', () => {
   });
 
   it('release frees the resource', () => {
-    const first = leases.acquire({ resource_kind: 'array', resource_id: 'arr1', task_id: 't1', ttl_seconds: 60 });
+    const first = leases.acquire({
+      resource_kind: 'array',
+      resource_id: 'arr1',
+      task_id: 't1',
+      ttl_seconds: 60,
+    });
     if (!first.ok) throw new Error('seed failed');
     leases.release(first.lease_id);
-    const second = leases.acquire({ resource_kind: 'array', resource_id: 'arr1', task_id: 't2', ttl_seconds: 60 });
+    const second = leases.acquire({
+      resource_kind: 'array',
+      resource_id: 'arr1',
+      task_id: 't2',
+      ttl_seconds: 60,
+    });
     expect(second.ok).toBe(true);
   });
 
   it('heartbeat extends ttl', () => {
-    const r = leases.acquire({ resource_kind: 'array', resource_id: 'arr1', task_id: 't1', ttl_seconds: 60 });
+    const r = leases.acquire({
+      resource_kind: 'array',
+      resource_id: 'arr1',
+      task_id: 't1',
+      ttl_seconds: 60,
+    });
     if (!r.ok) throw new Error('seed failed');
-    const t0 = (db.prepare('SELECT heartbeat_at FROM leases WHERE lease_id = ?').get(r.lease_id) as { heartbeat_at: number }).heartbeat_at;
+    const t0 = (
+      db.prepare('SELECT heartbeat_at FROM leases WHERE lease_id = ?').get(r.lease_id) as {
+        heartbeat_at: number;
+      }
+    ).heartbeat_at;
     leases.heartbeat(r.lease_id);
-    const t1 = (db.prepare('SELECT heartbeat_at FROM leases WHERE lease_id = ?').get(r.lease_id) as { heartbeat_at: number }).heartbeat_at;
+    const t1 = (
+      db.prepare('SELECT heartbeat_at FROM leases WHERE lease_id = ?').get(r.lease_id) as {
+        heartbeat_at: number;
+      }
+    ).heartbeat_at;
     expect(t1).toBeGreaterThanOrEqual(t0);
   });
 
   it('sweepExpired removes leases whose heartbeat_at + ttl is past now', () => {
-    const r = leases.acquire({ resource_kind: 'array', resource_id: 'arr1', task_id: 't1', ttl_seconds: 1 });
+    const r = leases.acquire({
+      resource_kind: 'array',
+      resource_id: 'arr1',
+      task_id: 't1',
+      ttl_seconds: 1,
+    });
     if (!r.ok) throw new Error('seed failed');
-    db.prepare('UPDATE leases SET heartbeat_at = ? WHERE lease_id = ?').run(Date.now() - 5000, r.lease_id);
+    db.prepare('UPDATE leases SET heartbeat_at = ? WHERE lease_id = ?').run(
+      Date.now() - 5000,
+      r.lease_id,
+    );
     const result = leases.sweepExpired();
     expect(result.leases_removed).toBe(1);
     expect(db.prepare('SELECT COUNT(*) AS n FROM leases').get()).toEqual({ n: 0 });
   });
 
   it('sweepExpired transitions still-running holder tasks to requires_manual_recovery', () => {
-    const r = leases.acquire({ resource_kind: 'array', resource_id: 'arr1', task_id: 't1', ttl_seconds: 1 });
+    const r = leases.acquire({
+      resource_kind: 'array',
+      resource_id: 'arr1',
+      task_id: 't1',
+      ttl_seconds: 1,
+    });
     if (!r.ok) throw new Error('seed failed');
-    db.prepare('UPDATE leases SET heartbeat_at = ? WHERE lease_id = ?').run(Date.now() - 5000, r.lease_id);
+    db.prepare('UPDATE leases SET heartbeat_at = ? WHERE lease_id = ?').run(
+      Date.now() - 5000,
+      r.lease_id,
+    );
 
     const result = leases.sweepExpired();
     expect(result.leases_removed).toBe(1);
@@ -85,15 +134,27 @@ describe('LeaseManager', () => {
   });
 
   it('sweepExpired does not touch terminal tasks even when their lease expires', () => {
-    db.prepare("UPDATE tasks SET state = 'success', terminal_at = ? WHERE task_id = 't1'").run(Date.now());
-    const r = leases.acquire({ resource_kind: 'array', resource_id: 'arr1', task_id: 't1', ttl_seconds: 1 });
+    db.prepare("UPDATE tasks SET state = 'success', terminal_at = ? WHERE task_id = 't1'").run(
+      Date.now(),
+    );
+    const r = leases.acquire({
+      resource_kind: 'array',
+      resource_id: 'arr1',
+      task_id: 't1',
+      ttl_seconds: 1,
+    });
     if (!r.ok) throw new Error('seed failed');
-    db.prepare('UPDATE leases SET heartbeat_at = ? WHERE lease_id = ?').run(Date.now() - 5000, r.lease_id);
+    db.prepare('UPDATE leases SET heartbeat_at = ? WHERE lease_id = ?').run(
+      Date.now() - 5000,
+      r.lease_id,
+    );
 
     const result = leases.sweepExpired();
     expect(result.leases_removed).toBe(1);
     expect(result.tasks_recovered).toBe(0);
-    const task = db.prepare("SELECT state FROM tasks WHERE task_id = 't1'").get() as { state: string };
+    const task = db.prepare("SELECT state FROM tasks WHERE task_id = 't1'").get() as {
+      state: string;
+    };
     expect(task.state).toBe('success');
   });
 });

--- a/xiNAS-MCP/src/__tests__/state/migrations.test.ts
+++ b/xiNAS-MCP/src/__tests__/state/migrations.test.ts
@@ -23,7 +23,9 @@ describe('migrations runner', () => {
       'tasks',
     ]);
 
-    const versions = db.prepare('SELECT version, filename FROM schema_version ORDER BY version').all();
+    const versions = db
+      .prepare('SELECT version, filename FROM schema_version ORDER BY version')
+      .all();
     expect(versions).toEqual([{ version: 1, filename: '001-initial.sql' }]);
   });
 

--- a/xiNAS-MCP/src/api-server.ts
+++ b/xiNAS-MCP/src/api-server.ts
@@ -5,7 +5,10 @@ async function main(): Promise<void> {
   const handle = await startServer(configPath !== undefined ? { configPath } : {});
   const addr = handle.address;
   // eslint-disable-next-line no-console
-  console.log('xinas-api listening on', typeof addr === 'string' ? addr : `${addr.address}:${addr.port}`);
+  console.log(
+    'xinas-api listening on',
+    typeof addr === 'string' ? addr : `${addr.address}:${addr.port}`,
+  );
   const shutdown = async (signal: string) => {
     // eslint-disable-next-line no-console
     console.log(`received ${signal}, shutting down`);

--- a/xiNAS-MCP/src/api/handlers/reads.ts
+++ b/xiNAS-MCP/src/api/handlers/reads.ts
@@ -21,10 +21,7 @@ export function sendOk<T>(req: Request, res: Response, result: T, revisions: num
 }
 
 /** Read all KV entries under a prefix, return as a typed array. */
-export function listByPrefix<T>(
-  state: OpenedStateStore,
-  prefix: string,
-): RevisionedValue<T>[] {
+export function listByPrefix<T>(state: OpenedStateStore, prefix: string): RevisionedValue<T>[] {
   return state.kv.list<T>({ prefix });
 }
 

--- a/xiNAS-MCP/src/api/handlers/unsupported.ts
+++ b/xiNAS-MCP/src/api/handlers/unsupported.ts
@@ -13,22 +13,20 @@ import { errorStatus, makeError } from '../errors.js';
  */
 export function executorUnavailable(req: Request, res: Response): void {
   const ctx = req.context!;
-  res
-    .status(errorStatus('INTERNAL'))
-    .json(
-      buildEnvelope({
-        request_id: ctx.request_id,
-        correlation_id: ctx.correlation_id,
-        state_revision: 0,
-        errors: [
-          makeError(
-            'INTERNAL',
-            'mutating operations are unavailable: xinas-agent is not running',
-            { code: 'EXECUTOR_UNAVAILABLE' },
-            'start xinas-agent.service; mutating endpoints will return once the agent is healthy',
-          ),
-        ],
-        result: null,
-      }),
-    );
+  res.status(errorStatus('INTERNAL')).json(
+    buildEnvelope({
+      request_id: ctx.request_id,
+      correlation_id: ctx.correlation_id,
+      state_revision: 0,
+      errors: [
+        makeError(
+          'INTERNAL',
+          'mutating operations are unavailable: xinas-agent is not running',
+          { code: 'EXECUTOR_UNAVAILABLE' },
+          'start xinas-agent.service; mutating endpoints will return once the agent is healthy',
+        ),
+      ],
+      result: null,
+    }),
+  );
 }

--- a/xiNAS-MCP/src/api/middleware/audit.ts
+++ b/xiNAS-MCP/src/api/middleware/audit.ts
@@ -41,7 +41,8 @@ export function auditMiddleware(state: OpenedStateStore) {
           client_type: ctx.client_type,
           request_id: ctx.request_id,
           parameters_hash: parametersHash(req),
-          result_hash: 'sha256:' + createHash('sha256').update(String(res.statusCode)).digest('hex'),
+          result_hash:
+            'sha256:' + createHash('sha256').update(String(res.statusCode)).digest('hex'),
           ...(ctx.operation_id !== undefined ? { operation_id: ctx.operation_id } : {}),
         };
         state.audit.queue(entry);

--- a/xiNAS-MCP/src/api/middleware/auth.ts
+++ b/xiNAS-MCP/src/api/middleware/auth.ts
@@ -85,16 +85,14 @@ export function authMiddleware(config: ApiConfig) {
         ? 'unknown bearer token'
         : 'authentication required (bearer token or Unix peer-creds)',
     );
-    res
-      .status(errorStatus('PERMISSION_DENIED'))
-      .json(
-        buildEnvelope({
-          request_id: ctx.request_id,
-          correlation_id: ctx.correlation_id,
-          state_revision: 0,
-          errors: [err],
-          result: null,
-        }),
-      );
+    res.status(errorStatus('PERMISSION_DENIED')).json(
+      buildEnvelope({
+        request_id: ctx.request_id,
+        correlation_id: ctx.correlation_id,
+        state_revision: 0,
+        errors: [err],
+        result: null,
+      }),
+    );
   };
 }

--- a/xiNAS-MCP/src/api/middleware/error.ts
+++ b/xiNAS-MCP/src/api/middleware/error.ts
@@ -24,45 +24,39 @@ export function errorMiddleware(): ErrorRequestHandler {
   return (err: unknown, req: Request, res: Response, _next: NextFunction): void => {
     const ctx = req.context;
     if (err instanceof ApiException) {
-      res
-        .status(errorStatus(err.code))
-        .json(
-          buildEnvelope({
-            request_id: ctx?.request_id ?? 'unknown',
-            correlation_id: ctx?.correlation_id ?? 'unknown',
-            state_revision: 0,
-            errors: [makeError(err.code, err.message, err.details, err.remediation)],
-            result: null,
-          }),
-        );
-      return;
-    }
-    if (isBodyParseError(err)) {
-      const msg = err instanceof Error ? err.message : 'malformed request body';
-      res
-        .status(errorStatus('INVALID_ARGUMENT'))
-        .json(
-          buildEnvelope({
-            request_id: ctx?.request_id ?? 'unknown',
-            correlation_id: ctx?.correlation_id ?? 'unknown',
-            state_revision: 0,
-            errors: [makeError('INVALID_ARGUMENT', `malformed JSON body: ${msg}`)],
-            result: null,
-          }),
-        );
-      return;
-    }
-    const msg = err instanceof Error ? err.message : String(err);
-    res
-      .status(errorStatus('INTERNAL'))
-      .json(
+      res.status(errorStatus(err.code)).json(
         buildEnvelope({
           request_id: ctx?.request_id ?? 'unknown',
           correlation_id: ctx?.correlation_id ?? 'unknown',
           state_revision: 0,
-          errors: [makeError('INTERNAL', msg)],
+          errors: [makeError(err.code, err.message, err.details, err.remediation)],
           result: null,
         }),
       );
+      return;
+    }
+    if (isBodyParseError(err)) {
+      const msg = err instanceof Error ? err.message : 'malformed request body';
+      res.status(errorStatus('INVALID_ARGUMENT')).json(
+        buildEnvelope({
+          request_id: ctx?.request_id ?? 'unknown',
+          correlation_id: ctx?.correlation_id ?? 'unknown',
+          state_revision: 0,
+          errors: [makeError('INVALID_ARGUMENT', `malformed JSON body: ${msg}`)],
+          result: null,
+        }),
+      );
+      return;
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    res.status(errorStatus('INTERNAL')).json(
+      buildEnvelope({
+        request_id: ctx?.request_id ?? 'unknown',
+        correlation_id: ctx?.correlation_id ?? 'unknown',
+        state_revision: 0,
+        errors: [makeError('INTERNAL', msg)],
+        result: null,
+      }),
+    );
   };
 }

--- a/xiNAS-MCP/src/api/routes/audit-query.ts
+++ b/xiNAS-MCP/src/api/routes/audit-query.ts
@@ -12,10 +12,12 @@ export function auditRouter(_ctx: ApiContext): Router {
         request_id: ctx.request_id,
         correlation_id: ctx.correlation_id,
         state_revision: 0,
-        warnings: [{
-          code: 'AUDIT_QUERY_NOT_IMPLEMENTED',
-          message: 'audit query against the JSONL is not implemented in this PR; result is empty',
-        }],
+        warnings: [
+          {
+            code: 'AUDIT_QUERY_NOT_IMPLEMENTED',
+            message: 'audit query against the JSONL is not implemented in this PR; result is empty',
+          },
+        ],
         result: [],
       }),
     );

--- a/xiNAS-MCP/src/api/routes/config-history.ts
+++ b/xiNAS-MCP/src/api/routes/config-history.ts
@@ -26,7 +26,10 @@ export function configHistoryRouter(_ctx: ApiContext): Router {
   const r = Router();
   r.get('/config-history/snapshots', (req, res) => emptyEnvelope(req, res, []));
   r.get('/config-history/snapshots/:id', (_req, _res) => {
-    throw new ApiException('NOT_FOUND', 'snapshot not found (config-history bridge not integrated)');
+    throw new ApiException(
+      'NOT_FOUND',
+      'snapshot not found (config-history bridge not integrated)',
+    );
   });
   r.get('/config-history/diff', (req, res) => {
     // Per api-v1.yaml, both from and to are required string params.

--- a/xiNAS-MCP/src/api/routes/events.ts
+++ b/xiNAS-MCP/src/api/routes/events.ts
@@ -6,7 +6,12 @@ export function eventsRouter(ctx: ApiContext): Router {
   const r = Router();
   r.get('/events', (req, res) => {
     const rows = listByPrefix<Record<string, unknown>>(ctx.state, '/xinas/v1/events/');
-    sendOk(req, res, unwrapValues(rows), rows.map((x) => x.revision));
+    sendOk(
+      req,
+      res,
+      unwrapValues(rows),
+      rows.map((x) => x.revision),
+    );
   });
   return r;
 }

--- a/xiNAS-MCP/src/api/routes/inventory.ts
+++ b/xiNAS-MCP/src/api/routes/inventory.ts
@@ -5,8 +5,16 @@ import type { ApiContext } from '../context.js';
 export function inventoryRouter(ctx: ApiContext): Router {
   const r = Router();
   r.get('/inventory', (req, res) => {
-    const inv = getOrNull<Record<string, unknown>>(ctx.state, '/xinas/v1/observed/inventory/snapshot');
-    sendOk(req, res, inv?.value ?? { hardware: null, software: null, captured_at: null }, inv ? [inv.revision] : []);
+    const inv = getOrNull<Record<string, unknown>>(
+      ctx.state,
+      '/xinas/v1/observed/inventory/snapshot',
+    );
+    sendOk(
+      req,
+      res,
+      inv?.value ?? { hardware: null, software: null, captured_at: null },
+      inv ? [inv.revision] : [],
+    );
   });
   return r;
 }

--- a/xiNAS-MCP/src/api/routes/network.ts
+++ b/xiNAS-MCP/src/api/routes/network.ts
@@ -7,7 +7,10 @@ export function networkRouter(ctx: ApiContext): Router {
   const r = Router();
 
   r.get('/network', (req, res) => {
-    const ifaces = listByPrefix<Record<string, unknown>>(ctx.state, '/xinas/v1/observed/NetworkInterface/');
+    const ifaces = listByPrefix<Record<string, unknown>>(
+      ctx.state,
+      '/xinas/v1/observed/NetworkInterface/',
+    );
     sendOk(
       req,
       res,
@@ -17,19 +20,35 @@ export function networkRouter(ctx: ApiContext): Router {
   });
 
   r.get('/network/interfaces', (req, res) => {
-    const rows = listByPrefix<Record<string, unknown>>(ctx.state, '/xinas/v1/observed/NetworkInterface/');
-    sendOk(req, res, unwrapValues(rows), rows.map((x) => x.revision));
+    const rows = listByPrefix<Record<string, unknown>>(
+      ctx.state,
+      '/xinas/v1/observed/NetworkInterface/',
+    );
+    sendOk(
+      req,
+      res,
+      unwrapValues(rows),
+      rows.map((x) => x.revision),
+    );
   });
 
   r.get('/network/interfaces/:id', (req, res) => {
-    const row = getOrNull<Record<string, unknown>>(ctx.state, `/xinas/v1/observed/NetworkInterface/${req.params.id}`);
+    const row = getOrNull<Record<string, unknown>>(
+      ctx.state,
+      `/xinas/v1/observed/NetworkInterface/${req.params.id}`,
+    );
     if (!row) throw new ApiException('NOT_FOUND', `interface ${req.params.id} not found`);
     sendOk(req, res, row.value, [row.revision]);
   });
 
   r.get('/service-ips', (req, res) => {
     const rows = listByPrefix<Record<string, unknown>>(ctx.state, '/xinas/v1/desired/ServiceIP/');
-    sendOk(req, res, unwrapValues(rows), rows.map((x) => x.revision));
+    sendOk(
+      req,
+      res,
+      unwrapValues(rows),
+      rows.map((x) => x.revision),
+    );
   });
 
   return r;

--- a/xiNAS-MCP/src/api/routes/nfs.ts
+++ b/xiNAS-MCP/src/api/routes/nfs.ts
@@ -8,11 +8,19 @@ export function nfsRouter(ctx: ApiContext): Router {
 
   r.get('/shares', (req, res) => {
     const rows = listByPrefix<Record<string, unknown>>(ctx.state, '/xinas/v1/desired/Share/');
-    sendOk(req, res, unwrapValues(rows), rows.map((x) => x.revision));
+    sendOk(
+      req,
+      res,
+      unwrapValues(rows),
+      rows.map((x) => x.revision),
+    );
   });
 
   r.get('/shares/:id', (req, res) => {
-    const row = getOrNull<Record<string, unknown>>(ctx.state, `/xinas/v1/desired/Share/${req.params.id}`);
+    const row = getOrNull<Record<string, unknown>>(
+      ctx.state,
+      `/xinas/v1/desired/Share/${req.params.id}`,
+    );
     if (!row) throw new ApiException('NOT_FOUND', `share ${req.params.id} not found`);
     sendOk(req, res, row.value, [row.revision]);
   });
@@ -28,18 +36,31 @@ export function nfsRouter(ctx: ApiContext): Router {
 
   r.get('/nfs-profiles', (req, res) => {
     const rows = listByPrefix<Record<string, unknown>>(ctx.state, '/xinas/v1/desired/NfsProfile/');
-    sendOk(req, res, unwrapValues(rows), rows.map((x) => x.revision));
+    sendOk(
+      req,
+      res,
+      unwrapValues(rows),
+      rows.map((x) => x.revision),
+    );
   });
 
   r.get('/nfs-profiles/:id', (req, res) => {
-    const row = getOrNull<Record<string, unknown>>(ctx.state, `/xinas/v1/desired/NfsProfile/${req.params.id}`);
+    const row = getOrNull<Record<string, unknown>>(
+      ctx.state,
+      `/xinas/v1/desired/NfsProfile/${req.params.id}`,
+    );
     if (!row) throw new ApiException('NOT_FOUND', `nfs profile ${req.params.id} not found`);
     sendOk(req, res, row.value, [row.revision]);
   });
 
   r.get('/export-groups', (req, res) => {
     const rows = listByPrefix<Record<string, unknown>>(ctx.state, '/xinas/v1/desired/ExportGroup/');
-    sendOk(req, res, unwrapValues(rows), rows.map((x) => x.revision));
+    sendOk(
+      req,
+      res,
+      unwrapValues(rows),
+      rows.map((x) => x.revision),
+    );
   });
 
   return r;

--- a/xiNAS-MCP/src/api/routes/storage.ts
+++ b/xiNAS-MCP/src/api/routes/storage.ts
@@ -37,27 +37,51 @@ export function storageRouter(ctx: ApiContext): Router {
         return status?.safe_for_use === safeForUse;
       });
     }
-    sendOk(req, res, values, rows.map((x) => x.revision));
+    sendOk(
+      req,
+      res,
+      values,
+      rows.map((x) => x.revision),
+    );
   });
 
   r.get('/arrays', (req, res) => {
-    const rows = listByPrefix<Record<string, unknown>>(ctx.state, '/xinas/v1/observed/XiraidArray/');
-    sendOk(req, res, unwrapValues(rows), rows.map((x) => x.revision));
+    const rows = listByPrefix<Record<string, unknown>>(
+      ctx.state,
+      '/xinas/v1/observed/XiraidArray/',
+    );
+    sendOk(
+      req,
+      res,
+      unwrapValues(rows),
+      rows.map((x) => x.revision),
+    );
   });
 
   r.get('/arrays/:id', (req, res) => {
-    const row = getOrNull<Record<string, unknown>>(ctx.state, `/xinas/v1/observed/XiraidArray/${req.params.id}`);
+    const row = getOrNull<Record<string, unknown>>(
+      ctx.state,
+      `/xinas/v1/observed/XiraidArray/${req.params.id}`,
+    );
     if (!row) throw new ApiException('NOT_FOUND', `array ${req.params.id} not found`);
     sendOk(req, res, row.value, [row.revision]);
   });
 
   r.get('/filesystems', (req, res) => {
     const rows = listByPrefix<Record<string, unknown>>(ctx.state, '/xinas/v1/observed/Filesystem/');
-    sendOk(req, res, unwrapValues(rows), rows.map((x) => x.revision));
+    sendOk(
+      req,
+      res,
+      unwrapValues(rows),
+      rows.map((x) => x.revision),
+    );
   });
 
   r.get('/filesystems/:id', (req, res) => {
-    const row = getOrNull<Record<string, unknown>>(ctx.state, `/xinas/v1/observed/Filesystem/${req.params.id}`);
+    const row = getOrNull<Record<string, unknown>>(
+      ctx.state,
+      `/xinas/v1/observed/Filesystem/${req.params.id}`,
+    );
     if (!row) throw new ApiException('NOT_FOUND', `filesystem ${req.params.id} not found`);
     sendOk(req, res, row.value, [row.revision]);
   });

--- a/xiNAS-MCP/src/api/routes/system.ts
+++ b/xiNAS-MCP/src/api/routes/system.ts
@@ -11,12 +11,10 @@ export function systemRouter(ctx: ApiContext): Router {
     if (!cluster) throw new ApiException('NOT_FOUND', 'cluster not initialized');
     const nodes = listByPrefix<Record<string, unknown>>(ctx.state, '/xinas/v1/nodes/');
     if (nodes.length === 0) throw new ApiException('NOT_FOUND', 'no node registered');
-    sendOk(
-      req,
-      res,
-      { cluster: cluster.value, node: nodes[0]!.value },
-      [cluster.revision, ...nodes.map((n) => n.revision)],
-    );
+    sendOk(req, res, { cluster: cluster.value, node: nodes[0]!.value }, [
+      cluster.revision,
+      ...nodes.map((n) => n.revision),
+    ]);
   });
 
   r.get('/capabilities', (req, res) => {
@@ -30,7 +28,12 @@ export function systemRouter(ctx: ApiContext): Router {
 
   r.get('/controllers', (req, res) => {
     const nodes = listByPrefix<Record<string, unknown>>(ctx.state, '/xinas/v1/nodes/');
-    sendOk(req, res, unwrapValues(nodes), nodes.map((n) => n.revision));
+    sendOk(
+      req,
+      res,
+      unwrapValues(nodes),
+      nodes.map((n) => n.revision),
+    );
   });
 
   return r;

--- a/xiNAS-MCP/src/api/routes/tasks.ts
+++ b/xiNAS-MCP/src/api/routes/tasks.ts
@@ -14,10 +14,16 @@ function parseLimit(raw: unknown): number {
   }
   const n = Number.parseInt(raw, 10);
   if (!Number.isFinite(n) || String(n) !== raw) {
-    throw new ApiException('INVALID_ARGUMENT', `query param 'limit' must be an integer, got '${raw}'`);
+    throw new ApiException(
+      'INVALID_ARGUMENT',
+      `query param 'limit' must be an integer, got '${raw}'`,
+    );
   }
   if (n < 1 || n > 1000) {
-    throw new ApiException('INVALID_ARGUMENT', `query param 'limit' must be in [1, 1000], got ${n}`);
+    throw new ApiException(
+      'INVALID_ARGUMENT',
+      `query param 'limit' must be in [1, 1000], got ${n}`,
+    );
   }
   return n;
 }
@@ -46,7 +52,12 @@ export function tasksRouter(ctx: ApiContext): Router {
       values = values.filter((v) => (v as { kind?: string }).kind === kindFilter);
     }
     if (values.length > limit) values = values.slice(0, limit);
-    sendOk(req, res, values, rows.map((x) => x.revision));
+    sendOk(
+      req,
+      res,
+      values,
+      rows.map((x) => x.revision),
+    );
   });
 
   r.get('/tasks/:id', (req, res) => {

--- a/xiNAS-MCP/src/config/serverConfig.ts
+++ b/xiNAS-MCP/src/config/serverConfig.ts
@@ -13,9 +13,9 @@ const CONFIG_PATH = '/etc/xinas-mcp/config.json';
 const CONFIG_DIR = '/etc/xinas-mcp';
 
 export interface TlsConfig {
-  cert: string;    // Path to server certificate
-  key: string;     // Path to server private key
-  ca?: string;     // Path to CA cert for client verification (enables mTLS)
+  cert: string; // Path to server certificate
+  key: string; // Path to server private key
+  ca?: string; // Path to CA cert for client verification (enables mTLS)
 }
 
 export interface ServerConfig {

--- a/xiNAS-MCP/src/grpc/client.ts
+++ b/xiNAS-MCP/src/grpc/client.ts
@@ -48,10 +48,7 @@ export function readNetConfig(): XRaidNetConfig {
 }
 
 function readCaCert(): Buffer {
-  const candidates = [
-    path.join(CRT_DIR, 'ca-cert.pem'),
-    path.join(CRT_DIR, 'ca-cert.crt'),
-  ];
+  const candidates = [path.join(CRT_DIR, 'ca-cert.pem'), path.join(CRT_DIR, 'ca-cert.crt')];
   for (const p of candidates) {
     if (fs.existsSync(p)) {
       return fs.readFileSync(p);
@@ -59,7 +56,7 @@ function readCaCert(): Buffer {
   }
   throw new McpToolError(
     ErrorCode.INTERNAL,
-    `xiRAID CA cert not found. Tried: ${candidates.join(', ')}. Is xiraid-server.service running?`
+    `xiRAID CA cert not found. Tried: ${candidates.join(', ')}. Is xiraid-server.service running?`,
   );
 }
 
@@ -108,10 +105,7 @@ export async function getClient(controllerId = 'default'): Promise<any> {
 /**
  * Execute a gRPC operation with retry on UNAVAILABLE errors.
  */
-export async function withRetry<T>(
-  fn: () => Promise<T>,
-  toolName: string
-): Promise<T> {
+export async function withRetry<T>(fn: () => Promise<T>, toolName: string): Promise<T> {
   let lastError: Error | undefined;
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
@@ -120,13 +114,13 @@ export async function withRetry<T>(
       const grpcErr = err as grpc.ServiceError & Error;
       if (grpcErr.code === grpc.status.UNAVAILABLE && attempt < MAX_RETRIES - 1) {
         lastError = grpcErr;
-        await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
+        await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
         continue;
       }
       throw mapGrpcError(grpcErr, toolName);
     }
   }
-  throw mapGrpcError(lastError as (grpc.ServiceError & Error), toolName);
+  throw mapGrpcError(lastError as grpc.ServiceError & Error, toolName);
 }
 
 function mapGrpcError(err: grpc.ServiceError & Error, context: string): McpToolError {

--- a/xiNAS-MCP/src/grpc/config.ts
+++ b/xiNAS-MCP/src/grpc/config.ts
@@ -25,11 +25,15 @@ export interface ConfigApplyRequest {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type GrpcClient = any;
 
-export const configBackup = (client: GrpcClient, req: ConfigBackupRequest): Promise<XRaidResponse> =>
-  callRpc(client.configBackup.bind(client), req);
+export const configBackup = (
+  client: GrpcClient,
+  req: ConfigBackupRequest,
+): Promise<XRaidResponse> => callRpc(client.configBackup.bind(client), req);
 
-export const configRestore = (client: GrpcClient, req: ConfigRestoreRequest): Promise<XRaidResponse> =>
-  callRpc(client.configRestore.bind(client), req);
+export const configRestore = (
+  client: GrpcClient,
+  req: ConfigRestoreRequest,
+): Promise<XRaidResponse> => callRpc(client.configRestore.bind(client), req);
 
 export const configShow = (client: GrpcClient, req: ConfigShowRequest): Promise<XRaidResponse> =>
   callRpc(client.configShow.bind(client), req);

--- a/xiNAS-MCP/src/grpc/drive.ts
+++ b/xiNAS-MCP/src/grpc/drive.ts
@@ -25,11 +25,15 @@ export interface DriveCleanRequest {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type GrpcClient = any;
 
-export const driveFaultyCountShow = (client: GrpcClient, req: DriveFaultyCountShowRequest): Promise<XRaidResponse> =>
-  callRpc(client.driveFaultyCountShow.bind(client), req);
+export const driveFaultyCountShow = (
+  client: GrpcClient,
+  req: DriveFaultyCountShowRequest,
+): Promise<XRaidResponse> => callRpc(client.driveFaultyCountShow.bind(client), req);
 
-export const driveFaultyCountReset = (client: GrpcClient, req: DriveFaultyCountResetRequest): Promise<XRaidResponse> =>
-  callRpc(client.driveFaultyCountReset.bind(client), req);
+export const driveFaultyCountReset = (
+  client: GrpcClient,
+  req: DriveFaultyCountResetRequest,
+): Promise<XRaidResponse> => callRpc(client.driveFaultyCountReset.bind(client), req);
 
 export const driveLocate = (client: GrpcClient, req: DriveLocateRequest): Promise<XRaidResponse> =>
   callRpc(client.driveLocate.bind(client), req);

--- a/xiNAS-MCP/src/grpc/license.ts
+++ b/xiNAS-MCP/src/grpc/license.ts
@@ -15,8 +15,10 @@ type GrpcClient = any;
 export const licenseShow = (client: GrpcClient): Promise<XRaidResponse> =>
   callRpc(client.licenseShow.bind(client), {});
 
-export const licenseUpdate = (client: GrpcClient, req: LicenseUpdateRequest): Promise<XRaidResponse> =>
-  callRpc(client.licenseUpdate.bind(client), req);
+export const licenseUpdate = (
+  client: GrpcClient,
+  req: LicenseUpdateRequest,
+): Promise<XRaidResponse> => callRpc(client.licenseUpdate.bind(client), req);
 
 export const licenseDelete = (client: GrpcClient): Promise<XRaidResponse> =>
   callRpc(client.licenseDelete.bind(client), {});

--- a/xiNAS-MCP/src/grpc/mail.ts
+++ b/xiNAS-MCP/src/grpc/mail.ts
@@ -5,8 +5,13 @@
 
 import { callRpc, type XRaidResponse } from './responseParser.js';
 
-export interface MailAddRequest { address: string; level: string }
-export interface MailRemoveRequest { address: string }
+export interface MailAddRequest {
+  address: string;
+  level: string;
+}
+export interface MailRemoveRequest {
+  address: string;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type GrpcClient = any;

--- a/xiNAS-MCP/src/grpc/pool.ts
+++ b/xiNAS-MCP/src/grpc/pool.ts
@@ -5,14 +5,36 @@
 
 import { callRpc, type XRaidResponse } from './responseParser.js';
 
-export interface PoolCreateRequest { name: string; drives: string[] }
-export interface PoolDeleteRequest { name: string }
-export interface PoolAddRequest { name: string; drives: string[] }
-export interface PoolRemoveRequest { name: string; drives: string[] }
-export interface PoolShowRequest { name?: string; units?: string }
-export interface PoolActivateRequest { name: string }
-export interface PoolDeactivateRequest { name: string }
-export interface PoolAcquireRequest { name: string; size: number; discardable?: boolean }
+export interface PoolCreateRequest {
+  name: string;
+  drives: string[];
+}
+export interface PoolDeleteRequest {
+  name: string;
+}
+export interface PoolAddRequest {
+  name: string;
+  drives: string[];
+}
+export interface PoolRemoveRequest {
+  name: string;
+  drives: string[];
+}
+export interface PoolShowRequest {
+  name?: string;
+  units?: string;
+}
+export interface PoolActivateRequest {
+  name: string;
+}
+export interface PoolDeactivateRequest {
+  name: string;
+}
+export interface PoolAcquireRequest {
+  name: string;
+  size: number;
+  discardable?: boolean;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type GrpcClient = any;
@@ -32,11 +54,15 @@ export const poolRemove = (client: GrpcClient, req: PoolRemoveRequest): Promise<
 export const poolShow = (client: GrpcClient, req: PoolShowRequest): Promise<XRaidResponse> =>
   callRpc(client.poolShow.bind(client), req);
 
-export const poolActivate = (client: GrpcClient, req: PoolActivateRequest): Promise<XRaidResponse> =>
-  callRpc(client.poolActivate.bind(client), req);
+export const poolActivate = (
+  client: GrpcClient,
+  req: PoolActivateRequest,
+): Promise<XRaidResponse> => callRpc(client.poolActivate.bind(client), req);
 
-export const poolDeactivate = (client: GrpcClient, req: PoolDeactivateRequest): Promise<XRaidResponse> =>
-  callRpc(client.poolDeactivate.bind(client), req);
+export const poolDeactivate = (
+  client: GrpcClient,
+  req: PoolDeactivateRequest,
+): Promise<XRaidResponse> => callRpc(client.poolDeactivate.bind(client), req);
 
 export const poolAcquire = (client: GrpcClient, req: PoolAcquireRequest): Promise<XRaidResponse> =>
   callRpc(client.poolAcquire.bind(client), req);

--- a/xiNAS-MCP/src/grpc/raid.ts
+++ b/xiNAS-MCP/src/grpc/raid.ts
@@ -93,12 +93,22 @@ export interface RaidRestoreRequest {
   service?: boolean;
 }
 
-export interface RaidInitStartRequest { name: string }
-export interface RaidInitStopRequest { name: string }
-export interface RaidInitResetRequest { name: string }
+export interface RaidInitStartRequest {
+  name: string;
+}
+export interface RaidInitStopRequest {
+  name: string;
+}
+export interface RaidInitResetRequest {
+  name: string;
+}
 
-export interface RaidReconStartRequest { name: string }
-export interface RaidReconStopRequest { name: string }
+export interface RaidReconStartRequest {
+  name: string;
+}
+export interface RaidReconStopRequest {
+  name: string;
+}
 
 export interface RaidRestripeStartRequest {
   name: string;
@@ -106,8 +116,12 @@ export interface RaidRestripeStartRequest {
   drives: string[];
   group_size?: number;
 }
-export interface RaidRestripeContinueRequest { name: string }
-export interface RaidRestripeStopRequest { name: string }
+export interface RaidRestripeContinueRequest {
+  name: string;
+}
+export interface RaidRestripeStopRequest {
+  name: string;
+}
 
 export interface RaidReplaceRequest {
   name: string;
@@ -115,7 +129,9 @@ export interface RaidReplaceRequest {
   drive: string;
 }
 
-export interface RaidResizeRequest { name: string }
+export interface RaidResizeRequest {
+  name: string;
+}
 
 export interface RaidImportShowRequest {
   drives?: string[];
@@ -150,26 +166,40 @@ export const raidUnload = (client: GrpcClient, req: RaidUnloadRequest): Promise<
 export const raidRestore = (client: GrpcClient, req: RaidRestoreRequest): Promise<XRaidResponse> =>
   callRpc(client.raidRestore.bind(client), req);
 
-export const raidInitStart = (client: GrpcClient, req: RaidInitStartRequest): Promise<XRaidResponse> =>
-  callRpc(client.raidInitStart.bind(client), req);
+export const raidInitStart = (
+  client: GrpcClient,
+  req: RaidInitStartRequest,
+): Promise<XRaidResponse> => callRpc(client.raidInitStart.bind(client), req);
 
-export const raidInitStop = (client: GrpcClient, req: RaidInitStopRequest): Promise<XRaidResponse> =>
-  callRpc(client.raidInitStop.bind(client), req);
+export const raidInitStop = (
+  client: GrpcClient,
+  req: RaidInitStopRequest,
+): Promise<XRaidResponse> => callRpc(client.raidInitStop.bind(client), req);
 
-export const raidReconStart = (client: GrpcClient, req: RaidReconStartRequest): Promise<XRaidResponse> =>
-  callRpc(client.raidReconStart.bind(client), req);
+export const raidReconStart = (
+  client: GrpcClient,
+  req: RaidReconStartRequest,
+): Promise<XRaidResponse> => callRpc(client.raidReconStart.bind(client), req);
 
-export const raidReconStop = (client: GrpcClient, req: RaidReconStopRequest): Promise<XRaidResponse> =>
-  callRpc(client.raidReconStop.bind(client), req);
+export const raidReconStop = (
+  client: GrpcClient,
+  req: RaidReconStopRequest,
+): Promise<XRaidResponse> => callRpc(client.raidReconStop.bind(client), req);
 
-export const raidRestripeStart = (client: GrpcClient, req: RaidRestripeStartRequest): Promise<XRaidResponse> =>
-  callRpc(client.raidRestripeStart.bind(client), req);
+export const raidRestripeStart = (
+  client: GrpcClient,
+  req: RaidRestripeStartRequest,
+): Promise<XRaidResponse> => callRpc(client.raidRestripeStart.bind(client), req);
 
-export const raidRestripeContinue = (client: GrpcClient, req: RaidRestripeContinueRequest): Promise<XRaidResponse> =>
-  callRpc(client.raidRestripeContinue.bind(client), req);
+export const raidRestripeContinue = (
+  client: GrpcClient,
+  req: RaidRestripeContinueRequest,
+): Promise<XRaidResponse> => callRpc(client.raidRestripeContinue.bind(client), req);
 
-export const raidRestripeStop = (client: GrpcClient, req: RaidRestripeStopRequest): Promise<XRaidResponse> =>
-  callRpc(client.raidRestripeStop.bind(client), req);
+export const raidRestripeStop = (
+  client: GrpcClient,
+  req: RaidRestripeStopRequest,
+): Promise<XRaidResponse> => callRpc(client.raidRestripeStop.bind(client), req);
 
 export const raidReplace = (client: GrpcClient, req: RaidReplaceRequest): Promise<XRaidResponse> =>
   callRpc(client.raidReplace.bind(client), req);
@@ -177,9 +207,13 @@ export const raidReplace = (client: GrpcClient, req: RaidReplaceRequest): Promis
 export const raidResize = (client: GrpcClient, req: RaidResizeRequest): Promise<XRaidResponse> =>
   callRpc(client.raidResize.bind(client), req);
 
-export const raidImportShow = (client: GrpcClient, req: RaidImportShowRequest): Promise<XRaidResponse> =>
-  callRpc(client.raidImportShow.bind(client), req);
+export const raidImportShow = (
+  client: GrpcClient,
+  req: RaidImportShowRequest,
+): Promise<XRaidResponse> => callRpc(client.raidImportShow.bind(client), req);
 
-export const raidImportApply = (client: GrpcClient, req: RaidImportApplyRequest): Promise<XRaidResponse> =>
-  callRpc(client.raidImportApply.bind(client), req);
+export const raidImportApply = (
+  client: GrpcClient,
+  req: RaidImportApplyRequest,
+): Promise<XRaidResponse> => callRpc(client.raidImportApply.bind(client), req);
 /* eslint-enable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */

--- a/xiNAS-MCP/src/grpc/responseParser.ts
+++ b/xiNAS-MCP/src/grpc/responseParser.ts
@@ -44,7 +44,7 @@ export function parseResponse(response: { message?: string }): XRaidResponse {
 export function callRpc<TRequest, TResponse extends { message?: string }>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   rpcMethod: (req: TRequest, cb: (err: Error | null, res: TResponse) => void) => any,
-  request: TRequest
+  request: TRequest,
 ): Promise<XRaidResponse> {
   return new Promise((resolve, reject) => {
     rpcMethod(request, (err: Error | null, response: TResponse) => {

--- a/xiNAS-MCP/src/grpc/settings.ts
+++ b/xiNAS-MCP/src/grpc/settings.ts
@@ -26,8 +26,10 @@ export interface SettingsMailModifyRequest {
   progress_polling_interval?: number;
 }
 
-export const settingsMailModify = (client: GrpcClient, req: SettingsMailModifyRequest): Promise<XRaidResponse> =>
-  callRpc(client.settingsMailModify.bind(client), req);
+export const settingsMailModify = (
+  client: GrpcClient,
+  req: SettingsMailModifyRequest,
+): Promise<XRaidResponse> => callRpc(client.settingsMailModify.bind(client), req);
 
 export const settingsPoolShow = (client: GrpcClient): Promise<XRaidResponse> =>
   callRpc(client.settingsPoolShow.bind(client), {});

--- a/xiNAS-MCP/src/middleware/audit.ts
+++ b/xiNAS-MCP/src/middleware/audit.ts
@@ -40,8 +40,13 @@ function writeSyslog(message: string): void {
     const buf = Buffer.from(msg);
     // Best-effort connection to /dev/log Unix socket
     const conn = net.createConnection('/dev/log');
-    conn.on('connect', () => { conn.write(buf); conn.end(); });
-    conn.on('error', () => { /* ignore */ });
+    conn.on('connect', () => {
+      conn.write(buf);
+      conn.end();
+    });
+    conn.on('error', () => {
+      /* ignore */
+    });
   } catch {
     // Syslog is best-effort — never fail the main operation
   }

--- a/xiNAS-MCP/src/middleware/locking.ts
+++ b/xiNAS-MCP/src/middleware/locking.ts
@@ -18,12 +18,14 @@ export class ArrayLockManager {
       const existing = this.locks.get(arrayId)!;
       throw new McpToolError(
         ErrorCode.CONFLICT,
-        `Array '${arrayId}' is currently locked by '${existing.owner}'. Try again after it completes.`
+        `Array '${arrayId}' is currently locked by '${existing.owner}'. Try again after it completes.`,
       );
     }
 
     let resolve!: () => void;
-    const promise = new Promise<void>(r => { resolve = r; });
+    const promise = new Promise<void>((r) => {
+      resolve = r;
+    });
     this.locks.set(arrayId, { promise, owner: toolName, resolve });
 
     try {

--- a/xiNAS-MCP/src/middleware/planApply.ts
+++ b/xiNAS-MCP/src/middleware/planApply.ts
@@ -44,10 +44,7 @@ function inferOperation(plan: PlanResult): string | null {
   }
 }
 
-export async function applyWithPlan<T>(
-  mode: Mode,
-  ctx: PlanContext<T>
-): Promise<PlanResult | T> {
+export async function applyWithPlan<T>(mode: Mode, ctx: PlanContext<T>): Promise<PlanResult | T> {
   const plan = await ctx.preflight();
 
   if (mode === 'plan') {
@@ -59,7 +56,7 @@ export async function applyWithPlan<T>(
     throw new McpToolError(
       ErrorCode.PRECONDITION_FAILED,
       `Preflight checks failed. Blocking resources: ${plan.blocking_resources?.join(', ') ?? 'unknown'}`,
-      { plan }
+      { plan },
     );
   }
 

--- a/xiNAS-MCP/src/middleware/rbac.ts
+++ b/xiNAS-MCP/src/middleware/rbac.ts
@@ -82,7 +82,7 @@ export function checkPermission(toolName: string, ctx: CallContext): void {
   if (principalRank < requiredRank) {
     throw new McpToolError(
       ErrorCode.PERMISSION_DENIED,
-      `Tool '${toolName}' requires role '${required}'. Principal '${ctx.principal}' has role '${ctx.role}'.`
+      `Tool '${toolName}' requires role '${required}'. Principal '${ctx.principal}' has role '${ctx.role}'.`,
     );
   }
 }

--- a/xiNAS-MCP/src/os/configHistory.ts
+++ b/xiNAS-MCP/src/os/configHistory.ts
@@ -26,7 +26,12 @@ function run(args: string[], timeoutMs: number): Promise<ExecResult> {
   return new Promise((resolve, reject) => {
     execFile(PYTHON, ['-m', MODULE, ...args], { timeout: timeoutMs }, (err, stdout, stderr) => {
       if (err && 'killed' in err && err.killed) {
-        reject(new McpToolError(ErrorCode.TIMEOUT, `Config-history command timed out after ${timeoutMs}ms`));
+        reject(
+          new McpToolError(
+            ErrorCode.TIMEOUT,
+            `Config-history command timed out after ${timeoutMs}ms`,
+          ),
+        );
         return;
       }
       // execFile sets err for non-zero exit but we handle it ourselves
@@ -45,24 +50,35 @@ function parseJsonOutput(result: ExecResult): unknown {
       throw new McpToolError(code, errObj.error ?? result.stderr.trim());
     } catch (e) {
       if (e instanceof McpToolError) throw e;
-      throw new McpToolError(ErrorCode.INTERNAL, result.stderr.trim() || 'Config-history command failed');
+      throw new McpToolError(
+        ErrorCode.INTERNAL,
+        result.stderr.trim() || 'Config-history command failed',
+      );
     }
   }
 
   try {
     return JSON.parse(result.stdout);
   } catch {
-    throw new McpToolError(ErrorCode.INTERNAL, `Failed to parse config-history output: ${result.stdout.slice(0, 200)}`);
+    throw new McpToolError(
+      ErrorCode.INTERNAL,
+      `Failed to parse config-history output: ${result.stdout.slice(0, 200)}`,
+    );
   }
 }
 
 function mapErrorCode(code?: string): ErrorCode {
   switch (code) {
-    case 'NOT_FOUND': return ErrorCode.NOT_FOUND;
-    case 'CONFLICT': return ErrorCode.CONFLICT;
-    case 'PRECONDITION_FAILED': return ErrorCode.PRECONDITION_FAILED;
-    case 'RESOURCE_EXHAUSTION': return ErrorCode.RESOURCE_EXHAUSTION;
-    default: return ErrorCode.INTERNAL;
+    case 'NOT_FOUND':
+      return ErrorCode.NOT_FOUND;
+    case 'CONFLICT':
+      return ErrorCode.CONFLICT;
+    case 'PRECONDITION_FAILED':
+      return ErrorCode.PRECONDITION_FAILED;
+    case 'RESOURCE_EXHAUSTION':
+      return ErrorCode.RESOURCE_EXHAUSTION;
+    default:
+      return ErrorCode.INTERNAL;
   }
 }
 
@@ -79,7 +95,9 @@ export async function showSnapshot(id: string): Promise<unknown> {
 }
 
 export async function diffSnapshots(fromId: string, toId: string): Promise<unknown> {
-  return parseJsonOutput(await run(['snapshot', 'diff', fromId, toId, '--format', 'json'], READ_TIMEOUT_MS));
+  return parseJsonOutput(
+    await run(['snapshot', 'diff', fromId, toId, '--format', 'json'], READ_TIMEOUT_MS),
+  );
 }
 
 export async function checkDrift(): Promise<unknown> {
@@ -91,7 +109,16 @@ export async function getStatus(): Promise<unknown> {
 }
 
 export async function createSnapshot(operation: string, diffSummary?: string): Promise<unknown> {
-  const args = ['snapshot', 'create', '--source', 'mcp', '--operation', operation, '--format', 'json'];
+  const args = [
+    'snapshot',
+    'create',
+    '--source',
+    'mcp',
+    '--operation',
+    operation,
+    '--format',
+    'json',
+  ];
   if (diffSummary) args.push('--diff-summary', diffSummary);
   return parseJsonOutput(await run(args, WRITE_TIMEOUT_MS));
 }
@@ -100,7 +127,10 @@ export async function createSnapshot(operation: string, diffSummary?: string): P
  * Record a snapshot after a successful mutation.
  * Best-effort: errors are caught and returned as null.
  */
-export async function recordSnapshot(operation: string, diffSummary: string): Promise<unknown | null> {
+export async function recordSnapshot(
+  operation: string,
+  diffSummary: string,
+): Promise<unknown | null> {
   try {
     return await createSnapshot(operation, diffSummary);
   } catch {
@@ -113,7 +143,10 @@ export async function getRetentionPolicy(): Promise<unknown> {
   return parseJsonOutput(await run(['gc', 'policy', '--format', 'json'], READ_TIMEOUT_MS));
 }
 
-export async function setRetentionPolicy(maxSnapshots?: number, maxAgeDays?: number): Promise<unknown> {
+export async function setRetentionPolicy(
+  maxSnapshots?: number,
+  maxAgeDays?: number,
+): Promise<unknown> {
   const args = ['gc', 'policy', '--set', '--format', 'json'];
   if (maxSnapshots !== undefined) args.push('--max-snapshots', String(maxSnapshots));
   if (maxAgeDays !== undefined) args.push('--max-age-days', String(maxAgeDays));

--- a/xiNAS-MCP/src/os/diskInfo.ts
+++ b/xiNAS-MCP/src/os/diskInfo.ts
@@ -29,11 +29,19 @@ export interface NvmeHealth {
 }
 
 function readFile(p: string): string {
-  try { return fs.readFileSync(p, 'utf8').trim(); } catch { return ''; }
+  try {
+    return fs.readFileSync(p, 'utf8').trim();
+  } catch {
+    return '';
+  }
 }
 
 function listDir(p: string): string[] {
-  try { return fs.readdirSync(p); } catch { return []; }
+  try {
+    return fs.readdirSync(p);
+  } catch {
+    return [];
+  }
 }
 
 function readNvmeHealth(ctrlName: string): NvmeHealth {
@@ -41,7 +49,7 @@ function readNvmeHealth(ctrlName: string): NvmeHealth {
 
   // Temperature from hwmon
   let temperature_celsius: number | null = null;
-  const hwmons = listDir(base).filter(e => e.startsWith('hwmon'));
+  const hwmons = listDir(base).filter((e) => e.startsWith('hwmon'));
   for (const hwmon of hwmons) {
     const tempRaw = readFile(path.join(base, hwmon, 'temp1_input'));
     if (tempRaw) {
@@ -51,8 +59,8 @@ function readNvmeHealth(ctrlName: string): NvmeHealth {
   }
 
   // NVMe health log fields from sysfs
-  const parseHex = (v: string) => v ? parseInt(v, 16) : null;
-  const parseInt10 = (v: string) => v ? parseInt(v, 10) : null;
+  const parseHex = (v: string) => (v ? parseInt(v, 16) : null);
+  const parseInt10 = (v: string) => (v ? parseInt(v, 10) : null);
 
   const availSpareRaw = readFile(path.join(base, 'available_spare'));
   const mediaErrorsRaw = readFile(path.join(base, 'media_errors'));
@@ -93,7 +101,12 @@ export function listBlockDevices(): BlockDeviceInfo[] {
 
   for (const dev of devices) {
     // Skip partitions and loop devices
-    if (/\d$/.test(dev) || dev.startsWith('loop') || dev.startsWith('dm-') || dev.startsWith('sr')) {
+    if (
+      /\d$/.test(dev) ||
+      dev.startsWith('loop') ||
+      dev.startsWith('dm-') ||
+      dev.startsWith('sr')
+    ) {
       continue;
     }
     // Include nvme namespaces and sata drives
@@ -102,11 +115,12 @@ export function listBlockDevices(): BlockDeviceInfo[] {
     const base = path.join(blockDir, dev);
     const devicePath = `/dev/${dev}`;
 
-    const model = readFile(path.join(base, 'device/model')) ||
-                  readFile(path.join(base, 'device/device/model'));
+    const model =
+      readFile(path.join(base, 'device/model')) || readFile(path.join(base, 'device/device/model'));
     const serial = readFile(path.join(base, 'device/serial'));
-    const firmware = readFile(path.join(base, 'device/firmware_rev')) ||
-                     readFile(path.join(base, 'device/firmware_version'));
+    const firmware =
+      readFile(path.join(base, 'device/firmware_rev')) ||
+      readFile(path.join(base, 'device/firmware_version'));
 
     const sizeRaw = readFile(path.join(base, 'size'));
     const size_bytes = sizeRaw ? parseInt(sizeRaw) * 512 : 0;

--- a/xiNAS-MCP/src/os/healthEngine.ts
+++ b/xiNAS-MCP/src/os/healthEngine.ts
@@ -37,15 +37,12 @@ const PROFILE_TIMEOUT_MS: Record<string, number> = {
 };
 
 /** Directories to search for profile YAML files (same order as runner.py) */
-const PROFILE_DIRS = [
-  '/opt/xiNAS/healthcheck_profiles',
-  '/home/xinnor/xiNAS/healthcheck_profiles',
-];
+const PROFILE_DIRS = ['/opt/xiNAS/healthcheck_profiles', '/home/xinnor/xiNAS/healthcheck_profiles'];
 
 export interface EngineCheckResult {
   section: string;
   name: string;
-  status: string;  // PASS, WARN, FAIL, SKIP
+  status: string; // PASS, WARN, FAIL, SKIP
   actual: string;
   expected: string;
   evidence: string;
@@ -87,28 +84,34 @@ function findProfilePath(profile: string): string {
 
 function run(args: string[], timeoutMs: number): Promise<ExecResult> {
   return new Promise((resolve, reject) => {
-    execFile(resolvePython(), ['-m', MODULE, ...args], { timeout: timeoutMs }, (err, stdout, stderr) => {
-      if (err && 'killed' in err && err.killed) {
-        reject(new McpToolError(ErrorCode.TIMEOUT, `Health engine timed out after ${timeoutMs}ms`));
-        return;
-      }
-      const exitCode = err && 'code' in err ? (err.code as number) : 0;
-      resolve({ stdout: stdout ?? '', stderr: stderr ?? '', exitCode });
-    });
+    execFile(
+      resolvePython(),
+      ['-m', MODULE, ...args],
+      { timeout: timeoutMs },
+      (err, stdout, stderr) => {
+        if (err && 'killed' in err && err.killed) {
+          reject(
+            new McpToolError(ErrorCode.TIMEOUT, `Health engine timed out after ${timeoutMs}ms`),
+          );
+          return;
+        }
+        const exitCode = err && 'code' in err ? (err.code as number) : 0;
+        resolve({ stdout: stdout ?? '', stderr: stderr ?? '', exitCode });
+      },
+    );
   });
 }
 
 /**
  * Run the Python health engine with the given profile and return the parsed report.
  */
-export async function runEngineCheck(profile: 'quick' | 'standard' | 'deep'): Promise<EngineReport> {
+export async function runEngineCheck(
+  profile: 'quick' | 'standard' | 'deep',
+): Promise<EngineReport> {
   const profilePath = findProfilePath(profile);
   const timeoutMs = PROFILE_TIMEOUT_MS[profile] ?? 300_000;
 
-  const result = await run(
-    [profilePath, '/tmp', '--json', '--no-save'],
-    timeoutMs,
-  );
+  const result = await run([profilePath, '/tmp', '--json', '--no-save'], timeoutMs);
 
   if (result.exitCode !== 0) {
     throw new McpToolError(

--- a/xiNAS-MCP/src/os/networkInfo.ts
+++ b/xiNAS-MCP/src/os/networkInfo.ts
@@ -27,19 +27,37 @@ export interface InterfaceInfo {
 }
 
 function readFile(p: string): string {
-  try { return fs.readFileSync(p, 'utf8').trim(); } catch { return ''; }
+  try {
+    return fs.readFileSync(p, 'utf8').trim();
+  } catch {
+    return '';
+  }
 }
 
 function listDir(p: string): string[] {
-  try { return fs.readdirSync(p); } catch { return []; }
+  try {
+    return fs.readdirSync(p);
+  } catch {
+    return [];
+  }
 }
 
 /** Parse /proc/net/dev — returns map of iface -> {rx_bytes, tx_bytes, ...} */
-function parseNetDev(): Map<string, {
-  rx_bytes: number; rx_errors: number; rx_dropped: number;
-  tx_bytes: number; tx_errors: number; tx_dropped: number;
-}> {
-  const result = new Map<string, ReturnType<typeof parseNetDev> extends Map<string, infer V> ? V : never>();
+function parseNetDev(): Map<
+  string,
+  {
+    rx_bytes: number;
+    rx_errors: number;
+    rx_dropped: number;
+    tx_bytes: number;
+    tx_errors: number;
+    tx_dropped: number;
+  }
+> {
+  const result = new Map<
+    string,
+    ReturnType<typeof parseNetDev> extends Map<string, infer V> ? V : never
+  >();
   const content = readFile('/proc/net/dev');
   for (const line of content.split('\n').slice(2)) {
     const parts = line.trim().split(/\s+/);
@@ -130,8 +148,12 @@ export function listInterfaces(): InterfaceInfo[] {
     const duplex = duplexRaw || null;
 
     const stats = netDevStats.get(iface) ?? {
-      rx_bytes: 0, rx_errors: 0, rx_dropped: 0,
-      tx_bytes: 0, tx_errors: 0, tx_dropped: 0,
+      rx_bytes: 0,
+      rx_errors: 0,
+      rx_dropped: 0,
+      tx_bytes: 0,
+      tx_errors: 0,
+      tx_dropped: 0,
     };
 
     const bondInfo = parseBondInfo(iface);

--- a/xiNAS-MCP/src/os/nfsClient.ts
+++ b/xiNAS-MCP/src/os/nfsClient.ts
@@ -61,10 +61,12 @@ async function send(req: NfsRequest): Promise<NfsResponse> {
       if (!done) {
         done = true;
         clearTimeout(timeout);
-        reject(new McpToolError(
-          ErrorCode.INTERNAL,
-          `Cannot connect to nfs-helper at ${socketPath}: ${err.message}. Is xinas-nfs-helper.service running?`
-        ));
+        reject(
+          new McpToolError(
+            ErrorCode.INTERNAL,
+            `Cannot connect to nfs-helper at ${socketPath}: ${err.message}. Is xinas-nfs-helper.service running?`,
+          ),
+        );
       }
     });
   });

--- a/xiNAS-MCP/src/os/prometheusClient.ts
+++ b/xiNAS-MCP/src/os/prometheusClient.ts
@@ -89,18 +89,18 @@ export async function getPerformanceSummary(
     if (err instanceof McpToolError) throw err;
     throw new McpToolError(
       ErrorCode.INTERNAL,
-      `Failed to fetch Prometheus metrics from ${url}: ${String(err)}`
+      `Failed to fetch Prometheus metrics from ${url}: ${String(err)}`,
     );
   }
 
   const allMetrics = parsePrometheusText(text);
 
   // Filter by metric names and target (raid_name or drive label)
-  const filtered = allMetrics.filter(m => {
+  const filtered = allMetrics.filter((m) => {
     if (metricNames.length > 0 && !metricNames.includes(m.name)) return false;
     if (target && target !== '*') {
       // Check if any label value matches the target
-      return Object.values(m.labels).some(v => v === target);
+      return Object.values(m.labels).some((v) => v === target);
     }
     return true;
   });

--- a/xiNAS-MCP/src/os/systemInfo.ts
+++ b/xiNAS-MCP/src/os/systemInfo.ts
@@ -29,7 +29,11 @@ export interface SystemInfo {
 }
 
 function readFile(p: string): string {
-  try { return fs.readFileSync(p, 'utf8'); } catch { return ''; }
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return '';
+  }
 }
 
 function parseKeyValue(content: string): Record<string, string> {
@@ -89,10 +93,12 @@ export function getSystemInfo(): SystemInfo {
   try {
     const numaDir = '/sys/devices/system/node';
     if (fs.existsSync(numaDir)) {
-      const entries = fs.readdirSync(numaDir).filter(e => /^node\d+$/.test(e));
+      const entries = fs.readdirSync(numaDir).filter((e) => /^node\d+$/.test(e));
       if (entries.length > 0) numa_nodes = entries.length;
     }
-  } catch { /* */ }
+  } catch {
+    /* */
+  }
 
   // /etc/os-release
   const osRelease = parseOsRelease(readFile('/etc/os-release'));
@@ -147,23 +153,17 @@ export function checkNfsReadiness(): NfsReadiness {
   const blocking: string[] = [];
 
   if (!fs.existsSync('/usr/sbin/exportfs')) {
-    blocking.push(
-      'nfs-kernel-server package is not installed (missing /usr/sbin/exportfs)'
-    );
+    blocking.push('nfs-kernel-server package is not installed (missing /usr/sbin/exportfs)');
   }
 
   const nfsServer = getServiceState('nfs-server');
   if (!nfsServer.active) {
-    blocking.push(
-      `nfs-server.service is ${nfsServer.state} — NFS daemon is not running`
-    );
+    blocking.push(`nfs-server.service is ${nfsServer.state} — NFS daemon is not running`);
   }
 
   const helper = getServiceState('xinas-nfs-helper');
   if (!helper.active) {
-    blocking.push(
-      `xinas-nfs-helper.service is ${helper.state} — NFS helper daemon is not running`
-    );
+    blocking.push(`xinas-nfs-helper.service is ${helper.state} — NFS helper daemon is not running`);
   }
 
   return { ready: blocking.length === 0, blocking };

--- a/xiNAS-MCP/src/registry/toolRegistry.ts
+++ b/xiNAS-MCP/src/registry/toolRegistry.ts
@@ -14,96 +14,170 @@ import { loadConfig } from '../config/serverConfig.js';
 
 // Tool imports
 import {
-  GetServerInfoSchema, handleGetServerInfo,
-  ListControllersSchema, handleListControllers,
-  GetControllerCapabilitiesSchema, handleGetControllerCapabilities,
-  GetStatusSchema, handleGetStatus,
-  GetInventorySchema, handleGetInventory,
-  GetPerformanceSchema, handleGetPerformance,
-  GetLogsSchema, handleGetLogs,
+  GetServerInfoSchema,
+  handleGetServerInfo,
+  ListControllersSchema,
+  handleListControllers,
+  GetControllerCapabilitiesSchema,
+  handleGetControllerCapabilities,
+  GetStatusSchema,
+  handleGetStatus,
+  GetInventorySchema,
+  handleGetInventory,
+  GetPerformanceSchema,
+  handleGetPerformance,
+  GetLogsSchema,
+  handleGetLogs,
 } from '../tools/system.js';
 
-import { NetworkListSchema, handleNetworkList, NetworkConfigureSchema, handleNetworkConfigure } from '../tools/network.js';
+import {
+  NetworkListSchema,
+  handleNetworkList,
+  NetworkConfigureSchema,
+  handleNetworkConfigure,
+} from '../tools/network.js';
 
 import {
-  HealthRunCheckSchema, handleHealthRunCheck,
-  HealthGetAlertsSchema, handleHealthGetAlerts,
-  HealthFixNfsConfSchema, handleHealthFixNfsConf,
+  HealthRunCheckSchema,
+  handleHealthRunCheck,
+  HealthGetAlertsSchema,
+  handleHealthGetAlerts,
+  HealthFixNfsConfSchema,
+  handleHealthFixNfsConf,
 } from '../tools/health.js';
 
 import {
-  DiskListSchema, handleDiskList,
-  DiskGetSmartSchema, handleDiskGetSmart,
-  DiskRunSelftestSchema, handleDiskRunSelftest,
-  DiskSetLedSchema, handleDiskSetLed,
-  DiskSecureEraseSchema, handleDiskSecureErase,
+  DiskListSchema,
+  handleDiskList,
+  DiskGetSmartSchema,
+  handleDiskGetSmart,
+  DiskRunSelftestSchema,
+  handleDiskRunSelftest,
+  DiskSetLedSchema,
+  handleDiskSetLed,
+  DiskSecureEraseSchema,
+  handleDiskSecureErase,
 } from '../tools/disk.js';
 
 import {
-  RaidListSchema, handleRaidList,
-  RaidCreateSchema, handleRaidCreate,
-  RaidModifyPerformanceSchema, handleRaidModifyPerformance,
-  RaidLifecycleControlSchema, handleRaidLifecycleControl,
-  RaidUnloadSchema, handleRaidUnload,
-  RaidRestoreSchema, handleRaidRestore,
-  RaidDeleteSchema, handleRaidDelete,
+  RaidListSchema,
+  handleRaidList,
+  RaidCreateSchema,
+  handleRaidCreate,
+  RaidModifyPerformanceSchema,
+  handleRaidModifyPerformance,
+  RaidLifecycleControlSchema,
+  handleRaidLifecycleControl,
+  RaidUnloadSchema,
+  handleRaidUnload,
+  RaidRestoreSchema,
+  handleRaidRestore,
+  RaidDeleteSchema,
+  handleRaidDelete,
 } from '../tools/raid.js';
 
 import {
-  ShareListSchema, handleShareList,
-  ShareGetActiveSessionsSchema, handleShareGetActiveSessions,
-  ShareCreateSchema, handleShareCreate,
-  ShareUpdatePolicySchema, handleShareUpdatePolicy,
-  ShareSetQuotaSchema, handleShareSetQuota,
-  ShareDeleteSchema, handleShareDelete,
+  ShareListSchema,
+  handleShareList,
+  ShareGetActiveSessionsSchema,
+  handleShareGetActiveSessions,
+  ShareCreateSchema,
+  handleShareCreate,
+  ShareUpdatePolicySchema,
+  handleShareUpdatePolicy,
+  ShareSetQuotaSchema,
+  handleShareSetQuota,
+  ShareDeleteSchema,
+  handleShareDelete,
 } from '../tools/share.js';
 
 import {
-  AuthGetSupportedModesSchema, handleAuthGetSupportedModes,
-  AuthValidateKerberosSchema, handleAuthValidateKerberos,
-  AuthListUsersSchema, handleAuthListUsers,
-  AuthCreateUserSchema, handleAuthCreateUser,
-  AuthDeleteUserSchema, handleAuthDeleteUser,
-  AuthSetQuotaSchema, handleAuthSetQuota,
-  AuthListQuotasSchema, handleAuthListQuotas,
-  AuthChangePasswordSchema, handleAuthChangePassword,
-  AuthSetUserLockSchema, handleAuthSetUserLock,
-  AuthChangeShellSchema, handleAuthChangeShell,
-  AuthAddToGroupSchema, handleAuthAddToGroup,
-  AuthRemoveFromGroupSchema, handleAuthRemoveFromGroup,
+  AuthGetSupportedModesSchema,
+  handleAuthGetSupportedModes,
+  AuthValidateKerberosSchema,
+  handleAuthValidateKerberos,
+  AuthListUsersSchema,
+  handleAuthListUsers,
+  AuthCreateUserSchema,
+  handleAuthCreateUser,
+  AuthDeleteUserSchema,
+  handleAuthDeleteUser,
+  AuthSetQuotaSchema,
+  handleAuthSetQuota,
+  AuthListQuotasSchema,
+  handleAuthListQuotas,
+  AuthChangePasswordSchema,
+  handleAuthChangePassword,
+  AuthSetUserLockSchema,
+  handleAuthSetUserLock,
+  AuthChangeShellSchema,
+  handleAuthChangeShell,
+  AuthAddToGroupSchema,
+  handleAuthAddToGroup,
+  AuthRemoveFromGroupSchema,
+  handleAuthRemoveFromGroup,
 } from '../tools/auth.js';
 
 import {
-  PoolListSchema, handlePoolList,
-  PoolCreateSchema, handlePoolCreate,
-  PoolDeleteSchema, handlePoolDelete,
-  PoolAddDrivesSchema, handlePoolAddDrives,
-  PoolRemoveDrivesSchema, handlePoolRemoveDrives,
-  PoolActivateSchema, handlePoolActivate,
-  PoolDeactivateSchema, handlePoolDeactivate,
-  PoolAcquireSchema, handlePoolAcquire,
+  PoolListSchema,
+  handlePoolList,
+  PoolCreateSchema,
+  handlePoolCreate,
+  PoolDeleteSchema,
+  handlePoolDelete,
+  PoolAddDrivesSchema,
+  handlePoolAddDrives,
+  PoolRemoveDrivesSchema,
+  handlePoolRemoveDrives,
+  PoolActivateSchema,
+  handlePoolActivate,
+  PoolDeactivateSchema,
+  handlePoolDeactivate,
+  PoolAcquireSchema,
+  handlePoolAcquire,
 } from '../tools/pool.js';
 
 import {
-  MailListRecipientsSchema, handleMailListRecipients,
-  MailAddRecipientSchema, handleMailAddRecipient,
-  MailRemoveRecipientSchema, handleMailRemoveRecipient,
-  MailGetSettingsSchema, handleMailGetSettings,
-  MailUpdateSettingsSchema, handleMailUpdateSettings,
-  MailSendTestSchema, handleMailSendTest,
+  MailListRecipientsSchema,
+  handleMailListRecipients,
+  MailAddRecipientSchema,
+  handleMailAddRecipient,
+  MailRemoveRecipientSchema,
+  handleMailRemoveRecipient,
+  MailGetSettingsSchema,
+  handleMailGetSettings,
+  MailUpdateSettingsSchema,
+  handleMailUpdateSettings,
+  MailSendTestSchema,
+  handleMailSendTest,
 } from '../tools/mail.js';
 
-import { JobGetSchema, handleJobGet, JobListSchema, handleJobList, JobCancelSchema, handleJobCancel } from '../tools/job.js';
+import {
+  JobGetSchema,
+  handleJobGet,
+  JobListSchema,
+  handleJobList,
+  JobCancelSchema,
+  handleJobCancel,
+} from '../tools/job.js';
 
 import {
-  ConfigListSnapshotsSchema, handleConfigListSnapshots,
-  ConfigShowSnapshotSchema, handleConfigShowSnapshot,
-  ConfigDiffSnapshotsSchema, handleConfigDiffSnapshots,
-  ConfigCheckDriftSchema, handleConfigCheckDrift,
-  ConfigGetStatusSchema, handleConfigGetStatus,
-  ConfigRollbackSchema, handleConfigRollback,
-  ConfigGetRetentionSchema, handleConfigGetRetention,
-  ConfigSetRetentionSchema, handleConfigSetRetention,
+  ConfigListSnapshotsSchema,
+  handleConfigListSnapshots,
+  ConfigShowSnapshotSchema,
+  handleConfigShowSnapshot,
+  ConfigDiffSnapshotsSchema,
+  handleConfigDiffSnapshots,
+  ConfigCheckDriftSchema,
+  handleConfigCheckDrift,
+  ConfigGetStatusSchema,
+  handleConfigGetStatus,
+  ConfigRollbackSchema,
+  handleConfigRollback,
+  ConfigGetRetentionSchema,
+  handleConfigGetRetention,
+  ConfigSetRetentionSchema,
+  handleConfigSetRetention,
 } from '../tools/config.js';
 
 // --- Tool definition ---
@@ -118,74 +192,306 @@ interface ToolDef {
 
 const TOOLS: ToolDef[] = [
   // System
-  { name: 'system.get_server_info', description: 'Get MCP server info, version, and supported tool namespaces', schema: GetServerInfoSchema, handler: handleGetServerInfo },
-  { name: 'system.list_controllers', description: 'List available xiNAS controllers', schema: ListControllersSchema, handler: handleListControllers },
-  { name: 'system.get_controller_capabilities', description: 'Get RAID levels, NFS versions, auth modes, and license info for a controller', schema: GetControllerCapabilitiesSchema, handler: handleGetControllerCapabilities },
-  { name: 'system.get_status', description: 'Get controller status: uptime, OS, kernel, service states, load, memory', schema: GetStatusSchema, handler: handleGetStatus },
-  { name: 'system.get_inventory', description: 'Get hardware inventory: CPU, RAM, NICs, block devices', schema: GetInventorySchema, handler: handleGetInventory },
-  { name: 'system.get_performance', description: 'Get performance metrics (IOPS, throughput, latency) from Prometheus', schema: GetPerformanceSchema, handler: handleGetPerformance },
-  { name: 'system.get_logs', description: 'Get systemd journal entries for a service (journalctl)', schema: GetLogsSchema, handler: handleGetLogs },
+  {
+    name: 'system.get_server_info',
+    description: 'Get MCP server info, version, and supported tool namespaces',
+    schema: GetServerInfoSchema,
+    handler: handleGetServerInfo,
+  },
+  {
+    name: 'system.list_controllers',
+    description: 'List available xiNAS controllers',
+    schema: ListControllersSchema,
+    handler: handleListControllers,
+  },
+  {
+    name: 'system.get_controller_capabilities',
+    description: 'Get RAID levels, NFS versions, auth modes, and license info for a controller',
+    schema: GetControllerCapabilitiesSchema,
+    handler: handleGetControllerCapabilities,
+  },
+  {
+    name: 'system.get_status',
+    description: 'Get controller status: uptime, OS, kernel, service states, load, memory',
+    schema: GetStatusSchema,
+    handler: handleGetStatus,
+  },
+  {
+    name: 'system.get_inventory',
+    description: 'Get hardware inventory: CPU, RAM, NICs, block devices',
+    schema: GetInventorySchema,
+    handler: handleGetInventory,
+  },
+  {
+    name: 'system.get_performance',
+    description: 'Get performance metrics (IOPS, throughput, latency) from Prometheus',
+    schema: GetPerformanceSchema,
+    handler: handleGetPerformance,
+  },
+  {
+    name: 'system.get_logs',
+    description: 'Get systemd journal entries for a service (journalctl)',
+    schema: GetLogsSchema,
+    handler: handleGetLogs,
+  },
 
   // Network
-  { name: 'network.list', description: 'List network interfaces with link state, MTU, speeds, RDMA capability', schema: NetworkListSchema, handler: handleNetworkList },
-  { name: 'network.configure', description: 'Configure network interface: static IP, VLAN, bonding, RDMA parameters (plan/apply)', schema: NetworkConfigureSchema, handler: handleNetworkConfigure },
+  {
+    name: 'network.list',
+    description: 'List network interfaces with link state, MTU, speeds, RDMA capability',
+    schema: NetworkListSchema,
+    handler: handleNetworkList,
+  },
+  {
+    name: 'network.configure',
+    description:
+      'Configure network interface: static IP, VLAN, bonding, RDMA parameters (plan/apply)',
+    schema: NetworkConfigureSchema,
+    handler: handleNetworkConfigure,
+  },
 
   // Health
-  { name: 'health.run_check', description: 'Run health checks (quick/standard/deep): RAID, license, NFS, network, filesystem (XFS), sysctl, perf tuning, drives, memory, services', schema: HealthRunCheckSchema, handler: handleHealthRunCheck },
-  { name: 'health.get_alerts', description: 'Get active alerts from last health check run', schema: HealthGetAlertsSchema, handler: handleHealthGetAlerts },
-  { name: 'health.fix_nfs_conf', description: 'Apply /etc/nfs.conf fixes ([nfsd] threads/rdma or free-form section.key updates) and optionally restart nfs-server', schema: HealthFixNfsConfSchema, handler: handleHealthFixNfsConf },
+  {
+    name: 'health.run_check',
+    description:
+      'Run health checks (quick/standard/deep): RAID, license, NFS, network, filesystem (XFS), sysctl, perf tuning, drives, memory, services',
+    schema: HealthRunCheckSchema,
+    handler: handleHealthRunCheck,
+  },
+  {
+    name: 'health.get_alerts',
+    description: 'Get active alerts from last health check run',
+    schema: HealthGetAlertsSchema,
+    handler: handleHealthGetAlerts,
+  },
+  {
+    name: 'health.fix_nfs_conf',
+    description:
+      'Apply /etc/nfs.conf fixes ([nfsd] threads/rdma or free-form section.key updates) and optionally restart nfs-server',
+    schema: HealthFixNfsConfSchema,
+    handler: handleHealthFixNfsConf,
+  },
 
   // Disk
-  { name: 'disk.list', description: 'List block devices with RAID membership, health summary, and model info', schema: DiskListSchema, handler: handleDiskList },
-  { name: 'disk.get_smart', description: 'Get NVMe health log (SMART equivalent) for a drive', schema: DiskGetSmartSchema, handler: handleDiskGetSmart },
-  { name: 'disk.run_selftest', description: 'Run NVMe selftest (short or extended). Returns job_id.', schema: DiskRunSelftestSchema, handler: handleDiskRunSelftest },
-  { name: 'disk.set_led', description: 'Turn drive LED on (identify) or off', schema: DiskSetLedSchema, handler: handleDiskSetLed },
-  { name: 'disk.secure_erase', description: 'Securely erase a drive (DESTRUCTIVE, requires dangerous=true)', schema: DiskSecureEraseSchema, handler: handleDiskSecureErase },
+  {
+    name: 'disk.list',
+    description: 'List block devices with RAID membership, health summary, and model info',
+    schema: DiskListSchema,
+    handler: handleDiskList,
+  },
+  {
+    name: 'disk.get_smart',
+    description: 'Get NVMe health log (SMART equivalent) for a drive',
+    schema: DiskGetSmartSchema,
+    handler: handleDiskGetSmart,
+  },
+  {
+    name: 'disk.run_selftest',
+    description: 'Run NVMe selftest (short or extended). Returns job_id.',
+    schema: DiskRunSelftestSchema,
+    handler: handleDiskRunSelftest,
+  },
+  {
+    name: 'disk.set_led',
+    description: 'Turn drive LED on (identify) or off',
+    schema: DiskSetLedSchema,
+    handler: handleDiskSetLed,
+  },
+  {
+    name: 'disk.secure_erase',
+    description: 'Securely erase a drive (DESTRUCTIVE, requires dangerous=true)',
+    schema: DiskSecureEraseSchema,
+    handler: handleDiskSecureErase,
+  },
 
   // RAID
-  { name: 'raid.list', description: 'List RAID arrays with state, members, capacity, and rebuild progress', schema: RaidListSchema, handler: handleRaidList },
-  { name: 'raid.create', description: 'Create a new RAID array (plan/apply). Supports levels 0,1,5,6,7,10,50,60,70,N+M.', schema: RaidCreateSchema, handler: handleRaidCreate },
-  { name: 'raid.modify_performance', description: 'Modify RAID performance parameters (merge write/read, scheduler)', schema: RaidModifyPerformanceSchema, handler: handleRaidModifyPerformance },
-  { name: 'raid.lifecycle_control', description: 'Start/stop RAID initialization or reconstruction', schema: RaidLifecycleControlSchema, handler: handleRaidLifecycleControl },
-  { name: 'raid.unload', description: 'Unload a RAID array (preserves data, can be restored)', schema: RaidUnloadSchema, handler: handleRaidUnload },
-  { name: 'raid.restore', description: 'Restore a RAID array from drive metadata or config backup', schema: RaidRestoreSchema, handler: handleRaidRestore },
-  { name: 'raid.delete', description: 'Delete a RAID array permanently (DESTRUCTIVE, plan/apply, requires dangerous=true)', schema: RaidDeleteSchema, handler: handleRaidDelete },
+  {
+    name: 'raid.list',
+    description: 'List RAID arrays with state, members, capacity, and rebuild progress',
+    schema: RaidListSchema,
+    handler: handleRaidList,
+  },
+  {
+    name: 'raid.create',
+    description: 'Create a new RAID array (plan/apply). Supports levels 0,1,5,6,7,10,50,60,70,N+M.',
+    schema: RaidCreateSchema,
+    handler: handleRaidCreate,
+  },
+  {
+    name: 'raid.modify_performance',
+    description: 'Modify RAID performance parameters (merge write/read, scheduler)',
+    schema: RaidModifyPerformanceSchema,
+    handler: handleRaidModifyPerformance,
+  },
+  {
+    name: 'raid.lifecycle_control',
+    description: 'Start/stop RAID initialization or reconstruction',
+    schema: RaidLifecycleControlSchema,
+    handler: handleRaidLifecycleControl,
+  },
+  {
+    name: 'raid.unload',
+    description: 'Unload a RAID array (preserves data, can be restored)',
+    schema: RaidUnloadSchema,
+    handler: handleRaidUnload,
+  },
+  {
+    name: 'raid.restore',
+    description: 'Restore a RAID array from drive metadata or config backup',
+    schema: RaidRestoreSchema,
+    handler: handleRaidRestore,
+  },
+  {
+    name: 'raid.delete',
+    description:
+      'Delete a RAID array permanently (DESTRUCTIVE, plan/apply, requires dangerous=true)',
+    schema: RaidDeleteSchema,
+    handler: handleRaidDelete,
+  },
 
   // Pool
-  { name: 'pool.list', description: 'List spare pools with state, drives, and sizes', schema: PoolListSchema, handler: handlePoolList },
-  { name: 'pool.create', description: 'Create a spare pool from available drives (plan/apply)', schema: PoolCreateSchema, handler: handlePoolCreate },
-  { name: 'pool.delete', description: 'Delete a spare pool (DESTRUCTIVE, plan/apply, requires dangerous=true)', schema: PoolDeleteSchema, handler: handlePoolDelete },
-  { name: 'pool.add_drives', description: 'Add drives to an existing spare pool (plan/apply)', schema: PoolAddDrivesSchema, handler: handlePoolAddDrives },
-  { name: 'pool.remove_drives', description: 'Remove drives from a spare pool (plan/apply)', schema: PoolRemoveDrivesSchema, handler: handlePoolRemoveDrives },
-  { name: 'pool.activate', description: 'Activate a spare pool (load into memory)', schema: PoolActivateSchema, handler: handlePoolActivate },
-  { name: 'pool.deactivate', description: 'Deactivate a spare pool (unload from memory)', schema: PoolDeactivateSchema, handler: handlePoolDeactivate },
-  { name: 'pool.acquire', description: 'Manually acquire a drive from a spare pool (advanced)', schema: PoolAcquireSchema, handler: handlePoolAcquire },
+  {
+    name: 'pool.list',
+    description: 'List spare pools with state, drives, and sizes',
+    schema: PoolListSchema,
+    handler: handlePoolList,
+  },
+  {
+    name: 'pool.create',
+    description: 'Create a spare pool from available drives (plan/apply)',
+    schema: PoolCreateSchema,
+    handler: handlePoolCreate,
+  },
+  {
+    name: 'pool.delete',
+    description: 'Delete a spare pool (DESTRUCTIVE, plan/apply, requires dangerous=true)',
+    schema: PoolDeleteSchema,
+    handler: handlePoolDelete,
+  },
+  {
+    name: 'pool.add_drives',
+    description: 'Add drives to an existing spare pool (plan/apply)',
+    schema: PoolAddDrivesSchema,
+    handler: handlePoolAddDrives,
+  },
+  {
+    name: 'pool.remove_drives',
+    description: 'Remove drives from a spare pool (plan/apply)',
+    schema: PoolRemoveDrivesSchema,
+    handler: handlePoolRemoveDrives,
+  },
+  {
+    name: 'pool.activate',
+    description: 'Activate a spare pool (load into memory)',
+    schema: PoolActivateSchema,
+    handler: handlePoolActivate,
+  },
+  {
+    name: 'pool.deactivate',
+    description: 'Deactivate a spare pool (unload from memory)',
+    schema: PoolDeactivateSchema,
+    handler: handlePoolDeactivate,
+  },
+  {
+    name: 'pool.acquire',
+    description: 'Manually acquire a drive from a spare pool (advanced)',
+    schema: PoolAcquireSchema,
+    handler: handlePoolAcquire,
+  },
 
   // Share
-  { name: 'share.list', description: 'List NFS exports with paths, clients, and options', schema: ShareListSchema, handler: handleShareList },
-  { name: 'share.get_active_sessions', description: 'Get active NFS sessions for an export', schema: ShareGetActiveSessionsSchema, handler: handleShareGetActiveSessions },
-  { name: 'share.create', description: 'Create NFS export (plan/apply). Supports sys/krb5/rdma. Set create_path=true (with optional path_mode like "1777") to auto-create the export directory; parent must already exist.', schema: ShareCreateSchema, handler: handleShareCreate },
-  { name: 'share.update_policy', description: 'Update NFS export policy (clients, security, options)', schema: ShareUpdatePolicySchema, handler: handleShareUpdatePolicy },
-  { name: 'share.set_quota', description: 'Set XFS project quota on an export path', schema: ShareSetQuotaSchema, handler: handleShareSetQuota },
-  { name: 'share.delete', description: 'Delete NFS export (plan/apply, requires dangerous=true)', schema: ShareDeleteSchema, handler: handleShareDelete },
+  {
+    name: 'share.list',
+    description: 'List NFS exports with paths, clients, and options',
+    schema: ShareListSchema,
+    handler: handleShareList,
+  },
+  {
+    name: 'share.get_active_sessions',
+    description: 'Get active NFS sessions for an export',
+    schema: ShareGetActiveSessionsSchema,
+    handler: handleShareGetActiveSessions,
+  },
+  {
+    name: 'share.create',
+    description:
+      'Create NFS export (plan/apply). Supports sys/krb5/rdma. Set create_path=true (with optional path_mode like "1777") to auto-create the export directory; parent must already exist.',
+    schema: ShareCreateSchema,
+    handler: handleShareCreate,
+  },
+  {
+    name: 'share.update_policy',
+    description: 'Update NFS export policy (clients, security, options)',
+    schema: ShareUpdatePolicySchema,
+    handler: handleShareUpdatePolicy,
+  },
+  {
+    name: 'share.set_quota',
+    description: 'Set XFS project quota on an export path',
+    schema: ShareSetQuotaSchema,
+    handler: handleShareSetQuota,
+  },
+  {
+    name: 'share.delete',
+    description: 'Delete NFS export (plan/apply, requires dangerous=true)',
+    schema: ShareDeleteSchema,
+    handler: handleShareDelete,
+  },
 
   // Auth
-  { name: 'auth.get_supported_modes', description: 'Get supported NFS authentication modes and Kerberos readiness', schema: AuthGetSupportedModesSchema, handler: handleAuthGetSupportedModes },
-  { name: 'auth.validate_kerberos', description: 'Validate Kerberos configuration: keytab, time sync, krb5.conf', schema: AuthValidateKerberosSchema, handler: handleAuthValidateKerberos },
-  { name: 'auth.list_users', description: 'List system users (UID >= 1000) with username, uid, home, shell', schema: AuthListUsersSchema, handler: handleAuthListUsers },
-  { name: 'auth.create_user', description: 'Create a Linux user with home directory (plan/apply)', schema: AuthCreateUserSchema, handler: handleAuthCreateUser },
-  { name: 'auth.delete_user', description: 'Delete a Linux user, preserving home directory (plan/apply)', schema: AuthDeleteUserSchema, handler: handleAuthDeleteUser },
-  { name: 'auth.set_quota', description: 'Set disk quota for a user on an NFS export path', schema: AuthSetQuotaSchema, handler: handleAuthSetQuota },
-  { name: 'auth.list_quotas', description: 'List all disk quotas (repquota -a)', schema: AuthListQuotasSchema, handler: handleAuthListQuotas },
+  {
+    name: 'auth.get_supported_modes',
+    description: 'Get supported NFS authentication modes and Kerberos readiness',
+    schema: AuthGetSupportedModesSchema,
+    handler: handleAuthGetSupportedModes,
+  },
+  {
+    name: 'auth.validate_kerberos',
+    description: 'Validate Kerberos configuration: keytab, time sync, krb5.conf',
+    schema: AuthValidateKerberosSchema,
+    handler: handleAuthValidateKerberos,
+  },
+  {
+    name: 'auth.list_users',
+    description: 'List system users (UID >= 1000) with username, uid, home, shell',
+    schema: AuthListUsersSchema,
+    handler: handleAuthListUsers,
+  },
+  {
+    name: 'auth.create_user',
+    description: 'Create a Linux user with home directory (plan/apply)',
+    schema: AuthCreateUserSchema,
+    handler: handleAuthCreateUser,
+  },
+  {
+    name: 'auth.delete_user',
+    description: 'Delete a Linux user, preserving home directory (plan/apply)',
+    schema: AuthDeleteUserSchema,
+    handler: handleAuthDeleteUser,
+  },
+  {
+    name: 'auth.set_quota',
+    description: 'Set disk quota for a user on an NFS export path',
+    schema: AuthSetQuotaSchema,
+    handler: handleAuthSetQuota,
+  },
+  {
+    name: 'auth.list_quotas',
+    description: 'List all disk quotas (repquota -a)',
+    schema: AuthListQuotasSchema,
+    handler: handleAuthListQuotas,
+  },
   {
     name: 'auth.change_password',
-    description: "Change a user's password (plan/apply). Requires password and password_confirm fields to match.",
+    description:
+      "Change a user's password (plan/apply). Requires password and password_confirm fields to match.",
     schema: AuthChangePasswordSchema,
     handler: handleAuthChangePassword,
   },
   {
     name: 'auth.set_user_lock',
-    description: 'Lock or unlock a user account (plan/apply). Set locked=true to lock, false to unlock.',
+    description:
+      'Lock or unlock a user account (plan/apply). Set locked=true to lock, false to unlock.',
     schema: AuthSetUserLockSchema,
     handler: handleAuthSetUserLock,
   },
@@ -209,27 +515,112 @@ const TOOLS: ToolDef[] = [
   },
 
   // Mail
-  { name: 'mail.list_recipients', description: 'List xiRAID notification recipients with severity levels', schema: MailListRecipientsSchema, handler: handleMailListRecipients },
-  { name: 'mail.add_recipient', description: 'Add a notification recipient at a severity level (plan/apply)', schema: MailAddRecipientSchema, handler: handleMailAddRecipient },
-  { name: 'mail.remove_recipient', description: 'Remove a notification recipient (plan/apply)', schema: MailRemoveRecipientSchema, handler: handleMailRemoveRecipient },
-  { name: 'mail.get_settings', description: 'Get mail polling intervals (RAID state check + progress reporting)', schema: MailGetSettingsSchema, handler: handleMailGetSettings },
-  { name: 'mail.update_settings', description: 'Update mail polling intervals (plan/apply)', schema: MailUpdateSettingsSchema, handler: handleMailUpdateSettings },
-  { name: 'mail.send_test', description: 'Send a test notification to all configured recipients', schema: MailSendTestSchema, handler: handleMailSendTest },
+  {
+    name: 'mail.list_recipients',
+    description: 'List xiRAID notification recipients with severity levels',
+    schema: MailListRecipientsSchema,
+    handler: handleMailListRecipients,
+  },
+  {
+    name: 'mail.add_recipient',
+    description: 'Add a notification recipient at a severity level (plan/apply)',
+    schema: MailAddRecipientSchema,
+    handler: handleMailAddRecipient,
+  },
+  {
+    name: 'mail.remove_recipient',
+    description: 'Remove a notification recipient (plan/apply)',
+    schema: MailRemoveRecipientSchema,
+    handler: handleMailRemoveRecipient,
+  },
+  {
+    name: 'mail.get_settings',
+    description: 'Get mail polling intervals (RAID state check + progress reporting)',
+    schema: MailGetSettingsSchema,
+    handler: handleMailGetSettings,
+  },
+  {
+    name: 'mail.update_settings',
+    description: 'Update mail polling intervals (plan/apply)',
+    schema: MailUpdateSettingsSchema,
+    handler: handleMailUpdateSettings,
+  },
+  {
+    name: 'mail.send_test',
+    description: 'Send a test notification to all configured recipients',
+    schema: MailSendTestSchema,
+    handler: handleMailSendTest,
+  },
 
   // Jobs
-  { name: 'job.get', description: 'Get status and progress of a long-running job', schema: JobGetSchema, handler: handleJobGet },
-  { name: 'job.list', description: 'List all jobs for a controller', schema: JobListSchema, handler: handleJobList },
-  { name: 'job.cancel', description: 'Cancel a running job', schema: JobCancelSchema, handler: handleJobCancel },
+  {
+    name: 'job.get',
+    description: 'Get status and progress of a long-running job',
+    schema: JobGetSchema,
+    handler: handleJobGet,
+  },
+  {
+    name: 'job.list',
+    description: 'List all jobs for a controller',
+    schema: JobListSchema,
+    handler: handleJobList,
+  },
+  {
+    name: 'job.cancel',
+    description: 'Cancel a running job',
+    schema: JobCancelSchema,
+    handler: handleJobCancel,
+  },
 
   // Config History
-  { name: 'config.list_snapshots', description: 'List configuration snapshots with status and rollback class', schema: ConfigListSnapshotsSchema, handler: handleConfigListSnapshots },
-  { name: 'config.show_snapshot', description: 'Get full manifest and details for a specific snapshot', schema: ConfigShowSnapshotSchema, handler: handleConfigShowSnapshot },
-  { name: 'config.diff_snapshots', description: 'Compare two snapshots and show config/runtime changes', schema: ConfigDiffSnapshotsSchema, handler: handleConfigDiffSnapshots },
-  { name: 'config.check_drift', description: 'Detect out-of-band changes to managed config files', schema: ConfigCheckDriftSchema, handler: handleConfigCheckDrift },
-  { name: 'config.get_status', description: 'Get config-history status: baseline, counts, current effective', schema: ConfigGetStatusSchema, handler: handleConfigGetStatus },
-  { name: 'config.rollback', description: 'Roll back to a previous configuration snapshot (plan/apply, admin-only)', schema: ConfigRollbackSchema, handler: handleConfigRollback },
-  { name: 'config.get_retention', description: 'Get current snapshot retention policy (max_snapshots, max_age_days)', schema: ConfigGetRetentionSchema, handler: handleConfigGetRetention },
-  { name: 'config.set_retention', description: 'Update snapshot retention policy (admin, plan/apply)', schema: ConfigSetRetentionSchema, handler: handleConfigSetRetention },
+  {
+    name: 'config.list_snapshots',
+    description: 'List configuration snapshots with status and rollback class',
+    schema: ConfigListSnapshotsSchema,
+    handler: handleConfigListSnapshots,
+  },
+  {
+    name: 'config.show_snapshot',
+    description: 'Get full manifest and details for a specific snapshot',
+    schema: ConfigShowSnapshotSchema,
+    handler: handleConfigShowSnapshot,
+  },
+  {
+    name: 'config.diff_snapshots',
+    description: 'Compare two snapshots and show config/runtime changes',
+    schema: ConfigDiffSnapshotsSchema,
+    handler: handleConfigDiffSnapshots,
+  },
+  {
+    name: 'config.check_drift',
+    description: 'Detect out-of-band changes to managed config files',
+    schema: ConfigCheckDriftSchema,
+    handler: handleConfigCheckDrift,
+  },
+  {
+    name: 'config.get_status',
+    description: 'Get config-history status: baseline, counts, current effective',
+    schema: ConfigGetStatusSchema,
+    handler: handleConfigGetStatus,
+  },
+  {
+    name: 'config.rollback',
+    description: 'Roll back to a previous configuration snapshot (plan/apply, admin-only)',
+    schema: ConfigRollbackSchema,
+    handler: handleConfigRollback,
+  },
+  {
+    name: 'config.get_retention',
+    description: 'Get current snapshot retention policy (max_snapshots, max_age_days)',
+    schema: ConfigGetRetentionSchema,
+    handler: handleConfigGetRetention,
+  },
+  {
+    name: 'config.set_retention',
+    description: 'Update snapshot retention policy (admin, plan/apply)',
+    schema: ConfigSetRetentionSchema,
+    handler: handleConfigSetRetention,
+  },
 ];
 
 /**
@@ -241,7 +632,7 @@ const TOOLS: ToolDef[] = [
 export function registerAllTools(server: Server, defaultRole?: Role): void {
   // List tools handler
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: TOOLS.map(t => ({
+    tools: TOOLS.map((t) => ({
       name: t.name,
       description: t.description,
       inputSchema: zodToJsonSchema(t.schema, { target: 'jsonSchema7' }),
@@ -253,21 +644,25 @@ export function registerAllTools(server: Server, defaultRole?: Role): void {
     const { name, arguments: args } = request.params;
     const config = loadConfig();
 
-    const tool = TOOLS.find(t => t.name === name);
+    const tool = TOOLS.find((t) => t.name === name);
     if (!tool) {
       return {
-        content: [{ type: 'text', text: JSON.stringify({ error: 'UNKNOWN_TOOL', message: `Unknown tool: ${name}` }) }],
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ error: 'UNKNOWN_TOOL', message: `Unknown tool: ${name}` }),
+          },
+        ],
         isError: true,
       };
     }
 
     // Build call context. Per-request _meta token takes priority, then defaultRole.
-    const authHeader = (request as { params: { arguments?: unknown; _meta?: { authorization?: string } } })
-      .params._meta?.authorization;
+    const authHeader = (
+      request as { params: { arguments?: unknown; _meta?: { authorization?: string } } }
+    ).params._meta?.authorization;
     const token = authHeader?.replace('Bearer ', '');
-    const role: Role = token
-      ? (config.tokens[token] ?? 'viewer')
-      : (defaultRole ?? 'admin');
+    const role: Role = token ? (config.tokens[token] ?? 'viewer') : (defaultRole ?? 'admin');
     const ctx = buildContext(token, role);
 
     const startMs = Date.now();
@@ -291,14 +686,16 @@ export function registerAllTools(server: Server, defaultRole?: Role): void {
       if (err instanceof McpToolError) {
         errorStr = err.message;
         return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              error: err.code,
-              message: err.message,
-              details: err.details,
-            }),
-          }],
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                error: err.code,
+                message: err.message,
+                details: err.details,
+              }),
+            },
+          ],
           isError: true,
         };
       }

--- a/xiNAS-MCP/src/server/controllerResolver.ts
+++ b/xiNAS-MCP/src/server/controllerResolver.ts
@@ -16,7 +16,7 @@ export function resolveController(controllerId?: string): ControllerInfo {
   if (controllerId && controllerId !== localId) {
     throw new McpToolError(
       ErrorCode.NOT_FOUND,
-      `Unknown controller_id: ${controllerId}. This server manages: ${localId}`
+      `Unknown controller_id: ${controllerId}. This server manages: ${localId}`,
     );
   }
 

--- a/xiNAS-MCP/src/state/audit-drainer.ts
+++ b/xiNAS-MCP/src/state/audit-drainer.ts
@@ -13,8 +13,8 @@ import type { AuditAppender } from './audit.js';
 
 export interface AuditDrainerOptions {
   path: string;
-  rotateBytes?: number;       // default 256 MiB (rotation lands in a later PR)
-  drainIntervalMs?: number;   // default 500
+  rotateBytes?: number; // default 256 MiB (rotation lands in a later PR)
+  drainIntervalMs?: number; // default 500
   /**
    * If set, the drainer calls audit.notifyJsonlAdvanced(lastHash)
    * after each successful batch so AuditAppender's currentTailHash

--- a/xiNAS-MCP/src/state/audit.ts
+++ b/xiNAS-MCP/src/state/audit.ts
@@ -66,9 +66,7 @@ export class AuditAppender {
       `INSERT INTO audit_index (request_id, operation_id, task_id, audit_seq, durable_file, durable_offset)
        VALUES (?, ?, ?, ?, NULL, NULL)`,
     );
-    this.tailHashStmt = db.prepare(
-      'SELECT hash FROM audit_outbox ORDER BY audit_seq DESC LIMIT 1',
-    );
+    this.tailHashStmt = db.prepare('SELECT hash FROM audit_outbox ORDER BY audit_seq DESC LIMIT 1');
   }
 
   /**

--- a/xiNAS-MCP/src/state/gc.ts
+++ b/xiNAS-MCP/src/state/gc.ts
@@ -5,9 +5,9 @@ import type { Database } from 'better-sqlite3';
 import { LeaseManager } from './leases.js';
 
 export interface GcOptions {
-  taskRetentionDays?: number;   // default 30
-  archiveDir?: string;          // default '/var/lib/xinas/state/archive'
-  leaseGraceMs?: number;        // additional grace beyond ttl_seconds, default 0
+  taskRetentionDays?: number; // default 30
+  archiveDir?: string; // default '/var/lib/xinas/state/archive'
+  leaseGraceMs?: number; // additional grace beyond ttl_seconds, default 0
 }
 
 export interface GcSweepResult {

--- a/xiNAS-MCP/src/state/index.ts
+++ b/xiNAS-MCP/src/state/index.ts
@@ -34,10 +34,10 @@ export { LeaseManager } from './leases.js';
 export { GcSweeper } from './gc.js';
 
 export interface OpenStateStoreOptions {
-  databasePath: string;       // e.g. /var/lib/xinas/state/xinas.db
-  auditJsonlPath: string;     // e.g. /var/log/xinas/audit.jsonl
-  nodeId: string;             // controller_id used in audit genesis hash
-  archiveDir?: string;        // passed to GcSweeper; default per gc.ts
+  databasePath: string; // e.g. /var/lib/xinas/state/xinas.db
+  auditJsonlPath: string; // e.g. /var/log/xinas/audit.jsonl
+  nodeId: string; // controller_id used in audit genesis hash
+  archiveDir?: string; // passed to GcSweeper; default per gc.ts
 }
 
 export interface OpenedStateStore {

--- a/xiNAS-MCP/src/state/store.ts
+++ b/xiNAS-MCP/src/state/store.ts
@@ -30,11 +30,7 @@ import type {
 export interface KvStore {
   get<T = unknown>(key: string): RevisionedValue<T> | null;
 
-  put<T = unknown>(
-    key: string,
-    value: T,
-    opts?: PutOptions,
-  ): CasResult<T>;
+  put<T = unknown>(key: string, value: T, opts?: PutOptions): CasResult<T>;
 
   patch<T = unknown>(
     key: string,
@@ -61,11 +57,7 @@ export interface KvStore {
 export interface KvTransaction {
   get<T = unknown>(key: string): RevisionedValue<T> | null;
 
-  put<T = unknown>(
-    key: string,
-    value: T,
-    opts?: PutOptions,
-  ): CasResult<T>;
+  put<T = unknown>(key: string, value: T, opts?: PutOptions): CasResult<T>;
 
   delete(key: string, expected_revision?: number): DeleteResult;
 }

--- a/xiNAS-MCP/src/state/types.ts
+++ b/xiNAS-MCP/src/state/types.ts
@@ -7,22 +7,16 @@
 
 export type ValidationStatus = 'valid' | 'drift' | 'invalid' | 'pending';
 
-export type ClientType =
-  | 'rest'
-  | 'mcp'
-  | 'tui'
-  | 'cli'
-  | 'automation'
-  | 'system';
+export type ClientType = 'rest' | 'mcp' | 'tui' | 'cli' | 'automation' | 'system';
 
 export interface RevisionedValue<T = unknown> {
   key: string;
   value: T;
-  revision: number;          // monotonic per key; first write is 1
-  created_at: number;        // epoch ms; never changes after creation
-  modified_at: number;       // epoch ms; updated on each put/patch
-  owner: string;             // principal or source identifier
-  source: string;            // origin tag, e.g. 'ansible:nfs_server'
+  revision: number; // monotonic per key; first write is 1
+  created_at: number; // epoch ms; never changes after creation
+  modified_at: number; // epoch ms; updated on each put/patch
+  owner: string; // principal or source identifier
+  source: string; // origin tag, e.g. 'ansible:nfs_server'
   validation_status: ValidationStatus;
 }
 
@@ -39,9 +33,9 @@ export interface PutOptions {
 }
 
 export interface ListOptions {
-  prefix?: string;           // e.g., '/xinas/v1/desired/Share/'
-  limit?: number;            // default 1000
-  start_after?: string;      // pagination cursor (key string)
+  prefix?: string; // e.g., '/xinas/v1/desired/Share/'
+  limit?: number; // default 1000
+  start_after?: string; // pagination cursor (key string)
 }
 
 export type CasResult<T = unknown> =
@@ -73,14 +67,14 @@ export interface WatchHandle {
  * Required fields are non-optional; payload is free-form.
  */
 export interface AuditEntry {
-  kind: string;                        // operation/tool name, e.g. 'share.create'
-  timestamp: number;                   // epoch ms; set by AuditAppender at queue time
-  node_id: string;                     // controller_id; injected by AuditAppender
+  kind: string; // operation/tool name, e.g. 'share.create'
+  timestamp: number; // epoch ms; set by AuditAppender at queue time
+  node_id: string; // controller_id; injected by AuditAppender
   principal: string;
   client_type: ClientType;
   request_id: string;
-  parameters_hash: string;             // sha256 of canonicalized request input
-  result_hash: string;                 // sha256 of canonicalized result; '' on failure
+  parameters_hash: string; // sha256 of canonicalized request input
+  result_hash: string; // sha256 of canonicalized result; '' on failure
   operation_id?: string;
   task_id?: string;
   state_revision?: number;

--- a/xiNAS-MCP/src/tools/auth.ts
+++ b/xiNAS-MCP/src/tools/auth.ts
@@ -35,7 +35,10 @@ const USERNAME_RE = /^[a-z_][a-z0-9_-]{0,31}$/;
 export const AuthCreateUserSchema = z.object({
   controller_id: z.string().optional(),
   username: z.string().describe('Linux username (lowercase, max 32 chars)'),
-  home_dir: z.string().optional().describe('Home directory path (defaults to /mnt/data/<username>)'),
+  home_dir: z
+    .string()
+    .optional()
+    .describe('Home directory path (defaults to /mnt/data/<username>)'),
   password: z.string().optional().describe('User password (optional, account locked if omitted)'),
   password_confirm: z.string().optional().describe('Password confirmation (must match password)'),
   mode: z.enum(['plan', 'apply']).default('plan'),
@@ -97,7 +100,9 @@ export const AuthRemoveFromGroupSchema = z.object({
 
 // --- Handlers ---
 
-export async function handleAuthGetSupportedModes(params: z.infer<typeof AuthGetSupportedModesSchema>) {
+export async function handleAuthGetSupportedModes(
+  params: z.infer<typeof AuthGetSupportedModesSchema>,
+) {
   resolveController(params.controller_id);
   const client = await getClient(params.controller_id);
 
@@ -113,14 +118,14 @@ export async function handleAuthGetSupportedModes(params: z.infer<typeof AuthGet
 
 function checkKerberosReady(): boolean {
   // Check if krb5.conf and keytab are present
-  return fs.existsSync('/etc/krb5.conf') && (
-    fs.existsSync('/etc/krb5.keytab') ||
-    fs.existsSync('/etc/nfs.keytab')
+  return (
+    fs.existsSync('/etc/krb5.conf') &&
+    (fs.existsSync('/etc/krb5.keytab') || fs.existsSync('/etc/nfs.keytab'))
   );
 }
 
 export async function handleAuthValidateKerberos(
-  params: z.infer<typeof AuthValidateKerberosSchema>
+  params: z.infer<typeof AuthValidateKerberosSchema>,
 ): Promise<{
   realm: string;
   kdc_reachable: boolean;
@@ -148,13 +153,16 @@ export async function handleAuthValidateKerberos(
     time_sync_ok = !adjtime.includes('UNSYNC');
   } catch {
     // Check if chrony/ntp service is active
-    const ntpState = ['chrony', 'ntpd', 'systemd-timesyncd']
-      .some(svc => fs.existsSync(`/sys/fs/cgroup/system.slice/${svc}.service`));
+    const ntpState = ['chrony', 'ntpd', 'systemd-timesyncd'].some((svc) =>
+      fs.existsSync(`/sys/fs/cgroup/system.slice/${svc}.service`),
+    );
     time_sync_ok = ntpState;
   }
 
   if (!time_sync_ok) {
-    issues.push('Time synchronization may not be active — Kerberos requires time sync within 5 minutes');
+    issues.push(
+      'Time synchronization may not be active — Kerberos requires time sync within 5 minutes',
+    );
   }
 
   // krb5.conf check
@@ -177,7 +185,10 @@ export async function handleAuthValidateKerberos(
 
 const CMD_TIMEOUT_MS = 15_000;
 
-function exec(cmd: string, args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+function exec(
+  cmd: string,
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   return new Promise((resolve, reject) => {
     execFile(cmd, args, { timeout: CMD_TIMEOUT_MS }, (err, stdout, stderr) => {
       if (err && 'killed' in err && err.killed) {
@@ -251,7 +262,9 @@ export async function handleAuthCreateUser(params: z.infer<typeof AuthCreateUser
       const warnings: string[] = [];
 
       if (!USERNAME_RE.test(params.username)) {
-        blockingResources.push(`Invalid username '${params.username}': must match ${USERNAME_RE.source}`);
+        blockingResources.push(
+          `Invalid username '${params.username}': must match ${USERNAME_RE.source}`,
+        );
       }
 
       const existing = await lookupUser(params.username);
@@ -275,12 +288,14 @@ export async function handleAuthCreateUser(params: z.infer<typeof AuthCreateUser
       return {
         mode: 'plan' as const,
         description: `Create user '${params.username}' with home ${homeDir}`,
-        changes: [{
-          action: 'create',
-          resource_type: 'linux_user',
-          resource_id: params.username,
-          after: { username: params.username, home: homeDir, shell: '/bin/bash' },
-        }],
+        changes: [
+          {
+            action: 'create',
+            resource_type: 'linux_user',
+            resource_id: params.username,
+            after: { username: params.username, home: homeDir, shell: '/bin/bash' },
+          },
+        ],
         warnings,
         preflight_passed: blockingResources.length === 0,
         ...(blockingResources.length > 0 ? { blocking_resources: blockingResources } : {}),
@@ -288,7 +303,14 @@ export async function handleAuthCreateUser(params: z.infer<typeof AuthCreateUser
     },
 
     execute: async () => {
-      const result = await exec('useradd', ['-m', '-s', '/bin/bash', '-d', homeDir, params.username]);
+      const result = await exec('useradd', [
+        '-m',
+        '-s',
+        '/bin/bash',
+        '-d',
+        homeDir,
+        params.username,
+      ]);
       if (result.exitCode !== 0) {
         throw new McpToolError(ErrorCode.INTERNAL, `useradd failed: ${result.stderr.trim()}`);
       }
@@ -328,7 +350,9 @@ export async function handleAuthDeleteUser(params: z.infer<typeof AuthDeleteUser
       if (!existing) {
         blockingResources.push(`User '${params.username}' not found`);
       } else if (existing.uid < 1000) {
-        blockingResources.push(`Cannot delete system user '${params.username}' (UID ${existing.uid})`);
+        blockingResources.push(
+          `Cannot delete system user '${params.username}' (UID ${existing.uid})`,
+        );
       }
 
       // Check active NFS sessions
@@ -336,7 +360,9 @@ export async function handleAuthDeleteUser(params: z.infer<typeof AuthDeleteUser
         const sessions = await listSessions();
         // Note: NFS sessions don't directly expose usernames, but we warn about activity
         if (sessions.length > 0) {
-          warnings.push(`${sessions.length} active NFS session(s) — verify none belong to '${params.username}'`);
+          warnings.push(
+            `${sessions.length} active NFS session(s) — verify none belong to '${params.username}'`,
+          );
         }
       } catch {
         warnings.push('Could not check active NFS sessions');
@@ -345,12 +371,14 @@ export async function handleAuthDeleteUser(params: z.infer<typeof AuthDeleteUser
       return {
         mode: 'plan' as const,
         description: `Delete user '${params.username}' (home directory removed)`,
-        changes: [{
-          action: 'delete',
-          resource_type: 'linux_user',
-          resource_id: params.username,
-          before: existing ?? undefined,
-        }],
+        changes: [
+          {
+            action: 'delete',
+            resource_type: 'linux_user',
+            resource_id: params.username,
+            before: existing ?? undefined,
+          },
+        ],
         warnings,
         preflight_passed: blockingResources.length === 0,
         ...(blockingResources.length > 0 ? { blocking_resources: blockingResources } : {}),
@@ -442,7 +470,9 @@ export async function handleAuthChangePassword(params: z.infer<typeof AuthChange
       if (!existing) {
         blockingResources.push(`User '${params.username}' not found`);
       } else if (existing.uid < 1000) {
-        blockingResources.push(`Cannot modify system user '${params.username}' (UID ${existing.uid})`);
+        blockingResources.push(
+          `Cannot modify system user '${params.username}' (UID ${existing.uid})`,
+        );
       }
 
       if (params.password !== params.password_confirm) {
@@ -452,12 +482,14 @@ export async function handleAuthChangePassword(params: z.infer<typeof AuthChange
       return {
         mode: 'plan' as const,
         description: `Change password for '${params.username}'`,
-        changes: [{
-          action: 'modify',
-          resource_type: 'linux_user',
-          resource_id: params.username,
-          after: { password: '(changed)' },
-        }],
+        changes: [
+          {
+            action: 'modify',
+            resource_type: 'linux_user',
+            resource_id: params.username,
+            after: { password: '(changed)' },
+          },
+        ],
         warnings,
         preflight_passed: blockingResources.length === 0,
         ...(blockingResources.length > 0 ? { blocking_resources: blockingResources } : {}),
@@ -498,25 +530,31 @@ export async function handleAuthSetUserLock(params: z.infer<typeof AuthSetUserLo
       if (!existing) {
         blockingResources.push(`User '${params.username}' not found`);
       } else if (existing.uid < 1000) {
-        blockingResources.push(`Cannot modify system user '${params.username}' (UID ${existing.uid})`);
+        blockingResources.push(
+          `Cannot modify system user '${params.username}' (UID ${existing.uid})`,
+        );
       }
 
       const currentlyLocked = await isUserLocked(params.username);
       if (currentlyLocked === params.locked) {
-        warnings.push(`User '${params.username}' is already ${params.locked ? 'locked' : 'unlocked'}`);
+        warnings.push(
+          `User '${params.username}' is already ${params.locked ? 'locked' : 'unlocked'}`,
+        );
       }
 
       const action_desc = params.locked ? 'Lock' : 'Unlock';
       return {
         mode: 'plan' as const,
         description: `${action_desc} user '${params.username}'`,
-        changes: [{
-          action: 'modify',
-          resource_type: 'linux_user',
-          resource_id: params.username,
-          before: { locked: currentlyLocked },
-          after: { locked: params.locked },
-        }],
+        changes: [
+          {
+            action: 'modify',
+            resource_type: 'linux_user',
+            resource_id: params.username,
+            before: { locked: currentlyLocked },
+            after: { locked: params.locked },
+          },
+        ],
         warnings,
         preflight_passed: blockingResources.length === 0,
         ...(blockingResources.length > 0 ? { blocking_resources: blockingResources } : {}),
@@ -547,7 +585,9 @@ export async function handleAuthChangeShell(params: z.infer<typeof AuthChangeShe
       if (!existing) {
         blockingResources.push(`User '${params.username}' not found`);
       } else if (existing.uid < 1000) {
-        blockingResources.push(`Cannot modify system user '${params.username}' (UID ${existing.uid})`);
+        blockingResources.push(
+          `Cannot modify system user '${params.username}' (UID ${existing.uid})`,
+        );
       }
 
       if (!fs.existsSync(params.shell)) {
@@ -557,13 +597,15 @@ export async function handleAuthChangeShell(params: z.infer<typeof AuthChangeShe
       return {
         mode: 'plan' as const,
         description: `Change shell for '${params.username}' to ${params.shell}`,
-        changes: [{
-          action: 'modify',
-          resource_type: 'linux_user',
-          resource_id: params.username,
-          before: existing ? { shell: existing.shell } : undefined,
-          after: { shell: params.shell },
-        }],
+        changes: [
+          {
+            action: 'modify',
+            resource_type: 'linux_user',
+            resource_id: params.username,
+            before: existing ? { shell: existing.shell } : undefined,
+            after: { shell: params.shell },
+          },
+        ],
         warnings,
         preflight_passed: blockingResources.length === 0,
         ...(blockingResources.length > 0 ? { blocking_resources: blockingResources } : {}),
@@ -593,7 +635,9 @@ export async function handleAuthAddToGroup(params: z.infer<typeof AuthAddToGroup
       if (!existing) {
         blockingResources.push(`User '${params.username}' not found`);
       } else if (existing.uid < 1000) {
-        blockingResources.push(`Cannot modify system user '${params.username}' (UID ${existing.uid})`);
+        blockingResources.push(
+          `Cannot modify system user '${params.username}' (UID ${existing.uid})`,
+        );
       }
 
       const groupResult = await exec('getent', ['group', params.group]);
@@ -602,19 +646,23 @@ export async function handleAuthAddToGroup(params: z.infer<typeof AuthAddToGroup
       } else {
         const groupInfo = parseGroupLine(groupResult.stdout.trim());
         if (groupInfo && groupInfo.members.includes(params.username)) {
-          blockingResources.push(`User '${params.username}' is already a member of group '${params.group}'`);
+          blockingResources.push(
+            `User '${params.username}' is already a member of group '${params.group}'`,
+          );
         }
       }
 
       return {
         mode: 'plan' as const,
         description: `Add '${params.username}' to group '${params.group}'`,
-        changes: [{
-          action: 'modify',
-          resource_type: 'linux_user',
-          resource_id: params.username,
-          after: { added_to_group: params.group },
-        }],
+        changes: [
+          {
+            action: 'modify',
+            resource_type: 'linux_user',
+            resource_id: params.username,
+            after: { added_to_group: params.group },
+          },
+        ],
         warnings,
         preflight_passed: blockingResources.length === 0,
         ...(blockingResources.length > 0 ? { blocking_resources: blockingResources } : {}),
@@ -644,7 +692,9 @@ export async function handleAuthRemoveFromGroup(params: z.infer<typeof AuthRemov
       if (!existing) {
         blockingResources.push(`User '${params.username}' not found`);
       } else if (existing.uid < 1000) {
-        blockingResources.push(`Cannot modify system user '${params.username}' (UID ${existing.uid})`);
+        blockingResources.push(
+          `Cannot modify system user '${params.username}' (UID ${existing.uid})`,
+        );
       }
 
       const groupResult = await exec('getent', ['group', params.group]);
@@ -654,7 +704,9 @@ export async function handleAuthRemoveFromGroup(params: z.infer<typeof AuthRemov
         const groupInfo = parseGroupLine(groupResult.stdout.trim());
         if (groupInfo) {
           if (!groupInfo.members.includes(params.username)) {
-            blockingResources.push(`User '${params.username}' is not a member of group '${params.group}'`);
+            blockingResources.push(
+              `User '${params.username}' is not a member of group '${params.group}'`,
+            );
           }
           if (existing && groupInfo.gid === existing.gid) {
             blockingResources.push(`Cannot remove user from primary group '${params.group}'`);
@@ -665,12 +717,14 @@ export async function handleAuthRemoveFromGroup(params: z.infer<typeof AuthRemov
       return {
         mode: 'plan' as const,
         description: `Remove '${params.username}' from group '${params.group}'`,
-        changes: [{
-          action: 'modify',
-          resource_type: 'linux_user',
-          resource_id: params.username,
-          after: { removed_from_group: params.group },
-        }],
+        changes: [
+          {
+            action: 'modify',
+            resource_type: 'linux_user',
+            resource_id: params.username,
+            after: { removed_from_group: params.group },
+          },
+        ],
         warnings,
         preflight_passed: blockingResources.length === 0,
         ...(blockingResources.length > 0 ? { blocking_resources: blockingResources } : {}),

--- a/xiNAS-MCP/src/tools/config.ts
+++ b/xiNAS-MCP/src/tools/config.ts
@@ -5,7 +5,14 @@
  */
 
 import { z } from 'zod';
-import { listSnapshots, showSnapshot, diffSnapshots, getStatus, getRetentionPolicy, setRetentionPolicy } from '../os/configHistory.js';
+import {
+  listSnapshots,
+  showSnapshot,
+  diffSnapshots,
+  getStatus,
+  getRetentionPolicy,
+  setRetentionPolicy,
+} from '../os/configHistory.js';
 import { applyWithPlan } from '../middleware/planApply.js';
 import { resolveController } from '../server/controllerResolver.js';
 import type { PlanChange, PlanResult, Mode } from '../types/common.js';
@@ -50,9 +57,19 @@ export const ConfigGetRetentionSchema = z.object({
 
 export const ConfigSetRetentionSchema = z.object({
   controller_id: z.string().optional(),
-  max_snapshots: z.number().int().min(1).max(1000).optional()
+  max_snapshots: z
+    .number()
+    .int()
+    .min(1)
+    .max(1000)
+    .optional()
     .describe('Maximum rollback-eligible snapshots to retain'),
-  max_age_days: z.number().int().min(0).max(3650).optional()
+  max_age_days: z
+    .number()
+    .int()
+    .min(0)
+    .max(3650)
+    .optional()
     .describe('Delete snapshots older than N days (0 = disabled)'),
   mode: z.enum(['plan', 'apply']).default('plan'),
 });
@@ -80,7 +97,9 @@ export async function handleConfigCheckDrift(params: z.infer<typeof ConfigCheckD
   // For a full drift check, we use a dedicated drift command
   const { execFile } = await import('node:child_process');
   return new Promise((resolve, reject) => {
-    execFile('python3', ['-m', 'xinas_history', 'drift', 'check', '--format', 'json'],
+    execFile(
+      'python3',
+      ['-m', 'xinas_history', 'drift', 'check', '--format', 'json'],
       { timeout: 30_000 },
       (err, stdout, stderr) => {
         if (err && 'killed' in err && err.killed) {
@@ -92,7 +111,8 @@ export async function handleConfigCheckDrift(params: z.infer<typeof ConfigCheckD
         } catch {
           reject(new Error(stderr || 'Drift check failed'));
         }
-      });
+      },
+    );
   });
 }
 
@@ -108,8 +128,8 @@ export async function handleConfigRollback(params: z.infer<typeof ConfigRollback
   return applyWithPlan(mode, {
     preflight: async () => {
       // Get target snapshot info for plan output
-      const target = await showSnapshot(params.target_id) as Record<string, unknown>;
-      const status = await getStatus() as Record<string, unknown>;
+      const target = (await showSnapshot(params.target_id)) as Record<string, unknown>;
+      const status = (await getStatus()) as Record<string, unknown>;
 
       const warnings: string[] = [];
       const blockingResources: string[] = [];
@@ -128,13 +148,15 @@ export async function handleConfigRollback(params: z.infer<typeof ConfigRollback
       return {
         mode: 'plan' as const,
         description: `Roll back configuration to snapshot '${params.target_id}'`,
-        changes: [{
-          action: 'modify' as const,
-          resource_type: 'configuration',
-          resource_id: params.target_id,
-          before: { current_effective: status?.current_effective },
-          after: { target: params.target_id, rollback_class: rollbackClass },
-        }],
+        changes: [
+          {
+            action: 'modify' as const,
+            resource_type: 'configuration',
+            resource_id: params.target_id,
+            before: { current_effective: status?.current_effective },
+            after: { target: params.target_id, rollback_class: rollbackClass },
+          },
+        ],
         warnings,
         preflight_passed: blockingResources.length === 0,
         ...(blockingResources.length > 0 ? { blocking_resources: blockingResources } : {}),
@@ -144,22 +166,33 @@ export async function handleConfigRollback(params: z.infer<typeof ConfigRollback
     execute: async () => {
       const { execFile } = await import('node:child_process');
       return new Promise((resolve, reject) => {
-        execFile('python3', [
-          '-m', 'xinas_history', 'snapshot', 'rollback', params.target_id,
-          '--reason', params.reason,
-          '--yes',
-          '--format', 'json',
-        ], { timeout: 300_000 }, (err, stdout, stderr) => {
-          if (err && 'killed' in err && err.killed) {
-            reject(new Error('Rollback timed out'));
-            return;
-          }
-          try {
-            resolve(JSON.parse(stdout));
-          } catch {
-            reject(new Error(stderr || 'Rollback failed'));
-          }
-        });
+        execFile(
+          'python3',
+          [
+            '-m',
+            'xinas_history',
+            'snapshot',
+            'rollback',
+            params.target_id,
+            '--reason',
+            params.reason,
+            '--yes',
+            '--format',
+            'json',
+          ],
+          { timeout: 300_000 },
+          (err, stdout, stderr) => {
+            if (err && 'killed' in err && err.killed) {
+              reject(new Error('Rollback timed out'));
+              return;
+            }
+            try {
+              resolve(JSON.parse(stdout));
+            } catch {
+              reject(new Error(stderr || 'Rollback failed'));
+            }
+          },
+        );
       });
     },
   });
@@ -176,7 +209,7 @@ export async function handleConfigSetRetention(params: z.infer<typeof ConfigSetR
 
   return applyWithPlan(mode, {
     preflight: async () => {
-      const current = await getRetentionPolicy() as Record<string, unknown>;
+      const current = (await getRetentionPolicy()) as Record<string, unknown>;
       const changes: PlanChange[] = [];
 
       if (params.max_snapshots !== undefined) {

--- a/xiNAS-MCP/src/tools/disk.ts
+++ b/xiNAS-MCP/src/tools/disk.ts
@@ -57,7 +57,7 @@ export async function handleDiskList(params: z.infer<typeof DiskListSchema>) {
     const resp = await withRetry(() => raidShow(client, { extended: true }), 'disk.list raidShow');
     const raids = resp.data as Array<{
       name: string;
-      members?: Array<{ path: string; slot: number; state: string }>
+      members?: Array<{ path: string; slot: number; state: string }>;
     }> | null;
     if (raids) {
       for (const raid of raids) {
@@ -70,9 +70,11 @@ export async function handleDiskList(params: z.infer<typeof DiskListSchema>) {
         }
       }
     }
-  } catch { /* continue with unassigned info */ }
+  } catch {
+    /* continue with unassigned info */
+  }
 
-  const enriched = blockDevices.map(d => {
+  const enriched = blockDevices.map((d) => {
     const member = raidMembers.get(d.path);
     return {
       ...d,
@@ -84,7 +86,7 @@ export async function handleDiskList(params: z.infer<typeof DiskListSchema>) {
   });
 
   if (params.only_unassigned) {
-    return enriched.filter(d => d.role === 'unassigned');
+    return enriched.filter((d) => d.role === 'unassigned');
   }
   return enriched;
 }
@@ -92,7 +94,7 @@ export async function handleDiskList(params: z.infer<typeof DiskListSchema>) {
 export async function handleDiskGetSmart(params: z.infer<typeof DiskGetSmartSchema>) {
   resolveController(params.controller_id);
   const devices = listBlockDevices();
-  const dev = devices.find(d => d.path === params.disk_id);
+  const dev = devices.find((d) => d.path === params.disk_id);
 
   if (!dev) {
     throw new McpToolError(ErrorCode.NOT_FOUND, `Device not found: ${params.disk_id}`);
@@ -101,7 +103,7 @@ export async function handleDiskGetSmart(params: z.infer<typeof DiskGetSmartSche
   if (!dev.nvme_ctrl) {
     throw new McpToolError(
       ErrorCode.UNSUPPORTED,
-      `SATA SMART is not supported in v1. Only NVMe devices are supported. Device: ${params.disk_id}`
+      `SATA SMART is not supported in v1. Only NVMe devices are supported. Device: ${params.disk_id}`,
     );
   }
 
@@ -123,7 +125,7 @@ export async function handleDiskGetSmart(params: z.infer<typeof DiskGetSmartSche
 export async function handleDiskRunSelftest(params: z.infer<typeof DiskRunSelftestSchema>) {
   resolveController(params.controller_id);
   const devices = listBlockDevices();
-  const dev = devices.find(d => d.path === params.disk_id);
+  const dev = devices.find((d) => d.path === params.disk_id);
 
   if (!dev) {
     throw new McpToolError(ErrorCode.NOT_FOUND, `Device not found: ${params.disk_id}`);
@@ -132,7 +134,7 @@ export async function handleDiskRunSelftest(params: z.infer<typeof DiskRunSelfte
   if (!dev.nvme_ctrl) {
     throw new McpToolError(
       ErrorCode.UNSUPPORTED,
-      `Selftest is only supported for NVMe devices in v1. Device: ${params.disk_id}`
+      `Selftest is only supported for NVMe devices in v1. Device: ${params.disk_id}`,
     );
   }
 
@@ -145,7 +147,10 @@ export async function handleDiskRunSelftest(params: z.infer<typeof DiskRunSelfte
   const duration = params.test_type === 'short' ? 2 * 60 * 1000 : 30 * 60 * 1000;
 
   const timeout = setTimeout(() => {
-    JobManager.update(jobId, { state: 'success', result: { completed: true, test_type: params.test_type } });
+    JobManager.update(jobId, {
+      state: 'success',
+      result: { completed: true, test_type: params.test_type },
+    });
   }, duration);
   timeout.unref();
 
@@ -156,9 +161,7 @@ export async function handleDiskSetLed(params: z.infer<typeof DiskSetLedSchema>)
   resolveController(params.controller_id);
   const client = await getClient(params.controller_id);
 
-  const drives = params.state === 'identify_on' && params.disk_id
-    ? [params.disk_id]
-    : [];
+  const drives = params.state === 'identify_on' && params.disk_id ? [params.disk_id] : [];
 
   const resp = await withRetry(() => driveLocate(client, { drives }), 'disk.set_led');
   return { disk_id: params.disk_id, state: params.state, result: resp.data };
@@ -177,7 +180,7 @@ export async function handleDiskSecureErase(params: z.infer<typeof DiskSecureEra
       }
 
       const devices = listBlockDevices();
-      const dev = devices.find(d => d.path === params.disk_id);
+      const dev = devices.find((d) => d.path === params.disk_id);
       if (!dev) {
         blockingResources.push(`Device not found: ${params.disk_id}`);
       }
@@ -185,11 +188,13 @@ export async function handleDiskSecureErase(params: z.infer<typeof DiskSecureEra
       return {
         mode: 'plan' as const,
         description: `Secure erase ${params.disk_id} using ${params.mode}`,
-        changes: [{
-          action: 'delete',
-          resource_type: 'disk_data',
-          resource_id: params.disk_id,
-        }],
+        changes: [
+          {
+            action: 'delete',
+            resource_type: 'disk_data',
+            resource_id: params.disk_id,
+          },
+        ],
         warnings: ['This operation is IRREVERSIBLE and will destroy all data on the drive.'],
         preflight_passed: blockingResources.length === 0,
         ...(blockingResources.length > 0 ? { blocking_resources: blockingResources } : {}),
@@ -203,7 +208,7 @@ export async function handleDiskSecureErase(params: z.infer<typeof DiskSecureEra
       const client = await getClient(params.controller_id);
       const resp = await withRetry(
         () => driveClean(client, { drives: [params.disk_id] }),
-        'disk.secure_erase'
+        'disk.secure_erase',
       );
       return resp.data;
     },

--- a/xiNAS-MCP/src/tools/health.ts
+++ b/xiNAS-MCP/src/tools/health.ts
@@ -54,7 +54,7 @@ function makeAlertId(checkId: string, firstSeen: string): string {
 
 function addOrUpdateAlert(result: HealthCheckResult): void {
   if (result.status === 'OK' || result.status === 'UNKNOWN') return;
-  const existing = alertBuffer.find(a => a.check_id === result.check_id && !a.acknowledged);
+  const existing = alertBuffer.find((a) => a.check_id === result.check_id && !a.acknowledged);
   if (existing) {
     existing.last_seen = new Date().toISOString();
     existing.severity = result.status === 'CRIT' ? 'crit' : 'warn';
@@ -109,7 +109,10 @@ export const HealthFixNfsConfSchema = z
       .describe('Restart nfs-server after writing (only if anything changed)'),
   })
   .refine(
-    (v) => v.threads !== undefined || v.rdma !== undefined || (v.updates && Object.keys(v.updates).length > 0),
+    (v) =>
+      v.threads !== undefined ||
+      v.rdma !== undefined ||
+      (v.updates && Object.keys(v.updates).length > 0),
     { message: 'At least one of threads, rdma, or updates must be supplied' },
   );
 
@@ -120,7 +123,7 @@ async function checkRaidIntegrity(client: unknown): Promise<HealthCheckResult[]>
   try {
     const resp = await withRetry(
       () => raidShow(client as never, { extended: true, units: 'g' }),
-      'health.raid_integrity'
+      'health.raid_integrity',
     );
     type RaidInfo = {
       state: string;
@@ -131,10 +134,7 @@ async function checkRaidIntegrity(client: unknown): Promise<HealthCheckResult[]>
     // xiRAID may return either an array of raids or a record keyed by raid
     // name, depending on call parameters and version. Normalize to array
     // with `name` attached (see src/tools/pool.ts:getPoolDrives for prior art).
-    const data = resp.data as
-      | Array<RaidInfo & { name: string }>
-      | Record<string, RaidInfo>
-      | null;
+    const data = resp.data as Array<RaidInfo & { name: string }> | Record<string, RaidInfo> | null;
     const raids: Array<RaidInfo & { name: string }> =
       !data || typeof data !== 'object'
         ? []
@@ -164,7 +164,7 @@ async function checkRaidIntegrity(client: unknown): Promise<HealthCheckResult[]>
       }
 
       const badStates = ['failed', 'offline', 'error'];
-      if (badStates.some(s => raid.state?.toLowerCase().includes(s))) {
+      if (badStates.some((s) => raid.state?.toLowerCase().includes(s))) {
         status = 'CRIT';
         issues.push(`state=${raid.state}`);
       }
@@ -179,7 +179,10 @@ async function checkRaidIntegrity(client: unknown): Promise<HealthCheckResult[]>
         evidence: issues.join('; ') || undefined,
         impact: status !== 'OK' ? 'Data redundancy reduced or unavailable' : undefined,
         recommended_action: status !== 'OK' ? 'Check drive health and rebuild status' : undefined,
-        fix_hint: status !== 'OK' ? `raid.lifecycle_control array_id=${raid.name} action=start process=recon` : undefined,
+        fix_hint:
+          status !== 'OK'
+            ? `raid.lifecycle_control array_id=${raid.name} action=start process=recon`
+            : undefined,
       });
     }
   } catch (err) {
@@ -238,7 +241,9 @@ async function checkSpares(client: unknown): Promise<HealthCheckResult[]> {
         });
       }
     }
-  } catch { /* optional check */ }
+  } catch {
+    /* optional check */
+  }
   return results;
 }
 
@@ -247,7 +252,7 @@ async function checkFaultyCounts(client: unknown): Promise<HealthCheckResult[]> 
   try {
     const resp = await withRetry(
       () => driveFaultyCountShow(client as never, {}),
-      'health.faulty_counts'
+      'health.faulty_counts',
     );
     const counts = resp.data as Array<{ drive: string; count: number; threshold: number }> | null;
     if (counts) {
@@ -268,17 +273,19 @@ async function checkFaultyCounts(client: unknown): Promise<HealthCheckResult[]> 
         }
       }
     }
-  } catch { /* optional */ }
+  } catch {
+    /* optional */
+  }
   return results;
 }
 
 // --- Python engine result mapping ---
 
 const ENGINE_STATUS_MAP: Record<string, CheckStatus> = {
-  'PASS': 'OK',
-  'WARN': 'WARN',
-  'FAIL': 'CRIT',
-  'SKIP': 'UNKNOWN',
+  PASS: 'OK',
+  WARN: 'WARN',
+  FAIL: 'CRIT',
+  SKIP: 'UNKNOWN',
 };
 
 function mapEngineCheck(c: EngineCheckResult): HealthCheckResult {
@@ -298,28 +305,28 @@ function mapEngineCheck(c: EngineCheckResult): HealthCheckResult {
 
 // --- Main handlers ---
 
-export async function handleHealthRunCheck(params: z.infer<typeof HealthRunCheckSchema>): Promise<HealthCheckResult[]> {
+export async function handleHealthRunCheck(
+  params: z.infer<typeof HealthRunCheckSchema>,
+): Promise<HealthCheckResult[]> {
   resolveController(params.controller_id);
   const client = await getClient(params.controller_id);
   const profile = params.profile;
   const results: HealthCheckResult[] = [];
 
   // 1. gRPC-based checks (xiRAID-specific — not in Python engine)
-  results.push(...await checkRaidIntegrity(client));
+  results.push(...(await checkRaidIntegrity(client)));
   results.push(await checkLicense(client));
 
   if (profile === 'standard' || profile === 'deep') {
-    results.push(...await checkSpares(client));
-    results.push(...await checkFaultyCounts(client));
+    results.push(...(await checkSpares(client)));
+    results.push(...(await checkFaultyCounts(client)));
   }
 
   // 2. Python health engine checks (OS-level: services, CPU, kernel, VM,
   //    network, storage, NFS, RDMA, NVMe, filesystem, perf tuning, Kerberos)
   try {
     const report = await runEngineCheck(profile);
-    const engineResults = report.checks
-      .filter(c => c.status !== 'SKIP')
-      .map(mapEngineCheck);
+    const engineResults = report.checks.filter((c) => c.status !== 'SKIP').map(mapEngineCheck);
     results.push(...engineResults);
   } catch (err) {
     // Engine failure is non-fatal — report as single UNKNOWN check
@@ -358,11 +365,11 @@ export function handleHealthGetAlerts(params: z.infer<typeof HealthGetAlertsSche
 
   if (params.since) {
     const since = new Date(params.since).getTime();
-    alerts = alerts.filter(a => new Date(a.last_seen).getTime() >= since);
+    alerts = alerts.filter((a) => new Date(a.last_seen).getTime() >= since);
   }
 
   if (params.severity_min === 'crit') {
-    alerts = alerts.filter(a => a.severity === 'crit');
+    alerts = alerts.filter((a) => a.severity === 'crit');
   }
 
   return alerts.sort((a, b) => b.last_seen.localeCompare(a.last_seen));

--- a/xiNAS-MCP/src/tools/job.ts
+++ b/xiNAS-MCP/src/tools/job.ts
@@ -38,14 +38,17 @@ export class JobManager {
   }
 
   static list(controllerId: string): JobRecord[] {
-    return Array.from(jobs.values()).filter(j => j.controller_id === controllerId);
+    return Array.from(jobs.values()).filter((j) => j.controller_id === controllerId);
   }
 
   static cancel(jobId: string): void {
     const record = jobs.get(jobId);
     if (!record) throw new McpToolError(ErrorCode.NOT_FOUND, `Job not found: ${jobId}`);
     if (record.state === 'success' || record.state === 'failed') {
-      throw new McpToolError(ErrorCode.PRECONDITION_FAILED, `Job ${jobId} is already ${record.state}`);
+      throw new McpToolError(
+        ErrorCode.PRECONDITION_FAILED,
+        `Job ${jobId} is already ${record.state}`,
+      );
     }
     record.state = 'cancelled';
   }
@@ -75,7 +78,10 @@ export function handleJobList(params: z.infer<typeof JobListSchema>): JobRecord[
   return JobManager.list(params.controller_id);
 }
 
-export function handleJobCancel(params: z.infer<typeof JobCancelSchema>): { cancelled: true; job_id: string } {
+export function handleJobCancel(params: z.infer<typeof JobCancelSchema>): {
+  cancelled: true;
+  job_id: string;
+} {
   JobManager.cancel(params.job_id);
   return { cancelled: true, job_id: params.job_id };
 }

--- a/xiNAS-MCP/src/tools/mail.ts
+++ b/xiNAS-MCP/src/tools/mail.ts
@@ -30,7 +30,9 @@ export const MailListRecipientsSchema = z.object({
 export const MailAddRecipientSchema = z.object({
   controller_id: z.string().optional().describe('Controller UUID (defaults to local)'),
   address: z.string().min(1).describe('Recipient email address'),
-  level: z.enum(VALID_LEVELS).describe('Minimum notification level: info (all), warning (warn+error), error (errors only)'),
+  level: z
+    .enum(VALID_LEVELS)
+    .describe('Minimum notification level: info (all), warning (warn+error), error (errors only)'),
   mode: z.enum(['plan', 'apply']).default('plan'),
 });
 
@@ -46,8 +48,18 @@ export const MailGetSettingsSchema = z.object({
 
 export const MailUpdateSettingsSchema = z.object({
   controller_id: z.string().optional().describe('Controller UUID (defaults to local)'),
-  polling_interval: z.number().int().min(1).optional().describe('RAID/drive state polling interval in seconds'),
-  progress_polling_interval: z.number().int().min(1).optional().describe('Init/reconstruction progress polling interval in minutes'),
+  polling_interval: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe('RAID/drive state polling interval in seconds'),
+  progress_polling_interval: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe('Init/reconstruction progress polling interval in minutes'),
   mode: z.enum(['plan', 'apply']).default('plan'),
 });
 
@@ -80,12 +92,14 @@ export async function handleMailAddRecipient(
     preflight: async () => ({
       mode: 'plan' as const,
       description: `Add notification recipient ${params.address} at level '${params.level}'`,
-      changes: [{
-        action: 'create' as const,
-        resource_type: 'mail_recipient',
-        resource_id: params.address,
-        after: { address: params.address, level: params.level },
-      }],
+      changes: [
+        {
+          action: 'create' as const,
+          resource_type: 'mail_recipient',
+          resource_id: params.address,
+          after: { address: params.address, level: params.level },
+        },
+      ],
       warnings: [],
       preflight_passed: true,
     }),
@@ -113,9 +127,7 @@ export async function handleMailRemoveRecipient(
       const client = await getClient(params.controller_id);
       const resp = await withRetry(() => mailShow(client), 'mail.remove_recipient preflight');
       const recipients = resp.data as Array<{ address?: string; email?: string }> | null;
-      const found = recipients?.some(
-        r => (r.address ?? r.email) === params.address,
-      );
+      const found = recipients?.some((r) => (r.address ?? r.email) === params.address);
 
       const blockingResources: string[] = [];
       if (!found) {
@@ -125,12 +137,14 @@ export async function handleMailRemoveRecipient(
       return {
         mode: 'plan' as const,
         description: `Remove notification recipient ${params.address}`,
-        changes: [{
-          action: 'delete' as const,
-          resource_type: 'mail_recipient',
-          resource_id: params.address,
-          before: { address: params.address },
-        }],
+        changes: [
+          {
+            action: 'delete' as const,
+            resource_type: 'mail_recipient',
+            resource_id: params.address,
+            before: { address: params.address },
+          },
+        ],
         warnings: [],
         preflight_passed: blockingResources.length === 0,
         ...(blockingResources.length > 0 ? { blocking_resources: blockingResources } : {}),
@@ -173,10 +187,19 @@ export async function handleMailUpdateSettings(
   return applyWithPlan(mode, {
     preflight: async () => {
       const client = await getClient(params.controller_id);
-      const resp = await withRetry(() => settingsMailShow(client), 'mail.update_settings preflight');
+      const resp = await withRetry(
+        () => settingsMailShow(client),
+        'mail.update_settings preflight',
+      );
       const current = resp.data as Record<string, unknown> | null;
 
-      const changes: Array<{ action: 'modify'; resource_type: string; resource_id: string; before?: unknown; after?: unknown }> = [];
+      const changes: Array<{
+        action: 'modify';
+        resource_type: string;
+        resource_id: string;
+        before?: unknown;
+        after?: unknown;
+      }> = [];
       if (params.polling_interval != null) {
         changes.push({
           action: 'modify',
@@ -209,12 +232,10 @@ export async function handleMailUpdateSettings(
       const client = await getClient(params.controller_id);
       const req: { polling_interval?: number; progress_polling_interval?: number } = {};
       if (params.polling_interval != null) req.polling_interval = params.polling_interval;
-      if (params.progress_polling_interval != null) req.progress_polling_interval = params.progress_polling_interval;
+      if (params.progress_polling_interval != null)
+        req.progress_polling_interval = params.progress_polling_interval;
 
-      const resp = await withRetry(
-        () => settingsMailModify(client, req),
-        'mail.update_settings',
-      );
+      const resp = await withRetry(() => settingsMailModify(client, req), 'mail.update_settings');
       return resp.data ?? { ...req, status: 'updated' };
     },
   });

--- a/xiNAS-MCP/src/tools/network.ts
+++ b/xiNAS-MCP/src/tools/network.ts
@@ -26,7 +26,14 @@ const StaticIpSchema = z.object({
 });
 
 const BondingSchema = z.object({
-  mode: z.enum(['active-backup', 'balance-rr', 'balance-xor', '802.3ad', 'balance-tlb', 'balance-alb']),
+  mode: z.enum([
+    'active-backup',
+    'balance-rr',
+    'balance-xor',
+    '802.3ad',
+    'balance-tlb',
+    'balance-alb',
+  ]),
   members: z.array(z.string()),
 });
 
@@ -50,11 +57,7 @@ export const NetworkConfigureSchema = z.object({
 
 function buildNetplanYaml(params: z.infer<typeof NetworkConfigureSchema>): string {
   const iface = params.interface_id;
-  const lines: string[] = [
-    'network:',
-    '  version: 2',
-    '  renderer: networkd',
-  ];
+  const lines: string[] = ['network:', '  version: 2', '  renderer: networkd'];
 
   if (params.bonding) {
     lines.push('  bonds:');
@@ -120,7 +123,7 @@ export async function handleNetworkConfigure(params: z.infer<typeof NetworkConfi
   return applyWithPlan(mode, {
     preflight: async () => {
       const ifaces = listInterfaces();
-      const iface = ifaces.find(i => i.name === params.interface_id);
+      const iface = ifaces.find((i) => i.name === params.interface_id);
       const warnings: string[] = [];
 
       if (!iface && !params.bonding) {
@@ -139,13 +142,15 @@ export async function handleNetworkConfigure(params: z.infer<typeof NetworkConfi
       return {
         mode: 'plan' as const,
         description: `Configure interface '${params.interface_id}'`,
-        changes: [{
-          action: existingYaml ? 'modify' : 'create',
-          resource_type: 'network_config',
-          resource_id: params.interface_id,
-          before: existingYaml,
-          after: yaml,
-        }],
+        changes: [
+          {
+            action: existingYaml ? 'modify' : 'create',
+            resource_type: 'network_config',
+            resource_id: params.interface_id,
+            before: existingYaml,
+            after: yaml,
+          },
+        ],
         warnings,
         preflight_passed: true,
       } satisfies PlanResult;

--- a/xiNAS-MCP/src/tools/pool.ts
+++ b/xiNAS-MCP/src/tools/pool.ts
@@ -4,8 +4,16 @@
 
 import { z } from 'zod';
 import { getClient, withRetry } from '../grpc/client.js';
-import { poolShow, poolCreate, poolDelete, poolAdd, poolRemove,
-         poolActivate, poolDeactivate, poolAcquire } from '../grpc/pool.js';
+import {
+  poolShow,
+  poolCreate,
+  poolDelete,
+  poolAdd,
+  poolRemove,
+  poolActivate,
+  poolDeactivate,
+  poolAcquire,
+} from '../grpc/pool.js';
 import { raidShow } from '../grpc/raid.js';
 import { applyWithPlan } from '../middleware/planApply.js';
 import { resolveController } from '../server/controllerResolver.js';
@@ -73,7 +81,10 @@ async function getRaidDrives(controllerId?: string): Promise<Set<string>> {
   const drives = new Set<string>();
   try {
     const client = await getClient(controllerId);
-    const resp = await withRetry(() => raidShow(client, { extended: true, units: 'g' }), 'pool preflight raidShow');
+    const resp = await withRetry(
+      () => raidShow(client, { extended: true, units: 'g' }),
+      'pool preflight raidShow',
+    );
     const arrays = resp.data as Array<{ devices?: Array<{ device?: string }> }> | null;
     if (arrays) {
       for (const arr of arrays) {
@@ -82,7 +93,9 @@ async function getRaidDrives(controllerId?: string): Promise<Set<string>> {
         }
       }
     }
-  } catch { /* best-effort */ }
+  } catch {
+    /* best-effort */
+  }
   return drives;
 }
 
@@ -92,10 +105,13 @@ async function getPoolDrives(controllerId?: string): Promise<Map<string, string>
   try {
     const client = await getClient(controllerId);
     const resp = await withRetry(() => poolShow(client, { units: 'g' }), 'pool preflight poolShow');
-    const pools = resp.data as Record<string, { devices?: Array<[number, string, string[]]> }> | Array<{ name: string; devices?: Array<[number, string, string[]]> }> | null;
+    const pools = resp.data as
+      | Record<string, { devices?: Array<[number, string, string[]]> }>
+      | Array<{ name: string; devices?: Array<[number, string, string[]]> }>
+      | null;
     if (pools) {
       const entries = Array.isArray(pools)
-        ? pools.map(p => [p.name, p] as const)
+        ? pools.map((p) => [p.name, p] as const)
         : Object.entries(pools);
       for (const [poolName, pool] of entries) {
         for (const dev of pool.devices ?? []) {
@@ -104,34 +120,52 @@ async function getPoolDrives(controllerId?: string): Promise<Map<string, string>
         }
       }
     }
-  } catch { /* best-effort */ }
+  } catch {
+    /* best-effort */
+  }
   return map;
 }
 
 /** Check whether a pool is assigned to any RAID array. */
-async function isPoolAssignedToRaid(poolName: string, controllerId?: string): Promise<string | null> {
+async function isPoolAssignedToRaid(
+  poolName: string,
+  controllerId?: string,
+): Promise<string | null> {
   try {
     const client = await getClient(controllerId);
-    const resp = await withRetry(() => raidShow(client, { extended: true, units: 'g' }), 'pool preflight raidShow');
+    const resp = await withRetry(
+      () => raidShow(client, { extended: true, units: 'g' }),
+      'pool preflight raidShow',
+    );
     const arrays = resp.data as Array<{ name: string; sparepool?: string }> | null;
     if (arrays) {
       for (const arr of arrays) {
         if (arr.sparepool === poolName) return arr.name;
       }
     }
-  } catch { /* best-effort */ }
+  } catch {
+    /* best-effort */
+  }
   return null;
 }
 
 /** Verify a pool exists, return pool data or throw NOT_FOUND. */
-async function requirePool(poolName: string, controllerId?: string): Promise<Record<string, unknown>> {
+async function requirePool(
+  poolName: string,
+  controllerId?: string,
+): Promise<Record<string, unknown>> {
   const client = await getClient(controllerId);
-  const resp = await withRetry(() => poolShow(client, { name: poolName, units: 'g' }), 'pool preflight poolShow');
+  const resp = await withRetry(
+    () => poolShow(client, { name: poolName, units: 'g' }),
+    'pool preflight poolShow',
+  );
   const data = resp.data;
   // poolShow returns dict of name→pool or list of pools
   const pool = Array.isArray(data)
     ? data.find((p: Record<string, unknown>) => p.name === poolName)
-    : data && typeof data === 'object' ? (data as Record<string, unknown>)[poolName] : null;
+    : data && typeof data === 'object'
+      ? (data as Record<string, unknown>)[poolName]
+      : null;
   if (!pool) {
     throw new McpToolError(ErrorCode.NOT_FOUND, `Spare pool '${poolName}' not found`);
   }
@@ -157,7 +191,9 @@ export async function handlePoolCreate(params: z.infer<typeof PoolCreateSchema>)
       const warnings: string[] = [];
 
       if (!POOL_NAME_RE.test(params.name)) {
-        blockingResources.push(`Invalid pool name '${params.name}': must match ${POOL_NAME_RE.source}`);
+        blockingResources.push(
+          `Invalid pool name '${params.name}': must match ${POOL_NAME_RE.source}`,
+        );
       }
 
       // Check drives are not in RAID
@@ -180,12 +216,14 @@ export async function handlePoolCreate(params: z.infer<typeof PoolCreateSchema>)
       return {
         mode: 'plan' as const,
         description: `Create spare pool '${params.name}' with ${params.drives.length} drive(s)`,
-        changes: [{
-          action: 'create' as const,
-          resource_type: 'spare_pool',
-          resource_id: params.name,
-          after: { drives: params.drives },
-        }],
+        changes: [
+          {
+            action: 'create' as const,
+            resource_type: 'spare_pool',
+            resource_id: params.name,
+            after: { drives: params.drives },
+          },
+        ],
         warnings,
         preflight_passed: blockingResources.length === 0,
         ...(blockingResources.length > 0 ? { blocking_resources: blockingResources } : {}),
@@ -196,7 +234,7 @@ export async function handlePoolCreate(params: z.infer<typeof PoolCreateSchema>)
       const client = await getClient(params.controller_id);
       const resp = await withRetry(
         () => poolCreate(client, { name: params.name, drives: params.drives }),
-        'pool.create'
+        'pool.create',
       );
       return resp.data;
     },
@@ -223,7 +261,9 @@ export async function handlePoolDelete(params: z.infer<typeof PoolDeleteSchema>)
       // Check not assigned to RAID
       const assignedArray = await isPoolAssignedToRaid(params.name, params.controller_id);
       if (assignedArray) {
-        blockingResources.push(`Pool '${params.name}' is assigned to RAID array '${assignedArray}'`);
+        blockingResources.push(
+          `Pool '${params.name}' is assigned to RAID array '${assignedArray}'`,
+        );
       }
 
       if (!params.dangerous) {
@@ -233,11 +273,13 @@ export async function handlePoolDelete(params: z.infer<typeof PoolDeleteSchema>)
       return {
         mode: 'plan' as const,
         description: `Delete spare pool '${params.name}'`,
-        changes: [{
-          action: 'delete' as const,
-          resource_type: 'spare_pool',
-          resource_id: params.name,
-        }],
+        changes: [
+          {
+            action: 'delete' as const,
+            resource_type: 'spare_pool',
+            resource_id: params.name,
+          },
+        ],
         warnings,
         preflight_passed: blockingResources.length === 0,
         ...(blockingResources.length > 0 ? { blocking_resources: blockingResources } : {}),
@@ -246,13 +288,13 @@ export async function handlePoolDelete(params: z.infer<typeof PoolDeleteSchema>)
 
     execute: async () => {
       if (!params.dangerous) {
-        throw new McpToolError(ErrorCode.PRECONDITION_FAILED, 'dangerous=true is required for pool.delete');
+        throw new McpToolError(
+          ErrorCode.PRECONDITION_FAILED,
+          'dangerous=true is required for pool.delete',
+        );
       }
       const client = await getClient(params.controller_id);
-      const resp = await withRetry(
-        () => poolDelete(client, { name: params.name }),
-        'pool.delete'
-      );
+      const resp = await withRetry(() => poolDelete(client, { name: params.name }), 'pool.delete');
       return resp.data;
     },
   });
@@ -295,12 +337,14 @@ export async function handlePoolAddDrives(params: z.infer<typeof PoolAddDrivesSc
       return {
         mode: 'plan' as const,
         description: `Add ${params.drives.length} drive(s) to spare pool '${params.name}'`,
-        changes: [{
-          action: 'modify' as const,
-          resource_type: 'spare_pool',
-          resource_id: params.name,
-          after: { add_drives: params.drives },
-        }],
+        changes: [
+          {
+            action: 'modify' as const,
+            resource_type: 'spare_pool',
+            resource_id: params.name,
+            after: { add_drives: params.drives },
+          },
+        ],
         warnings,
         preflight_passed: blockingResources.length === 0,
         ...(blockingResources.length > 0 ? { blocking_resources: blockingResources } : {}),
@@ -311,7 +355,7 @@ export async function handlePoolAddDrives(params: z.infer<typeof PoolAddDrivesSc
       const client = await getClient(params.controller_id);
       const resp = await withRetry(
         () => poolAdd(client, { name: params.name, drives: params.drives }),
-        'pool.add_drives'
+        'pool.add_drives',
       );
       return resp.data;
     },
@@ -331,7 +375,9 @@ export async function handlePoolRemoveDrives(params: z.infer<typeof PoolRemoveDr
       try {
         const pool = await requirePool(params.name, params.controller_id);
         const devices = (pool.devices ?? []) as Array<[number, string, string[]]>;
-        const poolDevPaths = new Set(devices.map(d => Array.isArray(d) && d.length > 1 ? d[1] : String(d)));
+        const poolDevPaths = new Set(
+          devices.map((d) => (Array.isArray(d) && d.length > 1 ? d[1] : String(d))),
+        );
 
         for (const d of params.drives) {
           if (!poolDevPaths.has(d)) {
@@ -346,12 +392,14 @@ export async function handlePoolRemoveDrives(params: z.infer<typeof PoolRemoveDr
       return {
         mode: 'plan' as const,
         description: `Remove ${params.drives.length} drive(s) from spare pool '${params.name}'`,
-        changes: [{
-          action: 'modify' as const,
-          resource_type: 'spare_pool',
-          resource_id: params.name,
-          after: { remove_drives: params.drives },
-        }],
+        changes: [
+          {
+            action: 'modify' as const,
+            resource_type: 'spare_pool',
+            resource_id: params.name,
+            after: { remove_drives: params.drives },
+          },
+        ],
         warnings,
         preflight_passed: blockingResources.length === 0,
         ...(blockingResources.length > 0 ? { blocking_resources: blockingResources } : {}),
@@ -362,7 +410,7 @@ export async function handlePoolRemoveDrives(params: z.infer<typeof PoolRemoveDr
       const client = await getClient(params.controller_id);
       const resp = await withRetry(
         () => poolRemove(client, { name: params.name, drives: params.drives }),
-        'pool.remove_drives'
+        'pool.remove_drives',
       );
       return resp.data;
     },
@@ -372,10 +420,7 @@ export async function handlePoolRemoveDrives(params: z.infer<typeof PoolRemoveDr
 export async function handlePoolActivate(params: z.infer<typeof PoolActivateSchema>) {
   resolveController(params.controller_id);
   const client = await getClient(params.controller_id);
-  const resp = await withRetry(
-    () => poolActivate(client, { name: params.name }),
-    'pool.activate'
-  );
+  const resp = await withRetry(() => poolActivate(client, { name: params.name }), 'pool.activate');
   return resp.data;
 }
 
@@ -384,7 +429,7 @@ export async function handlePoolDeactivate(params: z.infer<typeof PoolDeactivate
   const client = await getClient(params.controller_id);
   const resp = await withRetry(
     () => poolDeactivate(client, { name: params.name }),
-    'pool.deactivate'
+    'pool.deactivate',
   );
   return resp.data;
 }
@@ -393,12 +438,13 @@ export async function handlePoolAcquire(params: z.infer<typeof PoolAcquireSchema
   resolveController(params.controller_id);
   const client = await getClient(params.controller_id);
   const resp = await withRetry(
-    () => poolAcquire(client, {
-      name: params.name,
-      size: params.size,
-      discardable: params.discardable,
-    }),
-    'pool.acquire'
+    () =>
+      poolAcquire(client, {
+        name: params.name,
+        size: params.size,
+        discardable: params.discardable,
+      }),
+    'pool.acquire',
   );
   return resp.data;
 }

--- a/xiNAS-MCP/src/tools/raid.ts
+++ b/xiNAS-MCP/src/tools/raid.ts
@@ -5,8 +5,18 @@
 import { z } from 'zod';
 import * as fs from 'fs';
 import { getClient, withRetry } from '../grpc/client.js';
-import { raidShow, raidCreate, raidDestroy, raidModify, raidUnload,
-         raidRestore, raidInitStart, raidInitStop, raidReconStart, raidReconStop } from '../grpc/raid.js';
+import {
+  raidShow,
+  raidCreate,
+  raidDestroy,
+  raidModify,
+  raidUnload,
+  raidRestore,
+  raidInitStart,
+  raidInitStop,
+  raidReconStart,
+  raidReconStop,
+} from '../grpc/raid.js';
 import { arrayLocks } from '../middleware/locking.js';
 import { applyWithPlan } from '../middleware/planApply.js';
 import { resolveController } from '../server/controllerResolver.js';
@@ -74,7 +84,16 @@ export const RaidDeleteSchema = z.object({
 
 // --- Min drive counts per RAID level ---
 const MIN_DRIVES: Record<string, number> = {
-  '0': 2, '1': 2, '5': 3, '6': 4, '7': 4, '10': 4, '50': 6, '60': 8, '70': 8, 'N+M': 4,
+  '0': 2,
+  '1': 2,
+  '5': 3,
+  '6': 4,
+  '7': 4,
+  '10': 4,
+  '50': 6,
+  '60': 8,
+  '70': 8,
+  'N+M': 4,
 };
 
 function requiresGroupSize(level: string): boolean {
@@ -96,7 +115,9 @@ async function getMountedArrayPaths(): Promise<Map<string, string>> {
       const match = device.match(/^\/dev\/xi_(.+)$/);
       if (match) result.set(match[1] ?? '', mountpoint);
     }
-  } catch { /* */ }
+  } catch {
+    /* */
+  }
   return result;
 }
 
@@ -105,7 +126,10 @@ async function getMountedArrayPaths(): Promise<Map<string, string>> {
 export async function handleRaidList(params: z.infer<typeof RaidListSchema>) {
   resolveController(params.controller_id);
   const client = await getClient(params.controller_id);
-  const resp = await withRetry(() => raidShow(client, { extended: params.extended, units: 'g' }), 'raid.list');
+  const resp = await withRetry(
+    () => raidShow(client, { extended: params.extended, units: 'g' }),
+    'raid.list',
+  );
   return resp.data;
 }
 
@@ -116,12 +140,14 @@ export async function handleRaidCreate(params: z.infer<typeof RaidCreateSchema>)
   return applyWithPlan(mode, {
     preflight: async () => {
       const warnings: string[] = [];
-      const changes = [{
-        action: 'create' as const,
-        resource_type: 'raid_array',
-        resource_id: params.name,
-        after: { level: params.level, drives: params.drives },
-      }];
+      const changes = [
+        {
+          action: 'create' as const,
+          resource_type: 'raid_array',
+          resource_id: params.name,
+          after: { level: params.level, drives: params.drives },
+        },
+      ];
 
       // Memory check
       const memLimit = params.memory_limit ?? 1024;
@@ -145,7 +171,9 @@ export async function handleRaidCreate(params: z.infer<typeof RaidCreateSchema>)
           changes,
           warnings,
           preflight_passed: false,
-          blocking_resources: [`RAID ${params.level} requires at least ${minDrives} drives (got ${params.drives.length})`],
+          blocking_resources: [
+            `RAID ${params.level} requires at least ${minDrives} drives (got ${params.drives.length})`,
+          ],
         } satisfies PlanResult;
       }
 
@@ -164,12 +192,16 @@ export async function handleRaidCreate(params: z.infer<typeof RaidCreateSchema>)
       // group_size divisibility
       if (params.group_size) {
         if (params.drives.length % params.group_size !== 0) {
-          warnings.push(`group_size ${params.group_size} does not evenly divide drive count ${params.drives.length}`);
+          warnings.push(
+            `group_size ${params.group_size} does not evenly divide drive count ${params.drives.length}`,
+          );
         }
       }
 
       if (params.drives.length > 20 && params.level === '7') {
-        warnings.push('Level 7 arrays with > 20 drives: consider Level 7.3 (N+M) for better performance');
+        warnings.push(
+          'Level 7 arrays with > 20 drives: consider Level 7.3 (N+M) for better performance',
+        );
       }
 
       return {
@@ -184,24 +216,32 @@ export async function handleRaidCreate(params: z.infer<typeof RaidCreateSchema>)
     execute: async () => {
       const client = await getClient(params.controller_id);
       return arrayLocks.withLock(params.name, 'raid.create', async () => {
-        const resp = await withRetry(() => raidCreate(client, {
-          name: params.name,
-          level: params.level,
-          drives: params.drives,
-          ...(params.group_size !== undefined ? { group_size: params.group_size } : {}),
-          ...(params.synd_cnt !== undefined ? { synd_cnt: params.synd_cnt } : {}),
-          ...(params.strip_size !== undefined ? { strip_size: params.strip_size } : {}),
-          ...(params.block_size !== undefined ? { block_size: parseInt(params.block_size) } : {}),
-          ...(params.memory_limit !== undefined ? { memory_limit: params.memory_limit } : {}),
-          ...(params.sparepool !== undefined ? { sparepool: params.sparepool } : {}),
-        }), 'raid.create');
+        const resp = await withRetry(
+          () =>
+            raidCreate(client, {
+              name: params.name,
+              level: params.level,
+              drives: params.drives,
+              ...(params.group_size !== undefined ? { group_size: params.group_size } : {}),
+              ...(params.synd_cnt !== undefined ? { synd_cnt: params.synd_cnt } : {}),
+              ...(params.strip_size !== undefined ? { strip_size: params.strip_size } : {}),
+              ...(params.block_size !== undefined
+                ? { block_size: parseInt(params.block_size) }
+                : {}),
+              ...(params.memory_limit !== undefined ? { memory_limit: params.memory_limit } : {}),
+              ...(params.sparepool !== undefined ? { sparepool: params.sparepool } : {}),
+            }),
+          'raid.create',
+        );
         return resp.data;
       });
     },
   });
 }
 
-export async function handleRaidModifyPerformance(params: z.infer<typeof RaidModifyPerformanceSchema>) {
+export async function handleRaidModifyPerformance(
+  params: z.infer<typeof RaidModifyPerformanceSchema>,
+) {
   resolveController(params.controller_id);
   const mode = params.mode as Mode;
 
@@ -210,10 +250,10 @@ export async function handleRaidModifyPerformance(params: z.infer<typeof RaidMod
       const client = await getClient(params.controller_id);
       const showResp = await withRetry(
         () => raidShow(client, { name: params.array_id, extended: false, units: 'g' }),
-        'raid.modify_performance preflight'
+        'raid.modify_performance preflight',
       );
       const raids = showResp.data as Array<{ name: string; state: string }> | null;
-      const raid = raids?.find(r => r.name === params.array_id);
+      const raid = raids?.find((r) => r.name === params.array_id);
       if (!raid) {
         return {
           mode: 'plan' as const,
@@ -228,18 +268,20 @@ export async function handleRaidModifyPerformance(params: z.infer<typeof RaidMod
       return {
         mode: 'plan' as const,
         description: `Modify performance parameters of array '${params.array_id}'`,
-        changes: [{
-          action: 'modify',
-          resource_type: 'raid_array',
-          resource_id: params.array_id,
-          before: { state: raid.state },
-          after: {
-            merge_write_enabled: params.merge_write_enabled,
-            merge_read_enabled: params.merge_read_enabled,
-            sched_enabled: params.sched_enabled,
-            memory_limit: params.memory_limit,
+        changes: [
+          {
+            action: 'modify',
+            resource_type: 'raid_array',
+            resource_id: params.array_id,
+            before: { state: raid.state },
+            after: {
+              merge_write_enabled: params.merge_write_enabled,
+              merge_read_enabled: params.merge_read_enabled,
+              sched_enabled: params.sched_enabled,
+              memory_limit: params.memory_limit,
+            },
           },
-        }],
+        ],
         warnings: [],
         preflight_passed: true,
       } satisfies PlanResult;
@@ -248,13 +290,23 @@ export async function handleRaidModifyPerformance(params: z.infer<typeof RaidMod
     execute: async () => {
       const client = await getClient(params.controller_id);
       return arrayLocks.withLock(params.array_id, 'raid.modify_performance', async () => {
-        const resp = await withRetry(() => raidModify(client, {
-          name: params.array_id,
-          ...(params.merge_write_enabled !== undefined ? { merge_write_enabled: params.merge_write_enabled } : {}),
-          ...(params.merge_read_enabled !== undefined ? { merge_read_enabled: params.merge_read_enabled } : {}),
-          ...(params.sched_enabled !== undefined ? { sched_enabled: params.sched_enabled } : {}),
-          ...(params.memory_limit !== undefined ? { memory_limit: params.memory_limit } : {}),
-        }), 'raid.modify_performance');
+        const resp = await withRetry(
+          () =>
+            raidModify(client, {
+              name: params.array_id,
+              ...(params.merge_write_enabled !== undefined
+                ? { merge_write_enabled: params.merge_write_enabled }
+                : {}),
+              ...(params.merge_read_enabled !== undefined
+                ? { merge_read_enabled: params.merge_read_enabled }
+                : {}),
+              ...(params.sched_enabled !== undefined
+                ? { sched_enabled: params.sched_enabled }
+                : {}),
+              ...(params.memory_limit !== undefined ? { memory_limit: params.memory_limit } : {}),
+            }),
+          'raid.modify_performance',
+        );
         return resp.data;
       });
     },
@@ -262,7 +314,7 @@ export async function handleRaidModifyPerformance(params: z.infer<typeof RaidMod
 }
 
 export async function handleRaidLifecycleControl(
-  params: z.infer<typeof RaidLifecycleControlSchema>
+  params: z.infer<typeof RaidLifecycleControlSchema>,
 ): Promise<unknown> {
   resolveController(params.controller_id);
   const client = await getClient(params.controller_id);
@@ -270,13 +322,27 @@ export async function handleRaidLifecycleControl(
   return arrayLocks.withLock(params.array_id, 'raid.lifecycle_control', async () => {
     let resp;
     if (params.process === 'init') {
-      resp = params.action === 'start'
-        ? await withRetry(() => raidInitStart(client, { name: params.array_id }), 'raid_init_start')
-        : await withRetry(() => raidInitStop(client, { name: params.array_id }), 'raid_init_stop');
+      resp =
+        params.action === 'start'
+          ? await withRetry(
+              () => raidInitStart(client, { name: params.array_id }),
+              'raid_init_start',
+            )
+          : await withRetry(
+              () => raidInitStop(client, { name: params.array_id }),
+              'raid_init_stop',
+            );
     } else {
-      resp = params.action === 'start'
-        ? await withRetry(() => raidReconStart(client, { name: params.array_id }), 'raid_recon_start')
-        : await withRetry(() => raidReconStop(client, { name: params.array_id }), 'raid_recon_stop');
+      resp =
+        params.action === 'start'
+          ? await withRetry(
+              () => raidReconStart(client, { name: params.array_id }),
+              'raid_recon_start',
+            )
+          : await withRetry(
+              () => raidReconStop(client, { name: params.array_id }),
+              'raid_recon_stop',
+            );
     }
 
     // Create a polling job for 'start' actions
@@ -294,8 +360,13 @@ export async function handleRaidLifecycleControl(
         try {
           const c = await getClient(ctrlId);
           const r = await raidShow(c, { name: arrayId, extended: true, units: 'g' });
-          const raids = r.data as Array<{ name: string; init_progress?: number; recon_progress?: number; state?: string }> | null;
-          const info = raids?.find(x => x.name === arrayId);
+          const raids = r.data as Array<{
+            name: string;
+            init_progress?: number;
+            recon_progress?: number;
+            state?: string;
+          }> | null;
+          const info = raids?.find((x) => x.name === arrayId);
           if (info) {
             const pct = params.process === 'init' ? info.init_progress : info.recon_progress;
             if (pct !== undefined) JobManager.update(jobId, { progress_pct: pct });
@@ -324,7 +395,7 @@ export async function handleRaidUnload(params: z.infer<typeof RaidUnloadSchema>)
   return arrayLocks.withLock(params.array_id, 'raid.unload', async () => {
     const resp = await withRetry(
       () => raidUnload(client, { name: params.array_id }),
-      'raid.unload'
+      'raid.unload',
     );
     return resp.data;
   });
@@ -334,10 +405,14 @@ export async function handleRaidRestore(params: z.infer<typeof RaidRestoreSchema
   resolveController(params.controller_id);
   const client = await getClient(params.controller_id);
 
-  const resp = await withRetry(() => raidRestore(client, {
-    all: params.source === 'drives',
-    ...(params.array_id ? { name: params.array_id } : {}),
-  }), 'raid.restore');
+  const resp = await withRetry(
+    () =>
+      raidRestore(client, {
+        all: params.source === 'drives',
+        ...(params.array_id ? { name: params.array_id } : {}),
+      }),
+    'raid.restore',
+  );
   return resp.data;
 }
 
@@ -362,7 +437,7 @@ export async function handleRaidDelete(params: z.infer<typeof RaidDeleteSchema>)
         const exports = await listExports();
         const mountpoint = mountedArrays.get(params.array_id);
         if (mountpoint) {
-          const activeExports = exports.filter(e => e.path.startsWith(mountpoint));
+          const activeExports = exports.filter((e) => e.path.startsWith(mountpoint));
           for (const exp of activeExports) {
             blockingResources.push(`Active NFS export: ${exp.path}`);
           }
@@ -378,11 +453,13 @@ export async function handleRaidDelete(params: z.infer<typeof RaidDeleteSchema>)
       return {
         mode: 'plan' as const,
         description: `Delete RAID array '${params.array_id}'`,
-        changes: [{
-          action: 'delete',
-          resource_type: 'raid_array',
-          resource_id: params.array_id,
-        }],
+        changes: [
+          {
+            action: 'delete',
+            resource_type: 'raid_array',
+            resource_id: params.array_id,
+          },
+        ],
         warnings,
         preflight_passed: blockingResources.length === 0,
         ...(blockingResources.length > 0 ? { blocking_resources: blockingResources } : {}),
@@ -391,13 +468,16 @@ export async function handleRaidDelete(params: z.infer<typeof RaidDeleteSchema>)
 
     execute: async () => {
       if (!params.dangerous) {
-        throw new McpToolError(ErrorCode.PRECONDITION_FAILED, 'dangerous=true is required for raid.delete');
+        throw new McpToolError(
+          ErrorCode.PRECONDITION_FAILED,
+          'dangerous=true is required for raid.delete',
+        );
       }
       const client = await getClient(params.controller_id);
       return arrayLocks.withLock(params.array_id, 'raid.delete', async () => {
         const resp = await withRetry(
           () => raidDestroy(client, { name: params.array_id, force: false }),
-          'raid.delete'
+          'raid.delete',
         );
         return resp.data;
       });

--- a/xiNAS-MCP/src/tools/share.ts
+++ b/xiNAS-MCP/src/tools/share.ts
@@ -5,8 +5,16 @@
 import { z } from 'zod';
 import * as fs from 'fs';
 import * as path from 'path';
-import { listExports, addExport, removeExport, updateExport,
-         listSessions, getSessions, setQuota, reloadExports } from '../os/nfsClient.js';
+import {
+  listExports,
+  addExport,
+  removeExport,
+  updateExport,
+  listSessions,
+  getSessions,
+  setQuota,
+  reloadExports,
+} from '../os/nfsClient.js';
 import { applyWithPlan } from '../middleware/planApply.js';
 import { resolveController } from '../server/controllerResolver.js';
 import type { ExportEntry, ClientSpec } from '../types/nfs.js';
@@ -40,12 +48,19 @@ export const ShareCreateSchema = z.object({
   nfs_versions: z.array(z.string()).default(['4.2', '4.1', '4', '3']),
   async_commit: z.boolean().default(false),
   rdma: z.boolean().default(false).describe('Enable RDMA transport'),
-  create_path: z.boolean().default(false).describe(
-    'Create the export directory on apply if it does not exist. Parent directory must already exist (single-level mkdir).'
-  ),
-  path_mode: z.string().regex(PATH_MODE_RE, 'octal mode like "0755" or "1777"').default('0755').describe(
-    'Octal mode for the created directory (only used when create_path=true). Examples: "0755", "1777".'
-  ),
+  create_path: z
+    .boolean()
+    .default(false)
+    .describe(
+      'Create the export directory on apply if it does not exist. Parent directory must already exist (single-level mkdir).',
+    ),
+  path_mode: z
+    .string()
+    .regex(PATH_MODE_RE, 'octal mode like "0755" or "1777"')
+    .default('0755')
+    .describe(
+      'Octal mode for the created directory (only used when create_path=true). Examples: "0755", "1777".',
+    ),
   mode: z.enum(['plan', 'apply']).default('plan'),
   idempotency_key: z.string().optional(),
 });
@@ -73,7 +88,10 @@ export const ShareDeleteSchema = z.object({
   share_id: z.string(),
   mode: z.enum(['plan', 'apply']).default('plan'),
   dangerous: z.boolean().default(false),
-  delete_data: z.boolean().default(false).describe('Also delete underlying filesystem data (DESTRUCTIVE)'),
+  delete_data: z
+    .boolean()
+    .default(false)
+    .describe('Also delete underlying filesystem data (DESTRUCTIVE)'),
 });
 
 // --- Helpers ---
@@ -107,7 +125,9 @@ export async function handleShareList(params: z.infer<typeof ShareListSchema>) {
   return listExports();
 }
 
-export async function handleShareGetActiveSessions(params: z.infer<typeof ShareGetActiveSessionsSchema>) {
+export async function handleShareGetActiveSessions(
+  params: z.infer<typeof ShareGetActiveSessionsSchema>,
+) {
   resolveController(params.controller_id);
   return getSessions(params.share_id);
 }
@@ -135,13 +155,13 @@ export async function handleShareCreate(params: z.infer<typeof ShareCreateSchema
       if (!pathExists) {
         if (!params.create_path) {
           blockingResources.push(
-            `Path does not exist: ${params.path} — set create_path=true to auto-create it on apply`
+            `Path does not exist: ${params.path} — set create_path=true to auto-create it on apply`,
           );
         } else {
           const parent = path.dirname(params.path);
           if (!fs.existsSync(parent) || !fs.statSync(parent).isDirectory()) {
             blockingResources.push(
-              `Parent directory does not exist: ${parent} — create the parent first (single-level mkdir only)`
+              `Parent directory does not exist: ${parent} — create the parent first (single-level mkdir only)`,
             );
           } else {
             warnings.push(`Path will be created at ${params.path} with mode ${params.path_mode}`);
@@ -155,7 +175,7 @@ export async function handleShareCreate(params: z.infer<typeof ShareCreateSchema
       // Check for duplicate
       try {
         const existing = await listExports();
-        if (existing.find(e => e.path === params.path)) {
+        if (existing.find((e) => e.path === params.path)) {
           warnings.push(`Export '${params.path}' already exists — will be overwritten`);
         }
       } catch {
@@ -164,7 +184,7 @@ export async function handleShareCreate(params: z.infer<typeof ShareCreateSchema
 
       const entry: ExportEntry = {
         path: params.path,
-        clients: params.clients.map(c => ({
+        clients: params.clients.map((c) => ({
           host: c.host,
           options: buildNfsOptions({
             clients: [c],
@@ -179,12 +199,14 @@ export async function handleShareCreate(params: z.infer<typeof ShareCreateSchema
       return {
         mode: 'plan' as const,
         description: `Create NFS export '${params.path}'`,
-        changes: [{
-          action: 'create',
-          resource_type: 'nfs_export',
-          resource_id: params.path,
-          after: entry,
-        }],
+        changes: [
+          {
+            action: 'create',
+            resource_type: 'nfs_export',
+            resource_id: params.path,
+            after: entry,
+          },
+        ],
         warnings,
         preflight_passed: blockingResources.length === 0,
         ...(blockingResources.length > 0 ? { blocking_resources: blockingResources } : {}),
@@ -194,7 +216,7 @@ export async function handleShareCreate(params: z.infer<typeof ShareCreateSchema
     execute: async () => {
       const entry: ExportEntry = {
         path: params.path,
-        clients: params.clients.map(c => ({
+        clients: params.clients.map((c) => ({
           host: c.host,
           options: buildNfsOptions({
             clients: [c],
@@ -237,26 +259,32 @@ export async function handleShareUpdatePolicy(params: z.infer<typeof ShareUpdate
       let exp: ExportEntry | undefined;
       try {
         const existing = await listExports();
-        exp = existing.find(e => e.path === params.share_id);
+        exp = existing.find((e) => e.path === params.share_id);
         if (!exp) {
           blockingResources.push(`Export '${params.share_id}' not found`);
         }
       } catch {
         if (nfs.ready) {
-          blockingResources.push(`Cannot verify export '${params.share_id}' — nfs-helper unreachable`);
+          blockingResources.push(
+            `Cannot verify export '${params.share_id}' — nfs-helper unreachable`,
+          );
         }
       }
 
       return {
         mode: 'plan' as const,
         description: `Update NFS export policy for '${params.share_id}'`,
-        changes: exp ? [{
-          action: 'modify' as const,
-          resource_type: 'nfs_export',
-          resource_id: params.share_id,
-          before: exp,
-          after: { ...exp, ...params },
-        }] : [],
+        changes: exp
+          ? [
+              {
+                action: 'modify' as const,
+                resource_type: 'nfs_export',
+                resource_id: params.share_id,
+                before: exp,
+                after: { ...exp, ...params },
+              },
+            ]
+          : [],
         warnings,
         preflight_passed: blockingResources.length === 0,
         ...(blockingResources.length > 0 ? { blocking_resources: blockingResources } : {}),
@@ -319,12 +347,14 @@ export async function handleShareDelete(params: z.infer<typeof ShareDeleteSchema
       return {
         mode: 'plan' as const,
         description: `Delete NFS export '${params.share_id}'`,
-        changes: [{
-          action: 'delete',
-          resource_type: 'nfs_export',
-          resource_id: params.share_id,
-          ...(params.delete_data ? {} : {}),
-        }],
+        changes: [
+          {
+            action: 'delete',
+            resource_type: 'nfs_export',
+            resource_id: params.share_id,
+            ...(params.delete_data ? {} : {}),
+          },
+        ],
         warnings,
         preflight_passed: blockingResources.length === 0,
         ...(blockingResources.length > 0 ? { blocking_resources: blockingResources } : {}),

--- a/xiNAS-MCP/src/tools/system.ts
+++ b/xiNAS-MCP/src/tools/system.ts
@@ -41,10 +41,28 @@ export const GetPerformanceSchema = z.object({
 
 export const GetLogsSchema = z.object({
   controller_id: z.string().optional(),
-  service: z.string().optional().describe('Systemd unit name (e.g. nfs-kernel-server, xiraid-server)'),
-  lines: z.number().int().min(1).max(500).default(50).describe('Number of journal lines to retrieve'),
-  since: z.string().optional().describe('Time filter: ISO 8601 timestamp or relative (e.g. "-1h", "-30m")'),
-  priority: z.number().int().min(0).max(7).optional().describe('Max syslog priority (0=emerg..7=debug)'),
+  service: z
+    .string()
+    .optional()
+    .describe('Systemd unit name (e.g. nfs-kernel-server, xiraid-server)'),
+  lines: z
+    .number()
+    .int()
+    .min(1)
+    .max(500)
+    .default(50)
+    .describe('Number of journal lines to retrieve'),
+  since: z
+    .string()
+    .optional()
+    .describe('Time filter: ISO 8601 timestamp or relative (e.g. "-1h", "-30m")'),
+  priority: z
+    .number()
+    .int()
+    .min(0)
+    .max(7)
+    .optional()
+    .describe('Max syslog priority (0=emerg..7=debug)'),
 });
 
 // --- Handlers ---
@@ -63,7 +81,7 @@ export function handleGetServerInfo(_params: z.infer<typeof GetServerInfoSchema>
       streamable_http: config.http_enabled,
       ...(config.sse_enabled || config.http_enabled ? { port } : {}),
       tls: !!config.tls,
-      mtls: !!(config.tls?.ca),
+      mtls: !!config.tls?.ca,
     },
   };
 }
@@ -71,16 +89,18 @@ export function handleGetServerInfo(_params: z.infer<typeof GetServerInfoSchema>
 export function handleListControllers(_params: z.infer<typeof ListControllersSchema>) {
   const config = loadConfig();
   const ctrlInfo = resolveController();
-  return [{
-    controller_id: config.controller_id,
-    hostname: getHostname(),
-    grpc_endpoint: ctrlInfo.grpc_endpoint,
-    nfs_socket: ctrlInfo.nfs_socket,
-  }];
+  return [
+    {
+      controller_id: config.controller_id,
+      hostname: getHostname(),
+      grpc_endpoint: ctrlInfo.grpc_endpoint,
+      nfs_socket: ctrlInfo.nfs_socket,
+    },
+  ];
 }
 
 export async function handleGetControllerCapabilities(
-  params: z.infer<typeof GetControllerCapabilitiesSchema>
+  params: z.infer<typeof GetControllerCapabilitiesSchema>,
 ) {
   resolveController(params.controller_id);
   const client = await getClient(params.controller_id);
@@ -113,8 +133,9 @@ export async function handleGetStatus(params: z.infer<typeof GetStatusSchema>) {
     withRetry(() => licenseShow(client), 'license_show'),
   ]);
 
-  const services = ['xiraid-server', 'nfs-server', 'nfs-kernel-server', 'xinas-nfs-helper']
-    .map(s => getServiceState(s));
+  const services = ['xiraid-server', 'nfs-server', 'nfs-kernel-server', 'xinas-nfs-helper'].map(
+    (s) => getServiceState(s),
+  );
 
   return {
     controller_id: loadConfig().controller_id,
@@ -142,7 +163,7 @@ export async function handleGetInventory(params: z.infer<typeof GetInventorySche
     hostname: getHostname(),
     cpu: sysInfo.cpu,
     memory: sysInfo.memory,
-    block_devices: blockDevices.map(d => ({
+    block_devices: blockDevices.map((d) => ({
       path: d.path,
       model: d.model,
       serial: d.serial,
@@ -150,7 +171,7 @@ export async function handleGetInventory(params: z.infer<typeof GetInventorySche
       rotational: d.rotational,
       nvme: !!d.nvme_ctrl,
     })),
-    network_interfaces: networkIfaces.map(i => ({
+    network_interfaces: networkIfaces.map((i) => ({
       name: i.name,
       mac: i.mac,
       operstate: i.operstate,
@@ -188,16 +209,18 @@ export async function handleGetLogs(params: z.infer<typeof GetLogsSchema>) {
   if (params.since) args.push('--since', params.since);
   if (params.priority !== undefined) args.push('-p', params.priority.toString());
 
-  const result = await new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve, reject) => {
-    execFile('journalctl', args, { timeout: JOURNAL_TIMEOUT_MS }, (err, stdout, stderr) => {
-      if (err && 'killed' in err && err.killed) {
-        reject(new McpToolError(ErrorCode.TIMEOUT, 'journalctl timed out'));
-        return;
-      }
-      const exitCode = err && 'code' in err ? (err.code as number) : 0;
-      resolve({ stdout: stdout ?? '', stderr: stderr ?? '', exitCode });
-    });
-  });
+  const result = await new Promise<{ stdout: string; stderr: string; exitCode: number }>(
+    (resolve, reject) => {
+      execFile('journalctl', args, { timeout: JOURNAL_TIMEOUT_MS }, (err, stdout, stderr) => {
+        if (err && 'killed' in err && err.killed) {
+          reject(new McpToolError(ErrorCode.TIMEOUT, 'journalctl timed out'));
+          return;
+        }
+        const exitCode = err && 'code' in err ? (err.code as number) : 0;
+        resolve({ stdout: stdout ?? '', stderr: stderr ?? '', exitCode });
+      });
+    },
+  );
 
   if (result.exitCode !== 0) {
     throw new McpToolError(ErrorCode.INTERNAL, `journalctl failed: ${result.stderr.trim()}`);
@@ -206,8 +229,8 @@ export async function handleGetLogs(params: z.infer<typeof GetLogsSchema>) {
   // Parse JSON-formatted journal entries
   const entries = result.stdout
     .split('\n')
-    .filter(line => line.trim())
-    .map(line => {
+    .filter((line) => line.trim())
+    .map((line) => {
       try {
         const entry = JSON.parse(line) as Record<string, string | undefined>;
         return {

--- a/xiNAS-MCP/src/types/common.ts
+++ b/xiNAS-MCP/src/types/common.ts
@@ -13,13 +13,13 @@ export const ErrorCode = {
   INTERNAL: 'INTERNAL',
   RESOURCE_EXHAUSTION: 'RESOURCE_EXHAUSTION',
 } as const;
-export type ErrorCode = typeof ErrorCode[keyof typeof ErrorCode];
+export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];
 
 export class McpToolError extends Error {
   constructor(
     public readonly code: ErrorCode,
     message: string,
-    public readonly details?: unknown
+    public readonly details?: unknown,
   ) {
     super(message);
     this.name = 'McpToolError';


### PR DESCRIPTION
## Summary

Mechanical `npm run format:write` pass — no logic changes. Biome reformatted 77 files under `xiNAS-MCP/src/`:

- The new test files from PR #200 (state store) and PR #201 (xinas-api skeleton).
- The legacy `src/tools/*.ts` MCP code that predated the biome config and was never formatted.

After this lands, the `typescript-format` CI gate runs clean. Once a few subsequent PRs confirm no drift gets reintroduced, we can flip it from `continue-on-error: true` to blocking (see the comment in [`.github/workflows/ci.yml` line 63](https://github.com/XinnorLab/xiNAS/blob/main/.github/workflows/ci.yml#L63) — `flip after backlog cleanup`).

## Why this exists

Five of the six warn-only CI failures (markdown, python-format, python-lint, python-typecheck, yamllint) are documented pre-existing backlog and need separate per-domain cleanup PRs. The sixth — `typescript-format` — was our own debt from PRs #200/#201, so it's the easiest one to retire.

## Verification

- `npm run format:check` → `Checked 108 files. No fixes applied.`
- `npx tsc --noEmit` → clean
- `npm test` → 176 tests across 32 files, all pass
- Diff stat: 77 files, +2145/-968 (all under `xiNAS-MCP/src/`)

## Test plan

- [x] Local format:check clean
- [x] Local typecheck clean
- [x] Local full vitest suite green (176/32)
- [ ] CI green (typescript-format expected to flip from failure to success)
- [ ] Operator approves merge

## Not in this PR

- The other five warn-only failures (per-domain cleanup PRs).
- Flipping `continue-on-error: true` on the typescript-format job (wants a few drift-free PRs of evidence first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)