### PR TITLE
feat(phase0): xinas-agent S0+S1 — Phase C agent process skeleton (DRAFT, stacked on #206)

### DIFF
--- a/xiNAS-MCP/package.json
+++ b/xiNAS-MCP/package.json
@@ -11,6 +11,8 @@
     "typecheck": "tsc --noEmit",
     "start": "node dist/index.js",
     "start:api": "node dist/api-server.js",
+    "dev:agent": "tsx src/agent-server.ts",
+    "start:agent": "node dist/agent-server.js",
     "lint": "biome lint src/",
     "format:check": "biome format src/",
     "format:write": "biome format --write src/",

--- a/xiNAS-MCP/src/__tests__/agent/agent-server.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/agent-server.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Layer 3 smoke test: boots a real agent process on an ephemeral UDS,
+ * sends agent.health, verifies the response shape, then shuts down.
+ *
+ * The agent reads its config from env vars overriding the file paths
+ * (XINAS_AGENT_CONFIG_PATH) so no real /etc or /var paths are touched.
+ */
+
+import { type ChildProcess, spawn } from 'node:child_process';
+import { execSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createConnection } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+const PROJECT_ROOT = resolve(import.meta.dirname, '../../..'); // -> xiNAS-MCP
+const AGENT_ENTRY = join(PROJECT_ROOT, 'dist/agent-server.js');
+
+// Helper: wait until a UDS socket file appears (up to timeoutMs).
+function waitForSocket(socketPath: string, timeoutMs = 5000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const check = () => {
+      if (existsSync(socketPath)) return resolve();
+      if (Date.now() > deadline) return reject(new Error(`socket ${socketPath} never appeared`));
+      setTimeout(check, 100);
+    };
+    check();
+  });
+}
+
+// Helper: send one JSON-RPC request and return the parsed response.
+function rpcCall(socketPath: string, req: object): Promise<object> {
+  return new Promise((resolve, reject) => {
+    const client = createConnection(socketPath, () => {
+      client.write(JSON.stringify(req) + '\n');
+    });
+    let buf = '';
+    client.on('data', (chunk: Buffer) => {
+      buf += chunk.toString();
+      const nl = buf.indexOf('\n');
+      if (nl !== -1) {
+        client.destroy();
+        try {
+          resolve(JSON.parse(buf.slice(0, nl)));
+        } catch (e) {
+          reject(e);
+        }
+      }
+    });
+    client.on('error', reject);
+    setTimeout(() => reject(new Error('rpcCall timeout')), 4000);
+  });
+}
+
+describe('agent-server process smoke test', () => {
+  const procs: ChildProcess[] = [];
+  const dirs: string[] = [];
+
+  // CI runs `npm test` without a prior build; production runs the
+  // compiled artifact. Build on demand if dist/agent-server.js is absent
+  // so the smoke test exercises the real compiled entry in every env.
+  beforeAll(() => {
+    if (!existsSync(AGENT_ENTRY)) {
+      execSync('npm run build', { cwd: PROJECT_ROOT, stdio: 'inherit' });
+    }
+  }, 180_000);
+
+  afterEach(async () => {
+    for (const p of procs.splice(0)) {
+      // A test may have already SIGTERM'd the process and consumed its
+      // 'exit' event (the SIGTERM case). Attaching a fresh 'exit' listener
+      // then would hang forever, so only wait when it is still running.
+      if (p.exitCode === null && p.signalCode === null) {
+        await new Promise<void>((res) => {
+          p.once('exit', () => res());
+          p.kill('SIGTERM');
+        });
+      }
+    }
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  it('boots, binds the UDS socket, and answers agent.health', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'xinas-agent-e2e-'));
+    dirs.push(dir);
+
+    const sockPath = join(dir, 'agent.sock');
+    const ctrlIdPath = join(dir, 'controller-id');
+    const tokenPath = join(dir, 'agent-token');
+    const configPath = join(dir, 'config.json');
+
+    writeFileSync(ctrlIdPath, '00000000-0000-0000-0000-000000000099\n');
+    writeFileSync(tokenPath, 'test-agent-token\n');
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        api_socket: join(dir, 'api.sock'), // api won't be present; agent just reads config
+        agent_socket: sockPath,
+        controller_id_path: ctrlIdPath,
+        agent_token_path: tokenPath,
+        socket_group: 'nogroup', // gid 65534 on Linux; agent skips chown on error
+      }),
+    );
+
+    const proc = spawn(process.execPath, [AGENT_ENTRY], {
+      env: { ...process.env, XINAS_AGENT_CONFIG_PATH: configPath },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    procs.push(proc);
+
+    // Collect stderr for diagnostics on failure.
+    const stderrLines: string[] = [];
+    proc.stderr?.on('data', (c: Buffer) => stderrLines.push(c.toString()));
+    proc.on('exit', (code) => {
+      if (code !== null && code !== 0) {
+        // Process exited prematurely — log stderr for diagnosis.
+        process.stderr.write('agent stderr:\n' + stderrLines.join(''));
+      }
+    });
+
+    await waitForSocket(sockPath);
+
+    const response = (await rpcCall(sockPath, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'agent.health',
+      params: {},
+    })) as Record<string, unknown>;
+
+    expect(response['result']).toBeDefined();
+    const result = response['result'] as Record<string, unknown>;
+    expect(result['version']).toBeDefined();
+    expect(result['controller_id']).toBe('00000000-0000-0000-0000-000000000099');
+    expect(result['in_flight_tasks']).toBe(0);
+    expect(result['collectors']).toBeDefined();
+  });
+
+  it('shuts down cleanly on SIGTERM', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'xinas-agent-sigterm-'));
+    dirs.push(dir);
+
+    const sockPath = join(dir, 'agent.sock');
+    const ctrlIdPath = join(dir, 'controller-id');
+    const tokenPath = join(dir, 'agent-token');
+    const configPath = join(dir, 'config.json');
+
+    writeFileSync(ctrlIdPath, '00000000-0000-0000-0000-00000000aabb\n');
+    writeFileSync(tokenPath, 'test-token\n');
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        api_socket: join(dir, 'api.sock'),
+        agent_socket: sockPath,
+        controller_id_path: ctrlIdPath,
+        agent_token_path: tokenPath,
+        socket_group: 'nogroup',
+      }),
+    );
+
+    const proc = spawn(process.execPath, [AGENT_ENTRY], {
+      env: { ...process.env, XINAS_AGENT_CONFIG_PATH: configPath },
+      stdio: 'ignore',
+    });
+    procs.push(proc);
+
+    await waitForSocket(sockPath);
+
+    const exitCode = await new Promise<number | null>((resolve) => {
+      proc.once('exit', (code) => resolve(code));
+      proc.kill('SIGTERM');
+    });
+
+    // Node processes exit with 0 on clean SIGTERM handler.
+    expect(exitCode).toBe(0);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/config.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/config.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { loadAgentConfig } from '../../agent/config.js';
+
+describe('loadAgentConfig', () => {
+  it('reads config + agent-token + controller-id', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'xinas-agent-config-'));
+    try {
+      writeFileSync(join(dir, 'controller-id'), '00000000-0000-0000-0000-0000000000aa\n');
+      writeFileSync(join(dir, 'agent-token'), 'agent-token-secret\n');
+      writeFileSync(
+        join(dir, 'config.json'),
+        JSON.stringify({
+          api_socket: '/run/xinas/api.sock',
+          agent_socket: '/run/xinas/agent.sock',
+          controller_id_path: join(dir, 'controller-id'),
+          agent_token_path: join(dir, 'agent-token'),
+          socket_group: 'xinas-api',
+        }),
+      );
+      const config = loadAgentConfig({ configPath: join(dir, 'config.json') });
+      expect(config.api_socket).toBe('/run/xinas/api.sock');
+      expect(config.controller_id).toBe('00000000-0000-0000-0000-0000000000aa');
+      expect(config.agent_token).toBe('agent-token-secret');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails fast if controller-id is missing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'xinas-agent-config-'));
+    try {
+      writeFileSync(join(dir, 'agent-token'), 'agent-token-secret\n');
+      writeFileSync(
+        join(dir, 'config.json'),
+        JSON.stringify({
+          api_socket: '/run/xinas/api.sock',
+          agent_socket: '/run/xinas/agent.sock',
+          controller_id_path: join(dir, 'controller-id'),
+          agent_token_path: join(dir, 'agent-token'),
+          socket_group: 'xinas-api',
+        }),
+      );
+      expect(() => loadAgentConfig({ configPath: join(dir, 'config.json') })).toThrow(
+        /controller-id/,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/rpc/dispatch.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/rpc/dispatch.test.ts
@@ -39,6 +39,20 @@ describe('createDispatcher', () => {
     expect(parsed.result).toBeUndefined();
   });
 
+  it.each(['__proto__', 'constructor', 'toString', 'hasOwnProperty'])(
+    'returns -32601 for inherited Object.prototype key %s (own-property routing)',
+    async (method) => {
+      const dispatch = createDispatcher({ 'agent.health': echoHandler });
+      const response = await dispatch(
+        JSON.stringify({ jsonrpc: '2.0', id: 7, method, params: {} }),
+      );
+      const parsed = JSON.parse(response);
+      expect(parsed.id).toBe(7);
+      expect(parsed.error?.code).toBe(-32601);
+      expect(parsed.result).toBeUndefined();
+    },
+  );
+
   it('returns -32602 when the handler throws a params error', async () => {
     const dispatch = createDispatcher({
       'agent.health': () => {

--- a/xiNAS-MCP/src/__tests__/agent/rpc/dispatch.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/rpc/dispatch.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { createDispatcher } from '../../../agent/rpc/dispatch.js';
+
+// A trivial handler for tests — returns its params echoed.
+function echoHandler(params: unknown): unknown {
+  return { echo: params };
+}
+
+describe('createDispatcher', () => {
+  it('routes a known method and returns a success envelope', async () => {
+    const dispatch = createDispatcher({
+      'agent.health': () => ({
+        status: 'starting',
+        version: '0.0.0',
+        uptime_seconds: 0,
+        controller_id: 'test-id',
+        in_flight_tasks: 0,
+        collectors: {},
+      }),
+    });
+    const response = await dispatch(
+      JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'agent.health', params: {} }),
+    );
+    const parsed = JSON.parse(response);
+    expect(parsed.jsonrpc).toBe('2.0');
+    expect(parsed.id).toBe(1);
+    expect(parsed.result).toBeDefined();
+    expect(parsed.error).toBeUndefined();
+  });
+
+  it('returns -32601 for a method absent from the allow-list', async () => {
+    const dispatch = createDispatcher({ 'agent.health': echoHandler });
+    const response = await dispatch(
+      JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'totally.unknown', params: {} }),
+    );
+    const parsed = JSON.parse(response);
+    expect(parsed.id).toBe(2);
+    expect(parsed.error?.code).toBe(-32601);
+    expect(parsed.result).toBeUndefined();
+  });
+
+  it('returns -32602 when the handler throws a params error', async () => {
+    const dispatch = createDispatcher({
+      'agent.health': () => {
+        const err = new Error('missing required param: foo') as Error & { code?: string };
+        err.code = 'INVALID_PARAMS';
+        throw err;
+      },
+    });
+    const response = await dispatch(
+      JSON.stringify({ jsonrpc: '2.0', id: 3, method: 'agent.health', params: {} }),
+    );
+    const parsed = JSON.parse(response);
+    expect(parsed.error?.code).toBe(-32602);
+  });
+
+  it('returns -32600 for malformed (non-JSON) input', async () => {
+    const dispatch = createDispatcher({ 'agent.health': echoHandler });
+    const response = await dispatch('this is not json at all');
+    const parsed = JSON.parse(response);
+    expect(parsed.id).toBeNull();
+    expect(parsed.error?.code).toBe(-32600);
+  });
+
+  it('returns -32600 for a valid JSON object missing the method field', async () => {
+    const dispatch = createDispatcher({ 'agent.health': echoHandler });
+    const response = await dispatch(JSON.stringify({ jsonrpc: '2.0', id: 4, params: {} }));
+    const parsed = JSON.parse(response);
+    expect(parsed.id).toBe(4);
+    expect(parsed.error?.code).toBe(-32600);
+  });
+
+  it('returns -32603 when the handler throws an unexpected error', async () => {
+    const dispatch = createDispatcher({
+      'agent.health': () => {
+        throw new Error('OS blew up');
+      },
+    });
+    const response = await dispatch(
+      JSON.stringify({ jsonrpc: '2.0', id: 5, method: 'agent.health', params: {} }),
+    );
+    const parsed = JSON.parse(response);
+    expect(parsed.error?.code).toBe(-32603);
+  });
+
+  it('returns -32000 with EXECUTOR_UNSUPPORTED data when handler throws that sentinel', async () => {
+    const dispatch = createDispatcher({
+      'arrays.list': () => {
+        const err = new Error('method not implemented in this build') as Error & {
+          code?: string;
+          rpcMethod?: string;
+        };
+        err.code = 'EXECUTOR_UNSUPPORTED';
+        err.rpcMethod = 'arrays.list';
+        throw err;
+      },
+    });
+    const response = await dispatch(
+      JSON.stringify({ jsonrpc: '2.0', id: 6, method: 'arrays.list', params: {} }),
+    );
+    const parsed = JSON.parse(response);
+    expect(parsed.error?.code).toBe(-32000);
+    expect(parsed.error?.data?.code).toBe('EXECUTOR_UNSUPPORTED');
+    expect(parsed.error?.data?.method).toBe('arrays.list');
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/rpc/methods/health.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/rpc/methods/health.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { makeHealthHandler } from '../../../../agent/rpc/methods/health.js';
+
+describe('agent.health handler', () => {
+  it('returns the required shape with no collectors registered', () => {
+    const handler = makeHealthHandler({
+      version: '0.1.0',
+      controllerId: '00000000-0000-0000-0000-000000000042',
+      startedAt: Date.now() - 5000,
+      getCollectorHealth: () => ({}),
+    });
+    const result = handler({}) as Record<string, unknown>;
+    expect(result['status']).toBe('starting');
+    expect(result['version']).toBe('0.1.0');
+    expect(typeof result['uptime_seconds']).toBe('number');
+    expect(result['uptime_seconds'] as number).toBeGreaterThanOrEqual(4);
+    expect(result['controller_id']).toBe('00000000-0000-0000-0000-000000000042');
+    expect(result['in_flight_tasks']).toBe(0);
+    expect(result['collectors']).toEqual({});
+  });
+
+  it('reports status=healthy when all collectors are running', () => {
+    const handler = makeHealthHandler({
+      version: '0.1.0',
+      controllerId: 'test-id',
+      startedAt: Date.now() - 1000,
+      getCollectorHealth: () => ({ disk: 'running', network: 'running' }),
+    });
+    const result = handler({}) as Record<string, unknown>;
+    expect(result['status']).toBe('healthy');
+    expect(result['collectors']).toEqual({ disk: 'running', network: 'running' });
+  });
+
+  it('reports status=degraded when any collector is in error state', () => {
+    const handler = makeHealthHandler({
+      version: '0.1.0',
+      controllerId: 'test-id',
+      startedAt: Date.now() - 1000,
+      getCollectorHealth: () => ({
+        disk: 'running',
+        network: 'error: connection refused',
+      }),
+    });
+    const result = handler({}) as Record<string, unknown>;
+    expect(result['status']).toBe('degraded');
+  });
+
+  it('reports status=stubbed when all non-stub collectors are absent', () => {
+    const handler = makeHealthHandler({
+      version: '0.1.0',
+      controllerId: 'test-id',
+      startedAt: Date.now() - 1000,
+      getCollectorHealth: () => ({
+        'xiraid-stub': 'stubbed',
+        'managed-files-stub': 'stubbed',
+      }),
+    });
+    const result = handler({}) as Record<string, unknown>;
+    // All present collectors are stubbed; no real collectors running.
+    // Status is 'starting' because no real collectors are up yet.
+    expect(['starting', 'stubbed']).toContain(result['status']);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/rpc/methods/health.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/rpc/methods/health.test.ts
@@ -58,6 +58,6 @@ describe('agent.health handler', () => {
     const result = handler({}) as Record<string, unknown>;
     // All present collectors are stubbed; no real collectors running.
     // Status is 'starting' because no real collectors are up yet.
-    expect(['starting', 'stubbed']).toContain(result['status']);
+    expect(result['status']).toBe('starting');
   });
 });

--- a/xiNAS-MCP/src/__tests__/agent/rpc/methods/stubs.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/rpc/methods/stubs.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { createDispatcher } from '../../../../agent/rpc/dispatch.js';
+import { makeHealthHandler } from '../../../../agent/rpc/methods/health.js';
+import { STUB_METHODS, makeStubHandler } from '../../../../agent/rpc/methods/stubs.js';
+
+// ---- individual stub handler shape ----
+
+describe('makeStubHandler', () => {
+  it('throws with code=EXECUTOR_UNSUPPORTED and the method name', () => {
+    const handler = makeStubHandler('arrays.create');
+    expect(() => handler({})).toThrow();
+    try {
+      handler({});
+    } catch (err: unknown) {
+      const typed = err as Error & { code?: string; rpcMethod?: string };
+      expect(typed.code).toBe('EXECUTOR_UNSUPPORTED');
+      expect(typed.rpcMethod).toBe('arrays.create');
+    }
+  });
+});
+
+// ---- all ADR-0002 enumerated methods are in the stub list ----
+
+const REQUIRED_STUB_METHODS = [
+  'arrays.create',
+  'arrays.delete',
+  'arrays.import',
+  'arrays.list',
+  'spare.set',
+  'fs.create',
+  'fs.mount',
+  'fs.unmount',
+  'fs.grow',
+  'fs.set_quota_mode',
+  'nfs.exports.add',
+  'nfs.exports.update',
+  'nfs.exports.remove',
+  'nfs.profile.render',
+  'nfs.profile.apply',
+  'nfs.profile.observe',
+  'network.render_netplan',
+  'network.flush_managed',
+  'network.apply',
+  'systemd.reload',
+  'systemd.restart',
+  'task.begin',
+  'task.stage_report',
+  'task.cancel',
+  'task.list_inflight',
+  'managed_files.checksums',
+];
+
+describe('STUB_METHODS coverage', () => {
+  for (const method of REQUIRED_STUB_METHODS) {
+    it(`includes stub for "${method}"`, () => {
+      expect(STUB_METHODS).toHaveProperty(method);
+    });
+  }
+});
+
+// ---- integration: dispatcher returns -32000 for stubbed methods ----
+
+describe('dispatcher integration with stubs', () => {
+  const healthHandler = makeHealthHandler({
+    version: '0.0.0',
+    controllerId: 'test',
+    startedAt: Date.now(),
+    getCollectorHealth: () => ({}),
+  });
+  const allHandlers = { 'agent.health': healthHandler, ...STUB_METHODS };
+  const dispatch = createDispatcher(allHandlers);
+
+  it('stubbed method returns -32000 EXECUTOR_UNSUPPORTED (not -32601)', async () => {
+    const response = JSON.parse(
+      await dispatch(
+        JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'arrays.create', params: {} }),
+      ),
+    );
+    expect(response.error?.code).toBe(-32000);
+    expect(response.error?.data?.code).toBe('EXECUTOR_UNSUPPORTED');
+    expect(response.error?.data?.method).toBe('arrays.create');
+  });
+
+  it('truly unknown method returns -32601 not -32000', async () => {
+    const response = JSON.parse(
+      await dispatch(
+        JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'completely.unknown', params: {} }),
+      ),
+    );
+    expect(response.error?.code).toBe(-32601);
+  });
+
+  it('agent.health still resolves to a success result', async () => {
+    const response = JSON.parse(
+      await dispatch(JSON.stringify({ jsonrpc: '2.0', id: 3, method: 'agent.health', params: {} })),
+    );
+    expect(response.result?.status).toBeDefined();
+    expect(response.error).toBeUndefined();
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/rpc/methods/version.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/rpc/methods/version.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { makeVersionHandler } from '../../../../agent/rpc/methods/version.js';
+
+describe('agent.version handler', () => {
+  it('returns the version field always', () => {
+    const handler = makeVersionHandler({ version: '1.2.3' });
+    const result = handler({}) as Record<string, unknown>;
+    expect(result['version']).toBe('1.2.3');
+  });
+
+  it('includes git_sha when provided', () => {
+    const handler = makeVersionHandler({ version: '1.2.3', gitSha: 'abc123' });
+    const result = handler({}) as Record<string, unknown>;
+    expect(result['git_sha']).toBe('abc123');
+  });
+
+  it('includes build_date when provided', () => {
+    const handler = makeVersionHandler({
+      version: '1.2.3',
+      buildDate: '2026-05-28T00:00:00Z',
+    });
+    const result = handler({}) as Record<string, unknown>;
+    expect(result['build_date']).toBe('2026-05-28T00:00:00Z');
+  });
+
+  it('omits git_sha and build_date when not provided (exactOptionalPropertyTypes)', () => {
+    const handler = makeVersionHandler({ version: '0.0.1' });
+    const result = handler({}) as Record<string, unknown>;
+    expect('git_sha' in result).toBe(false);
+    expect('build_date' in result).toBe(false);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/rpc/server.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/rpc/server.test.ts
@@ -95,6 +95,47 @@ describe('createAgentRpcServer', () => {
     expect((response as { error?: { code: number } }).error?.code).toBe(-32601);
   });
 
+  it('caps the per-connection read buffer and stays up for the next client', async () => {
+    const sockPath = tempSocketPath();
+    const dispatcher = createDispatcher({
+      'agent.health': () => ({
+        status: 'starting',
+        version: '0.0.0',
+        uptime_seconds: 0,
+        controller_id: 'test-id',
+        in_flight_tasks: 0,
+        collectors: {},
+      }),
+    });
+    const server = await createAgentRpcServer({
+      socketPath: sockPath,
+      dispatch: dispatcher,
+      socketGroupGid: process.getgid?.() ?? 0,
+    });
+    servers.push(server);
+
+    // Send ~2 MB with NO newline; the server must cap the buffer (1 MB) and
+    // close the connection rather than buffering unbounded.
+    await new Promise<void>((resolve, reject) => {
+      const client = createConnection(sockPath, () => {
+        client.write('x'.repeat(2 * 1024 * 1024));
+      });
+      client.on('close', () => resolve());
+      client.on('error', () => resolve()); // ECONNRESET on destroy is fine
+      setTimeout(() => reject(new Error('flood connection did not close')), 3000);
+    });
+
+    // The process/server must still be alive: a fresh connection gets a
+    // normal agent.health response.
+    const response = await roundtrip(sockPath, {
+      jsonrpc: '2.0',
+      id: 99,
+      method: 'agent.health',
+      params: {},
+    });
+    expect((response as { result?: { status: string } }).result?.status).toBe('starting');
+  });
+
   it('handles multiple sequential requests on the same connection', async () => {
     const sockPath = tempSocketPath();
     let callCount = 0;

--- a/xiNAS-MCP/src/__tests__/agent/rpc/server.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/rpc/server.test.ts
@@ -1,0 +1,145 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { createConnection } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createDispatcher } from '../../../agent/rpc/dispatch.js';
+import { createAgentRpcServer } from '../../../agent/rpc/server.js';
+
+const dirs: string[] = [];
+
+function tempSocketPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'xinas-server-test-'));
+  dirs.push(dir);
+  return join(dir, 'test.sock');
+}
+
+// Helper: connect to UDS, send one JSON-RPC request line, read one response line.
+function roundtrip(socketPath: string, request: object): Promise<object> {
+  return new Promise((resolve, reject) => {
+    const client = createConnection(socketPath, () => {
+      client.write(JSON.stringify(request) + '\n');
+    });
+    let buf = '';
+    client.on('data', (chunk: Buffer) => {
+      buf += chunk.toString();
+      const nl = buf.indexOf('\n');
+      if (nl !== -1) {
+        client.destroy();
+        try {
+          resolve(JSON.parse(buf.slice(0, nl)));
+        } catch (e) {
+          reject(e);
+        }
+      }
+    });
+    client.on('error', reject);
+    setTimeout(() => reject(new Error('roundtrip timeout')), 3000);
+  });
+}
+
+describe('createAgentRpcServer', () => {
+  const servers: Array<{ close(): Promise<void> }> = [];
+
+  afterEach(async () => {
+    for (const s of servers.splice(0)) await s.close();
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  it('listens on a UDS path, accepts a client, dispatches a request and returns the response', async () => {
+    const sockPath = tempSocketPath();
+    const dispatcher = createDispatcher({
+      'agent.health': () => ({
+        status: 'starting',
+        version: '0.0.0',
+        uptime_seconds: 0,
+        controller_id: 'test-id',
+        in_flight_tasks: 0,
+        collectors: {},
+      }),
+    });
+    const server = await createAgentRpcServer({
+      socketPath: sockPath,
+      dispatch: dispatcher,
+      socketGroupGid: process.getgid?.() ?? 0, // same gid for test (no chown needed)
+    });
+    servers.push(server);
+
+    expect(existsSync(sockPath)).toBe(true);
+
+    const response = await roundtrip(sockPath, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'agent.health',
+      params: {},
+    });
+    expect((response as { result?: { status: string } }).result?.status).toBe('starting');
+  });
+
+  it('handles an unknown method with -32601 over the real socket', async () => {
+    const sockPath = tempSocketPath();
+    const dispatcher = createDispatcher({ 'agent.health': () => ({ ok: true }) });
+    const server = await createAgentRpcServer({
+      socketPath: sockPath,
+      dispatch: dispatcher,
+      socketGroupGid: process.getgid?.() ?? 0,
+    });
+    servers.push(server);
+
+    const response = await roundtrip(sockPath, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'no.such.method',
+      params: {},
+    });
+    expect((response as { error?: { code: number } }).error?.code).toBe(-32601);
+  });
+
+  it('handles multiple sequential requests on the same connection', async () => {
+    const sockPath = tempSocketPath();
+    let callCount = 0;
+    const dispatcher = createDispatcher({
+      'agent.health': () => {
+        callCount++;
+        return { count: callCount };
+      },
+    });
+    const server = await createAgentRpcServer({
+      socketPath: sockPath,
+      dispatch: dispatcher,
+      socketGroupGid: process.getgid?.() ?? 0,
+    });
+    servers.push(server);
+
+    // Send two requests on the same connection.
+    const responses = await new Promise<object[]>((resolve, reject) => {
+      const client = createConnection(sockPath, () => {
+        client.write(
+          JSON.stringify({ jsonrpc: '2.0', id: 10, method: 'agent.health', params: {} }) + '\n',
+        );
+        client.write(
+          JSON.stringify({ jsonrpc: '2.0', id: 11, method: 'agent.health', params: {} }) + '\n',
+        );
+      });
+      const results: object[] = [];
+      let buf = '';
+      client.on('data', (chunk: Buffer) => {
+        buf += chunk.toString();
+        let nl: number;
+        while ((nl = buf.indexOf('\n')) !== -1) {
+          results.push(JSON.parse(buf.slice(0, nl)));
+          buf = buf.slice(nl + 1);
+          if (results.length === 2) {
+            client.destroy();
+            resolve(results);
+          }
+        }
+      });
+      client.on('error', reject);
+      setTimeout(() => reject(new Error('multi-request timeout')), 3000);
+    });
+
+    expect(responses).toHaveLength(2);
+    expect(callCount).toBe(2);
+  });
+});

--- a/xiNAS-MCP/src/agent-server.ts
+++ b/xiNAS-MCP/src/agent-server.ts
@@ -14,7 +14,7 @@
  * collector registry is empty; agent.health reports status='starting'.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { loadAgentConfig } from './agent/config.js';
 import { log } from './agent/log.js';
 import { createDispatcher } from './agent/rpc/dispatch.js';
@@ -41,7 +41,7 @@ async function main(): Promise<void> {
   // xinas-api group; in tests it may be the process's own gid.
   let socketGroupGid: number;
   try {
-    const gidStr = execSync(`getent group "${config.socket_group}"`, {
+    const gidStr = execFileSync('getent', ['group', config.socket_group], {
       encoding: 'utf8',
     }).split(':')[2];
     socketGroupGid = parseInt(gidStr ?? '', 10);
@@ -84,10 +84,23 @@ async function main(): Promise<void> {
 
   log('info', 'core', 'listening', { socket: config.agent_socket });
 
-  // Clean shutdown on SIGINT / SIGTERM.
+  // Clean shutdown on SIGINT / SIGTERM. server.close() resolves only once
+  // all open connections close, so a held-open client would block teardown
+  // until systemd SIGKILLs. Race the close against a short timer and
+  // force-exit so we never hang past systemd's stop timeout.
   async function shutdown(signal: string): Promise<void> {
     log('info', 'core', 'shutdown', { signal });
-    await server.close();
+    const forced = setTimeout(() => {
+      log('warn', 'core', 'shutdown_forced', { signal });
+      process.exit(0);
+    }, 3000);
+    forced.unref?.();
+    try {
+      await server.close();
+    } catch {
+      /* ignore */
+    }
+    clearTimeout(forced);
     process.exit(0);
   }
 

--- a/xiNAS-MCP/src/agent-server.ts
+++ b/xiNAS-MCP/src/agent-server.ts
@@ -1,0 +1,109 @@
+/**
+ * xinas-agent process entry point.
+ *
+ * Boot sequence (spec §Flow C step 2):
+ *  1. Load AgentConfig (reads /etc/xinas-agent/config.json,
+ *     /etc/xinas-agent/agent-token, /var/lib/xinas/controller-id).
+ *  2. Build the RPC handler map: real methods + stubs.
+ *  3. Create the JSON-RPC dispatcher.
+ *  4. Bind the UDS RPC server (chmod 0660, chown root:xinas-api).
+ *  5. Register SIGINT/SIGTERM for clean shutdown.
+ *  6. Log startup complete.
+ *
+ * Collectors and publisher are wired in Phase F (F3).  In S0 the
+ * collector registry is empty; agent.health reports status='starting'.
+ */
+
+import { execSync } from 'node:child_process';
+import { loadAgentConfig } from './agent/config.js';
+import { log } from './agent/log.js';
+import { createDispatcher } from './agent/rpc/dispatch.js';
+import { makeHealthHandler } from './agent/rpc/methods/health.js';
+import { STUB_METHODS } from './agent/rpc/methods/stubs.js';
+import { makeVersionHandler } from './agent/rpc/methods/version.js';
+import { createAgentRpcServer } from './agent/rpc/server.js';
+
+const VERSION = process.env['XINAS_AGENT_VERSION'] ?? '0.0.0-dev';
+const GIT_SHA = process.env['XINAS_AGENT_GIT_SHA'];
+const BUILD_DATE = process.env['XINAS_AGENT_BUILD_DATE'];
+
+async function main(): Promise<void> {
+  const configPath = process.env['XINAS_AGENT_CONFIG_PATH'];
+  const config = loadAgentConfig(configPath !== undefined ? { configPath } : undefined);
+
+  log('info', 'core', 'startup', {
+    version: VERSION,
+    controller_id: config.controller_id,
+    agent_socket: config.agent_socket,
+  });
+
+  // Resolve the socket group GID.  On a provisioned host this is the
+  // xinas-api group; in tests it may be the process's own gid.
+  let socketGroupGid: number;
+  try {
+    const gidStr = execSync(`getent group "${config.socket_group}"`, {
+      encoding: 'utf8',
+    }).split(':')[2];
+    socketGroupGid = parseInt(gidStr ?? '', 10);
+    if (isNaN(socketGroupGid)) throw new Error('unparseable gid');
+  } catch {
+    log('warn', 'core', 'socket_group_resolve_failed', {
+      group: config.socket_group,
+      fallback: 'process gid',
+    });
+    socketGroupGid = process.getgid?.() ?? 0;
+  }
+
+  // Empty collector registry for S0 — Phase E wires real collectors.
+  const getCollectorHealth = (): Record<string, string> => ({});
+
+  const healthHandler = makeHealthHandler({
+    version: VERSION,
+    controllerId: config.controller_id,
+    startedAt: Date.now(),
+    getCollectorHealth,
+  });
+
+  const versionHandler = makeVersionHandler({
+    version: VERSION,
+    ...(GIT_SHA !== undefined ? { gitSha: GIT_SHA } : {}),
+    ...(BUILD_DATE !== undefined ? { buildDate: BUILD_DATE } : {}),
+  });
+
+  const dispatch = createDispatcher({
+    'agent.health': healthHandler,
+    'agent.version': versionHandler,
+    ...STUB_METHODS,
+  });
+
+  const server = await createAgentRpcServer({
+    socketPath: config.agent_socket,
+    dispatch,
+    socketGroupGid,
+  });
+
+  log('info', 'core', 'listening', { socket: config.agent_socket });
+
+  // Clean shutdown on SIGINT / SIGTERM.
+  async function shutdown(signal: string): Promise<void> {
+    log('info', 'core', 'shutdown', { signal });
+    await server.close();
+    process.exit(0);
+  }
+
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(
+    JSON.stringify({
+      time: new Date().toISOString(),
+      level: 'error',
+      subsystem: 'core',
+      event: 'fatal',
+      error: err instanceof Error ? err.message : String(err),
+    }) + '\n',
+  );
+  process.exit(1);
+});

--- a/xiNAS-MCP/src/agent/config.ts
+++ b/xiNAS-MCP/src/agent/config.ts
@@ -1,0 +1,43 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+export interface AgentConfig {
+  api_socket: string; // api UDS the agent POSTs observations to
+  agent_socket: string; // the agent's own UDS it serves RPC on
+  socket_group: string; // group to chown the agent socket to (xinas-api)
+  controller_id: string; // resolved from controller_id_path
+  agent_token: string; // internal bearer, resolved from agent_token_path
+}
+
+interface AgentConfigFile {
+  api_socket: string;
+  agent_socket: string;
+  controller_id_path: string;
+  agent_token_path: string;
+  socket_group: string;
+}
+
+const DEFAULT_PATH = '/etc/xinas-agent/config.json';
+
+export function loadAgentConfig(
+  opts: { configPath?: string; inline?: AgentConfig } = {},
+): AgentConfig {
+  if (opts.inline !== undefined) return opts.inline;
+  const path = opts.configPath ?? DEFAULT_PATH;
+  if (!existsSync(path)) {
+    throw new Error(`xinas-agent config not found at ${path}`);
+  }
+  const file = JSON.parse(readFileSync(path, 'utf8')) as AgentConfigFile;
+  if (!existsSync(file.controller_id_path)) {
+    throw new Error(`controller-id file not found at ${file.controller_id_path}`);
+  }
+  if (!existsSync(file.agent_token_path)) {
+    throw new Error(`agent-token file not found at ${file.agent_token_path}`);
+  }
+  return {
+    api_socket: file.api_socket,
+    agent_socket: file.agent_socket,
+    socket_group: file.socket_group,
+    controller_id: readFileSync(file.controller_id_path, 'utf8').trim(),
+    agent_token: readFileSync(file.agent_token_path, 'utf8').trim(),
+  };
+}

--- a/xiNAS-MCP/src/agent/log.ts
+++ b/xiNAS-MCP/src/agent/log.ts
@@ -1,0 +1,25 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+/**
+ * Emit one JSON object per line to stderr. The agent runs under
+ * systemd; journald captures stderr. No secrets should ever be passed
+ * in `extra` (callers must redact tokens before logging).
+ *
+ * Standard fields per spec §Agent logs:
+ *   time (rfc3339), level, subsystem, event, + optional extra fields.
+ */
+export function log(
+  level: LogLevel,
+  subsystem: string,
+  event: string,
+  extra?: Record<string, unknown>,
+): void {
+  const line: Record<string, unknown> = {
+    time: new Date().toISOString(),
+    level,
+    subsystem,
+    event,
+    ...(extra ?? {}),
+  };
+  process.stderr.write(`${JSON.stringify(line)}\n`);
+}

--- a/xiNAS-MCP/src/agent/rpc/dispatch.ts
+++ b/xiNAS-MCP/src/agent/rpc/dispatch.ts
@@ -23,13 +23,6 @@ export interface RpcHandlerMap {
   [method: string]: RpcHandler;
 }
 
-interface RpcRequest {
-  jsonrpc: '2.0';
-  id: number | string | null;
-  method: string;
-  params?: unknown;
-}
-
 function errorEnvelope(
   id: number | string | null,
   code: number,
@@ -69,14 +62,17 @@ export function createDispatcher(handlers: RpcHandlerMap): (line: string) => Pro
     const params = req['params'] ?? {};
 
     // 3. Route.
-    const handler = handlers[method];
-    if (handler === undefined) {
+    // Own-property only: inherited Object.prototype keys (constructor,
+    // toString, __proto__, hasOwnProperty, …) must NOT resolve to inherited
+    // members — they are not part of the RPC surface and must return -32601.
+    if (!Object.prototype.hasOwnProperty.call(handlers, method)) {
       return errorEnvelope(
         id,
         -32601,
         `Method not found: "${method}" is not in the agent's RPC surface`,
       );
     }
+    const handler = handlers[method] as RpcHandler;
 
     // 4. Invoke.
     try {

--- a/xiNAS-MCP/src/agent/rpc/dispatch.ts
+++ b/xiNAS-MCP/src/agent/rpc/dispatch.ts
@@ -1,0 +1,102 @@
+/**
+ * JSON-RPC 2.0 dispatcher over NDJSON.
+ *
+ * Takes a single line of text (one NDJSON record), validates the
+ * JSON-RPC 2.0 envelope, looks up the method in an explicit allow-list
+ * provided by the caller, invokes the handler, and returns a fully-formed
+ * JSON-RPC 2.0 response line (no trailing newline — the server adds it).
+ *
+ * Error code mapping (per spec §Errors):
+ *   -32600  Invalid Request  malformed envelope or missing `method`
+ *   -32601  Method not found method absent from the allow-list
+ *   -32602  Invalid params   handler throws with err.code === 'INVALID_PARAMS'
+ *   -32603  Internal error   any other unhandled handler throw
+ *   -32000  Custom           handler throws with err.code === 'EXECUTOR_UNSUPPORTED';
+ *             data: { code: 'EXECUTOR_UNSUPPORTED', method: string }
+ *
+ * No side effects; safe to unit-test without a real socket.
+ */
+
+export type RpcHandler = (params: unknown) => unknown | Promise<unknown>;
+
+export interface RpcHandlerMap {
+  [method: string]: RpcHandler;
+}
+
+interface RpcRequest {
+  jsonrpc: '2.0';
+  id: number | string | null;
+  method: string;
+  params?: unknown;
+}
+
+function errorEnvelope(
+  id: number | string | null,
+  code: number,
+  message: string,
+  data?: unknown,
+): string {
+  const error: Record<string, unknown> = { code, message };
+  if (data !== undefined) error['data'] = data;
+  return JSON.stringify({ jsonrpc: '2.0', id, error });
+}
+
+export function createDispatcher(handlers: RpcHandlerMap): (line: string) => Promise<string> {
+  return async function dispatch(line: string): Promise<string> {
+    // 1. Parse JSON.
+    let raw: unknown;
+    try {
+      raw = JSON.parse(line);
+    } catch {
+      return errorEnvelope(null, -32600, 'Parse error: input is not valid JSON');
+    }
+
+    // 2. Validate the envelope shape.
+    if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+      return errorEnvelope(null, -32600, 'Invalid Request: envelope must be a JSON object');
+    }
+
+    const req = raw as Record<string, unknown>;
+    const id: number | string | null =
+      typeof req['id'] === 'number' || typeof req['id'] === 'string'
+        ? (req['id'] as number | string)
+        : null;
+
+    if (typeof req['method'] !== 'string' || req['method'].length === 0) {
+      return errorEnvelope(id, -32600, 'Invalid Request: missing or non-string "method" field');
+    }
+    const method = req['method'] as string;
+    const params = req['params'] ?? {};
+
+    // 3. Route.
+    const handler = handlers[method];
+    if (handler === undefined) {
+      return errorEnvelope(
+        id,
+        -32601,
+        `Method not found: "${method}" is not in the agent's RPC surface`,
+      );
+    }
+
+    // 4. Invoke.
+    try {
+      const result = await handler(params);
+      return JSON.stringify({ jsonrpc: '2.0', id, result });
+    } catch (err: unknown) {
+      if (!(err instanceof Error)) {
+        return errorEnvelope(id, -32603, 'Internal error');
+      }
+      const typed = err as Error & { code?: string; rpcMethod?: string };
+      if (typed.code === 'EXECUTOR_UNSUPPORTED') {
+        return errorEnvelope(id, -32000, 'method not implemented in this build', {
+          code: 'EXECUTOR_UNSUPPORTED',
+          method: typed.rpcMethod ?? method,
+        });
+      }
+      if (typed.code === 'INVALID_PARAMS') {
+        return errorEnvelope(id, -32602, typed.message);
+      }
+      return errorEnvelope(id, -32603, `Internal error: ${typed.message}`);
+    }
+  };
+}

--- a/xiNAS-MCP/src/agent/rpc/methods/health.ts
+++ b/xiNAS-MCP/src/agent/rpc/methods/health.ts
@@ -1,0 +1,51 @@
+/**
+ * agent.health RPC handler.
+ *
+ * Reports the agent's overall health status derived from the live
+ * collector registry snapshot.  Status computation:
+ *   "starting"  — no real collectors have reported yet
+ *   "healthy"   — all registered collectors are 'running' or 'stubbed'
+ *   "degraded"  — at least one collector is in an 'error: ...' state
+ *
+ * The HeartbeatTracker on the api side maps 'degraded' to its own
+ * EXECUTOR_DEGRADED warning per spec §Flow B.
+ */
+
+export type CollectorHealthSnapshot = Record<string, string>;
+
+export interface HealthHandlerOptions {
+  version: string;
+  controllerId: string;
+  startedAt: number; // Date.now() at agent startup
+  getCollectorHealth: () => CollectorHealthSnapshot;
+}
+
+export type RpcHandler = (params: unknown) => unknown;
+
+export function makeHealthHandler(opts: HealthHandlerOptions): RpcHandler {
+  return function healthHandler(_params: unknown): unknown {
+    const collectors = opts.getCollectorHealth();
+    const entries = Object.values(collectors);
+    const uptimeSeconds = Math.floor((Date.now() - opts.startedAt) / 1000);
+
+    let status: 'starting' | 'healthy' | 'degraded' | 'stubbed';
+    if (entries.length === 0) {
+      status = 'starting';
+    } else if (entries.some((v) => v.startsWith('error:'))) {
+      status = 'degraded';
+    } else if (entries.every((v) => v === 'stubbed')) {
+      status = 'starting'; // no real collectors yet
+    } else {
+      status = 'healthy';
+    }
+
+    return {
+      status,
+      version: opts.version,
+      uptime_seconds: uptimeSeconds,
+      controller_id: opts.controllerId,
+      in_flight_tasks: 0,
+      collectors,
+    };
+  };
+}

--- a/xiNAS-MCP/src/agent/rpc/methods/health.ts
+++ b/xiNAS-MCP/src/agent/rpc/methods/health.ts
@@ -28,7 +28,7 @@ export function makeHealthHandler(opts: HealthHandlerOptions): RpcHandler {
     const entries = Object.values(collectors);
     const uptimeSeconds = Math.floor((Date.now() - opts.startedAt) / 1000);
 
-    let status: 'starting' | 'healthy' | 'degraded' | 'stubbed';
+    let status: 'starting' | 'healthy' | 'degraded';
     if (entries.length === 0) {
       status = 'starting';
     } else if (entries.some((v) => v.startsWith('error:'))) {

--- a/xiNAS-MCP/src/agent/rpc/methods/stubs.ts
+++ b/xiNAS-MCP/src/agent/rpc/methods/stubs.ts
@@ -1,0 +1,76 @@
+/**
+ * Stub handlers for every ADR-0002 enumerated method that is not yet
+ * implemented in S0+S1.
+ *
+ * Each stub throws an error with:
+ *   err.code   = 'EXECUTOR_UNSUPPORTED'
+ *   err.rpcMethod = <the method name>
+ *
+ * The dispatcher (dispatch.ts) catches this sentinel and emits a
+ * JSON-RPC -32000 envelope with data.code = 'EXECUTOR_UNSUPPORTED'.
+ *
+ * Why a throw and not a direct return?  The handler's return type is
+ * `unknown`; a throw keeps the dispatch path symmetric (all errors go
+ * through the catch block, which formats them consistently per spec).
+ *
+ * STUB_METHODS is exported as a plain map; merge it into the full
+ * handler map in the process entry point alongside the real handlers.
+ */
+
+import type { RpcHandler } from '../dispatch.js';
+
+export function makeStubHandler(method: string): RpcHandler {
+  return function stubHandler(_params: unknown): never {
+    const err = new Error('method not implemented in this build') as Error & {
+      code: string;
+      rpcMethod: string;
+    };
+    err.code = 'EXECUTOR_UNSUPPORTED';
+    err.rpcMethod = method;
+    throw err;
+  };
+}
+
+const STUB_METHOD_NAMES = [
+  // Arrays (xiRAID adapter — S3/WS5)
+  'arrays.create',
+  'arrays.delete',
+  'arrays.import',
+  'arrays.list',
+  // Spare (xiRAID — S3/WS5)
+  'spare.set',
+  // Filesystem (S4/WS6)
+  'fs.create',
+  'fs.mount',
+  'fs.unmount',
+  'fs.grow',
+  'fs.set_quota_mode',
+  // NFS exports (S5/WS7)
+  'nfs.exports.add',
+  'nfs.exports.update',
+  'nfs.exports.remove',
+  // NFS profile (S5/WS7)
+  'nfs.profile.render',
+  'nfs.profile.apply',
+  'nfs.profile.observe',
+  // Network (S6/WS8)
+  'network.render_netplan',
+  'network.flush_managed',
+  'network.apply',
+  // Systemd (S4/WS6)
+  'systemd.reload',
+  'systemd.restart',
+  // Task envelope (S2/WS4)
+  'task.begin',
+  'task.stage_report',
+  'task.cancel',
+  'task.list_inflight',
+  // Managed files drift (WS9)
+  'managed_files.checksums',
+] as const;
+
+export type StubMethodName = (typeof STUB_METHOD_NAMES)[number];
+
+export const STUB_METHODS: Record<string, RpcHandler> = Object.fromEntries(
+  STUB_METHOD_NAMES.map((m) => [m, makeStubHandler(m)]),
+);

--- a/xiNAS-MCP/src/agent/rpc/methods/version.ts
+++ b/xiNAS-MCP/src/agent/rpc/methods/version.ts
@@ -1,0 +1,25 @@
+/**
+ * agent.version RPC handler.
+ *
+ * Returns build metadata.  git_sha and build_date are optional;
+ * when absent they are NOT present in the response object at all
+ * (exactOptionalPropertyTypes: no undefined placeholders).
+ */
+
+export interface VersionHandlerOptions {
+  version: string;
+  gitSha?: string;
+  buildDate?: string;
+}
+
+export type RpcHandler = (params: unknown) => unknown;
+
+export function makeVersionHandler(opts: VersionHandlerOptions): RpcHandler {
+  return function versionHandler(_params: unknown): unknown {
+    return {
+      version: opts.version,
+      ...(opts.gitSha !== undefined ? { git_sha: opts.gitSha } : {}),
+      ...(opts.buildDate !== undefined ? { build_date: opts.buildDate } : {}),
+    };
+  };
+}

--- a/xiNAS-MCP/src/agent/rpc/server.ts
+++ b/xiNAS-MCP/src/agent/rpc/server.ts
@@ -1,0 +1,93 @@
+/**
+ * UDS RPC server for xinas-agent.
+ *
+ * Binds a Unix domain socket at `socketPath`.  After binding:
+ *   - `chmodSync(socketPath, 0o660)` so only owner and group can connect.
+ *   - `chownSync(socketPath, -1, socketGroupGid)` to assign the xinas-api
+ *     group (gid resolved by the caller from the group name at boot time).
+ *     `-1` for uid preserves the existing owner (root when running as root).
+ *
+ * Per connection: buffers incoming data, splits on '\n', feeds each
+ * complete line to the dispatcher, writes the response line followed
+ * by '\n' back to the socket.  Connections are not multiplexed — each
+ * request/response pair is processed in order on its connection.
+ *
+ * Returns a handle with a `close()` method that stops accepting new
+ * connections and resolves when the server socket is closed.
+ */
+
+import { chmodSync, chownSync, existsSync, unlinkSync } from 'node:fs';
+import { type Server, type Socket, createServer } from 'node:net';
+
+export interface AgentRpcServerOptions {
+  socketPath: string;
+  dispatch: (line: string) => Promise<string>;
+  socketGroupGid: number;
+}
+
+export interface AgentRpcServerHandle {
+  close(): Promise<void>;
+}
+
+export async function createAgentRpcServer(
+  opts: AgentRpcServerOptions,
+): Promise<AgentRpcServerHandle> {
+  const { socketPath, dispatch, socketGroupGid } = opts;
+
+  // Clean up any stale socket file from a previous run.
+  if (existsSync(socketPath)) {
+    unlinkSync(socketPath);
+  }
+
+  const server: Server = createServer((socket: Socket) => {
+    let buf = '';
+    socket.on('data', (chunk: Buffer) => {
+      buf += chunk.toString('utf8');
+      let nl: number;
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        dispatch(line)
+          .then((response) => {
+            if (!socket.destroyed) socket.write(`${response}\n`);
+          })
+          .catch(() => {
+            // dispatch itself should never throw; defensive fallback.
+            if (!socket.destroyed) {
+              socket.write(
+                `${JSON.stringify({
+                  jsonrpc: '2.0',
+                  id: null,
+                  error: { code: -32603, message: 'Internal error' },
+                })}\n`,
+              );
+            }
+          });
+      }
+    });
+    socket.on('error', () => socket.destroy());
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, () => {
+      server.removeListener('error', reject);
+      try {
+        chmodSync(socketPath, 0o660);
+        chownSync(socketPath, -1, socketGroupGid);
+      } catch {
+        // In test environments running without root, chown may fail if the gid
+        // is foreign; chmod is more likely to succeed and is the critical gate.
+      }
+      resolve();
+    });
+  });
+
+  return {
+    close(): Promise<void> {
+      return new Promise((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}

--- a/xiNAS-MCP/src/agent/rpc/server.ts
+++ b/xiNAS-MCP/src/agent/rpc/server.ts
@@ -18,6 +18,11 @@
 
 import { chmodSync, chownSync, existsSync, unlinkSync } from 'node:fs';
 import { type Server, type Socket, createServer } from 'node:net';
+import { log } from '../log.js';
+
+// Cap the per-connection read buffer. A client that never sends '\n' would
+// otherwise grow `buf` without bound and OOM the root daemon (DoS guard).
+const MAX_LINE_BYTES = 1024 * 1024; // 1 MB
 
 export interface AgentRpcServerOptions {
   socketPath: string;
@@ -43,6 +48,19 @@ export async function createAgentRpcServer(
     let buf = '';
     socket.on('data', (chunk: Buffer) => {
       buf += chunk.toString('utf8');
+      if (buf.length > MAX_LINE_BYTES) {
+        if (!socket.destroyed) {
+          socket.write(
+            `${JSON.stringify({
+              jsonrpc: '2.0',
+              id: null,
+              error: { code: -32600, message: 'Invalid Request: request too large' },
+            })}\n`,
+          );
+        }
+        socket.destroy();
+        return;
+      }
       let nl: number;
       while ((nl = buf.indexOf('\n')) !== -1) {
         const line = buf.slice(0, nl);
@@ -68,16 +86,41 @@ export async function createAgentRpcServer(
     socket.on('error', () => socket.destroy());
   });
 
+  // Tighten umask so the UDS is born 0660 (not 0755 / world-connectable)
+  // for the window between bind and the post-listen chmod. Restored inside
+  // the listen callback / on error — NOT in a synchronous finally, because
+  // listen is async and the socket is created after the call returns.
+  const prevUmask = process.umask(0o117); // socket born 0660
   await new Promise<void>((resolve, reject) => {
-    server.once('error', reject);
+    const onError = (err: Error) => {
+      process.umask(prevUmask);
+      reject(err);
+    };
+    server.once('error', onError);
     server.listen(socketPath, () => {
-      server.removeListener('error', reject);
+      process.umask(prevUmask); // restore right after bind
+      server.removeListener('error', onError);
       try {
         chmodSync(socketPath, 0o660);
         chownSync(socketPath, -1, socketGroupGid);
-      } catch {
-        // In test environments running without root, chown may fail if the gid
-        // is foreign; chmod is more likely to succeed and is the critical gate.
+      } catch (err) {
+        // The socket is the only auth gate. As root (production) a
+        // mis-permissioned socket must not serve — fail closed so systemd
+        // Restart=on-failure retries. As non-root (test/dev) chown to a
+        // foreign gid fails as expected; tolerate with a warn.
+        const isRoot = process.getuid?.() === 0;
+        if (isRoot) {
+          log('error', 'rpc', 'socket_perm_failed', {
+            socket: socketPath,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          reject(err instanceof Error ? err : new Error(String(err)));
+          return;
+        }
+        log('warn', 'rpc', 'socket_perm_skipped', {
+          socket: socketPath,
+          reason: 'not running as root (test/dev)',
+        });
       }
       resolve();
     });

--- a/xiNAS-MCP/xinas-agent.service
+++ b/xiNAS-MCP/xinas-agent.service
@@ -1,0 +1,34 @@
+# xinas-agent.service — privileged observation + execution agent
+#
+# This is the SKELETON unit for S0+S1 (boots and answers RPC).
+# Full hardening (CapabilityBoundingSet, SystemCallFilter, etc.) and
+# the Ansible role template that derives from this skeleton land in K5.
+#
+# Depends on: xinas-api.service (must be listening before the agent
+# POSTs /internal/v1/agent_started).
+
+[Unit]
+Description=xiNAS Agent (privileged observation and execution daemon)
+Documentation=https://github.com/xinnor/xiNAS
+After=network-online.target xinas-api.service
+Wants=network-online.target
+Requires=xinas-api.service
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/local/bin/xinas-agent
+Restart=on-failure
+RestartSec=5s
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=xinas-agent
+
+# Runtime socket directory is created by the xinas_api role's
+# tmpfiles config (/run/xinas mode 0750 xinas-api:xinas-api).
+# The agent creates agent.sock itself and chowns it to root:xinas-api 0660.
+RuntimeDirectory=xinas
+RuntimeDirectoryMode=0750
+
+[Install]
+WantedBy=multi-user.target

--- a/xiNAS-MCP/xinas-agent.service
+++ b/xiNAS-MCP/xinas-agent.service
@@ -24,11 +24,14 @@ StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=xinas-agent
 
-# Runtime socket directory is created by the xinas_api role's
-# tmpfiles config (/run/xinas mode 0750 xinas-api:xinas-api).
-# The agent creates agent.sock itself and chowns it to root:xinas-api 0660.
-RuntimeDirectory=xinas
-RuntimeDirectoryMode=0750
+# /run/xinas is owned by the xinas_api role's tmpfiles.d config
+# (root:xinas-admin 0770) and recreated each boot by
+# systemd-tmpfiles-setup.service. The agent must NOT declare
+# RuntimeDirectory=xinas: systemd would re-own /run/xinas to root:root 0750
+# (breaking group traverse) and, worse, REMOVE the directory when this unit
+# stops — destroying the live api.sock on `systemctl restart xinas-agent`.
+# The agent only creates agent.sock inside /run/xinas and chowns that file
+# to root:xinas-api 0660.
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Phase C — agent process skeleton (stacked on #206)

Third execution slice of the xinas-agent S0+S1 plan. **Base is #206's branch** (Phase B parse lib), so this PR's diff is the 6 Phase C commits. Rebase down the stack as #204 → #205 → #206 land.

After this slice the **xinas-agent boots as a real process**: loads its config + resolves controller_id/agent_token, binds `/run/xinas/agent.sock` (chmod 0660, chown root:xinas-api), serves JSON-RPC 2.0 over NDJSON, answers `agent.health`/`agent.version`, returns `EXECUTOR_UNSUPPORTED` for the 26 ADR-0002 stubs, and shuts down cleanly on SIGTERM.

### Commits (sequential — each builds on the last)
| Task | Commit | What |
|------|--------|------|
| C1 | `e4a800d` | agent config loader (resolves controller_id + agent_token from disk) + structured stderr logger (`time`/level/subsystem/event) |
| C2 | `de68d82` | JSON-RPC 2.0 dispatcher with explicit method allow-list; the load-bearing −32601 (off-surface) vs −32000 (EXECUTOR_UNSUPPORTED) distinction |
| C3 | `9e58f2c` | UDS RPC server — bind, per-connection NDJSON reader, chmod/chown |
| C4 | `0bb6b09` | `agent.health` (derived status) + `agent.version` (conditional-spread optionals) + the 26-method stub registry |
| C5 | `779a07e` | process entry wiring it all together, `dev:agent`/`start:agent` scripts, skeleton `xinas-agent.service` |
| review | `81039f1` | security + robustness fixes (below) |

### Security/robustness review → fixes (`81039f1`)
The review ran adversarially against a **root daemon** and caught real issues — all fixed:
- **`RuntimeDirectory=xinas` removed** — it would make `systemctl restart xinas-agent` tear down `/run/xinas` and **destroy the live `api.sock`** (the api role owns that dir via tmpfiles; the api unit dropped `RuntimeDirectory` for exactly this reason).
- **Socket-permission window closed** — the UDS was born 0755 (world-connectable) until the post-`listen()` chmod; now umask'd to 0660 at bind. chmod/chown **fail closed when running as root** (the socket is the only auth gate).
- **Prototype-chain keys** (`constructor`/`toString`/`__proto__`) now return −32601 instead of a success envelope / −32603 (own-property routing).
- **1 MB read-buffer cap** so a client that never sends `\n` can't OOM the root process.
- **Bounded SIGTERM shutdown** (races `server.close()` against a 3s timer + force-exit) so a held-open connection can't block teardown.
- `getent` via `execFileSync` (no shell); dropped a never-produced `'stubbed'` health status.

### C5 smoke-test note
The two Layer-3 smoke tests spawn the **compiled** `dist/agent-server.js`. CI's `typescript-tests` job runs `npm test` without a prior build, so the test self-builds when the artifact is absent (and the plan's `../../../..` path bug → `../../..` was fixed). A third latent plan bug — an `afterEach` that hung on an already-exited process — was also fixed.

### Verification
- `tsc --noEmit` exit 0 · **286 tests / 52 files pass** (+5 from the review's prototype-key + buffer-bound tests) · `biome lint` warnings-only
- `xinas_api` role still ansible-lint clean (production profile)
- Code-only (agent runtime + skeleton unit); no `Requires-Rebuild` trailer (the Ansible role template for the agent lands in Phase K).

### Not in this PR
Phases D–L (probes, collectors, publisher, API internal routes + heartbeat, comprehensive tests, Ansible role, sanity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)