### PR TITLE
feat(phase0): xinas-agent S0+S1 — Phase E collector layer (DRAFT, stacked on #208)

### DIFF
--- a/xiNAS-MCP/src/__tests__/agent/collectors/base.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/collectors/base.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CollectorRegistry } from '../../../agent/collectors/base.js';
+import type { Collector, Kind, ObservationDelta } from '../../../agent/collectors/base.js';
+
+function makeMockCollector(kind: Kind): Collector {
+  let _emitFn: ((delta: ObservationDelta) => void) | null = null;
+  let _state: 'running' | 'stubbed' | 'error' = 'running';
+
+  return {
+    kind,
+    async initialSweep(): Promise<ObservationDelta[]> {
+      return [
+        {
+          kind,
+          id: 'test-id',
+          op: 'upsert',
+          value: { status: { observed_at: new Date().toISOString() } },
+        },
+      ];
+    },
+    async start(emit) {
+      _emitFn = emit;
+    },
+    async stop() {
+      _emitFn = null;
+    },
+    health() {
+      return { state: _state };
+    },
+    _triggerEmit(delta: ObservationDelta) {
+      _emitFn?.(delta);
+    },
+  } as Collector & { _triggerEmit(d: ObservationDelta): void };
+}
+
+describe('CollectorRegistry', () => {
+  let registry: CollectorRegistry;
+
+  beforeEach(() => {
+    registry = new CollectorRegistry();
+  });
+
+  it('register + healthSnapshot: returns state for registered collector', () => {
+    const col = makeMockCollector('Disk');
+    registry.register(col);
+    const snap = registry.healthSnapshot();
+    expect(snap['Disk']).toBe('running');
+  });
+
+  it('start: calls start on all registered collectors with the shared emit', async () => {
+    const received: ObservationDelta[] = [];
+    const col = makeMockCollector('NetworkInterface') as Collector & {
+      _triggerEmit(d: ObservationDelta): void;
+    };
+    registry.register(col);
+    await registry.start((delta) => received.push(delta));
+    col._triggerEmit({
+      kind: 'NetworkInterface',
+      id: 'eth0',
+      op: 'upsert',
+      value: { status: { observed_at: new Date().toISOString() } },
+    });
+    expect(received).toHaveLength(1);
+    expect(received[0]?.id).toBe('eth0');
+  });
+
+  it('stop: calls stop on all collectors', async () => {
+    const stopSpy = vi.fn().mockResolvedValue(undefined);
+    const col: Collector = {
+      kind: 'Disk',
+      initialSweep: async () => [],
+      start: async () => {},
+      stop: stopSpy,
+      health: () => ({ state: 'running' }),
+    };
+    registry.register(col);
+    await registry.stop();
+    expect(stopSpy).toHaveBeenCalledOnce();
+  });
+
+  it('healthSnapshot: reflects error state of individual collectors', () => {
+    const col: Collector = {
+      kind: 'Filesystem',
+      initialSweep: async () => [],
+      start: async () => {},
+      stop: async () => {},
+      health: () => ({ state: 'error', reason: 'probe failed' }),
+    };
+    registry.register(col);
+    const snap = registry.healthSnapshot();
+    expect(snap['Filesystem']).toBe('error: probe failed');
+  });
+
+  it('initialSweep: returns all deltas from all collectors', async () => {
+    registry.register(makeMockCollector('User'));
+    registry.register(makeMockCollector('Group'));
+    const deltas = await registry.initialSweep();
+    expect(deltas).toHaveLength(2);
+    const kinds = deltas.map((d) => d.kind);
+    expect(kinds).toContain('User');
+    expect(kinds).toContain('Group');
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/collectors/base.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/collectors/base.test.ts
@@ -100,4 +100,91 @@ describe('CollectorRegistry', () => {
     expect(kinds).toContain('User');
     expect(kinds).toContain('Group');
   });
+
+  it('initialSweep: one failing collector does not blind the fleet', async () => {
+    const failing: Collector = {
+      kind: 'NfsSession',
+      initialSweep: async () => {
+        throw new Error('nfs-helper down');
+      },
+      start: async () => {},
+      stop: async () => {},
+      health: () => ({ state: 'error', reason: 'nfs-helper down' }),
+    };
+    registry.register(makeMockCollector('Disk'));
+    registry.register(failing);
+    registry.register(makeMockCollector('Group'));
+    const deltas = await registry.initialSweep();
+    // Healthy collectors' deltas still returned despite the failing one.
+    const kinds = deltas.map((d) => d.kind);
+    expect(kinds).toContain('Disk');
+    expect(kinds).toContain('Group');
+    expect(kinds).not.toContain('NfsSession');
+    // The failing collector still surfaces its error via healthSnapshot.
+    expect(registry.healthSnapshot()['NfsSession']).toBe('error: nfs-helper down');
+  });
+
+  it('stop: a failing stop() does not prevent stopping the rest', async () => {
+    const stopSpy = vi.fn().mockResolvedValue(undefined);
+    const failing: Collector = {
+      kind: 'NetworkInterface',
+      initialSweep: async () => [],
+      start: async () => {},
+      stop: async () => {
+        throw new Error('stop blew up');
+      },
+      health: () => ({ state: 'running' }),
+    };
+    const healthy: Collector = {
+      kind: 'Disk',
+      initialSweep: async () => [],
+      start: async () => {},
+      stop: stopSpy,
+      health: () => ({ state: 'running' }),
+    };
+    registry.register(failing);
+    registry.register(healthy);
+    await expect(registry.stop()).resolves.toBeUndefined();
+    // The healthy collector was still stopped (no leaked subscriptions).
+    expect(stopSpy).toHaveBeenCalledOnce();
+  });
+
+  it('start: a failing start() does not abort the fleet', async () => {
+    const startSpy = vi.fn().mockResolvedValue(undefined);
+    const failing: Collector = {
+      kind: 'NetworkInterface',
+      initialSweep: async () => [],
+      start: async () => {
+        throw new Error('start blew up');
+      },
+      stop: async () => {},
+      health: () => ({ state: 'running' }),
+    };
+    const healthy: Collector = {
+      kind: 'Disk',
+      initialSweep: async () => [],
+      start: startSpy,
+      stop: async () => {},
+      health: () => ({ state: 'running' }),
+    };
+    registry.register(failing);
+    registry.register(healthy);
+    await expect(registry.start(() => {})).resolves.toBeUndefined();
+    expect(startSpy).toHaveBeenCalledOnce();
+  });
+
+  it('healthSnapshot: a collector advertising healthKinds reports each kind', () => {
+    const usersLike: Collector = {
+      kind: 'User',
+      initialSweep: async () => [],
+      start: async () => {},
+      stop: async () => {},
+      health: () => ({ state: 'error', reason: 'getent failed' }),
+      healthKinds: () => ['User', 'Group'],
+    };
+    registry.register(usersLike);
+    const snap = registry.healthSnapshot();
+    expect(snap['User']).toBe('error: getent failed');
+    expect(snap['Group']).toBe('error: getent failed');
+  });
 });

--- a/xiNAS-MCP/src/__tests__/agent/collectors/disk.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/collectors/disk.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ObservationDelta } from '../../../agent/collectors/base.js';
+import { DiskCollector } from '../../../agent/collectors/disk.js';
+
+/** Minimal fake for the disk probe interface injected into the collector. */
+function makeFakeDiskProbe(
+  options: {
+    snapshotResult?: Array<{ id: string; model?: string }>;
+    eventLines?: string[];
+  } = {},
+) {
+  let _onDelta: ((event: { action: string; devname: string }) => void) | null = null;
+
+  return {
+    snapshot: vi.fn().mockResolvedValue(
+      (options.snapshotResult ?? [{ id: 'nvme0n1', model: 'INTEL SSD' }]).map((d) => ({
+        kind: 'Disk' as const,
+        id: d.id,
+        status: {
+          name: d.id,
+          ...(d.model ? { model: d.model } : {}),
+          observed_at: new Date().toISOString(),
+        },
+      })),
+    ),
+    startEventStream: vi
+      .fn()
+      .mockImplementation((onDelta: (event: { action: string; devname: string }) => void) => {
+        _onDelta = onDelta;
+        return { stop: vi.fn() };
+      }),
+    _fireEvent(action: string, devname: string) {
+      _onDelta?.({ action, devname });
+    },
+  };
+}
+
+describe('DiskCollector', () => {
+  it('initialSweep: returns ObservationDelta[] from probe snapshot', async () => {
+    const probe = makeFakeDiskProbe({
+      snapshotResult: [{ id: 'nvme0n1', model: 'INTEL SSD' }, { id: 'nvme1n1' }],
+    });
+    const collector = new DiskCollector({ probe });
+    const deltas = await collector.initialSweep();
+    expect(deltas).toHaveLength(2);
+    expect(deltas[0]).toMatchObject({ kind: 'Disk', id: 'nvme0n1', op: 'upsert' });
+    expect(deltas[0]?.value?.status).toMatchObject({ model: 'INTEL SSD' });
+    // status.observed_at must be present
+    expect(typeof (deltas[0]?.value?.status as Record<string, unknown>)?.observed_at).toBe(
+      'string',
+    );
+  });
+
+  it('start: subscribes to udevadm events and emits upsert delta on add', async () => {
+    const probe = makeFakeDiskProbe({ snapshotResult: [{ id: 'nvme0n1' }] });
+    const collector = new DiskCollector({ probe });
+    const received: ObservationDelta[] = [];
+    await collector.start((d) => received.push(d));
+    // Simulate a udevadm "add" event for a new device
+    probe._fireEvent('add', 'nvme2n1');
+    // The collector should re-probe and emit an upsert for nvme2n1
+    // (snapshot is called again on event)
+    await vi.waitFor(() => expect(received.length).toBeGreaterThan(0), { timeout: 500 });
+    const upsert = received.find((d) => d.id === 'nvme2n1');
+    expect(upsert?.op).toBe('upsert');
+    await collector.stop();
+  });
+
+  it('start: emits delete delta on remove event', async () => {
+    const probe = makeFakeDiskProbe({ snapshotResult: [] });
+    const collector = new DiskCollector({ probe });
+    const received: ObservationDelta[] = [];
+    await collector.start((d) => received.push(d));
+    probe._fireEvent('remove', 'nvme0n1');
+    await vi.waitFor(() => expect(received.length).toBeGreaterThan(0), { timeout: 500 });
+    expect(received[0]).toMatchObject({ kind: 'Disk', id: 'nvme0n1', op: 'delete' });
+    await collector.stop();
+  });
+
+  it('health: reports running after start', async () => {
+    const probe = makeFakeDiskProbe();
+    const collector = new DiskCollector({ probe });
+    await collector.start(() => {});
+    expect(collector.health().state).toBe('running');
+    await collector.stop();
+  });
+
+  it('health: reports error when snapshot throws', async () => {
+    const probe = makeFakeDiskProbe();
+    probe.snapshot.mockRejectedValueOnce(new Error('lsblk failed'));
+    const collector = new DiskCollector({ probe });
+    await collector.initialSweep().catch(() => {});
+    expect(collector.health().state).toBe('error');
+  });
+
+  it('pollIntervalMs: is 60000', () => {
+    const probe = makeFakeDiskProbe();
+    const collector = new DiskCollector({ probe });
+    expect(collector.pollIntervalMs).toBe(60_000);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/collectors/filesystem.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/collectors/filesystem.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ObservationDelta } from '../../../agent/collectors/base.js';
+import { FilesystemCollector } from '../../../agent/collectors/filesystem.js';
+
+function makeFakeFsProbe(
+  options: {
+    snapshotResult?: Array<{ id: string; mountpoint: string; currently_mounted?: boolean }>;
+  } = {},
+) {
+  let _watchCallback: ((eventType: string, filename: string) => void) | null = null;
+
+  return {
+    snapshot: vi.fn().mockResolvedValue(
+      (
+        options.snapshotResult ?? [
+          { id: 'srv-share01.mount', mountpoint: '/srv/share01', currently_mounted: true },
+        ]
+      ).map((fs) => ({
+        kind: 'Filesystem' as const,
+        id: fs.id,
+        status: {
+          mountpoint: fs.mountpoint,
+          currently_mounted: fs.currently_mounted ?? false,
+          observed_at: new Date().toISOString(),
+        },
+      })),
+    ),
+    watchMountUnits: vi
+      .fn()
+      .mockImplementation((cb: (eventType: string, filename: string) => void) => {
+        _watchCallback = cb;
+        return { stop: vi.fn() };
+      }),
+    _fireWatchEvent(eventType: string, filename: string) {
+      _watchCallback?.(eventType, filename);
+    },
+  };
+}
+
+describe('FilesystemCollector', () => {
+  it('initialSweep: snapshot → upsert deltas with currently_mounted and observed_at', async () => {
+    const probe = makeFakeFsProbe({
+      snapshotResult: [
+        { id: 'srv-share01.mount', mountpoint: '/srv/share01', currently_mounted: true },
+        { id: 'srv-share02.mount', mountpoint: '/srv/share02', currently_mounted: false },
+      ],
+    });
+    const col = new FilesystemCollector({ probe });
+    const deltas = await col.initialSweep();
+    expect(deltas).toHaveLength(2);
+    const delta0 = deltas[0];
+    expect(delta0).toMatchObject({ kind: 'Filesystem', id: 'srv-share01.mount', op: 'upsert' });
+    expect((delta0?.value?.status as Record<string, unknown>)?.currently_mounted).toBe(true);
+    expect(typeof (delta0?.value?.status as Record<string, unknown>)?.observed_at).toBe('string');
+  });
+
+  it('start: new .mount file → re-snapshot → emit upsert', async () => {
+    const probe = makeFakeFsProbe({
+      snapshotResult: [{ id: 'srv-new.mount', mountpoint: '/srv/new', currently_mounted: false }],
+    });
+    const col = new FilesystemCollector({ probe });
+    const received: ObservationDelta[] = [];
+    await col.start((d) => received.push(d));
+    probe._fireWatchEvent('rename', 'srv-new.mount');
+    await vi.waitFor(() => expect(received.length).toBeGreaterThan(0), { timeout: 500 });
+    expect(received[0]).toMatchObject({ kind: 'Filesystem', id: 'srv-new.mount', op: 'upsert' });
+    await col.stop();
+  });
+
+  it('start: non-mount file change → no emit', async () => {
+    const probe = makeFakeFsProbe({ snapshotResult: [] });
+    const col = new FilesystemCollector({ probe });
+    const received: ObservationDelta[] = [];
+    await col.start((d) => received.push(d));
+    probe._fireWatchEvent('change', 'some-other.service');
+    // give time to not emit
+    await new Promise((r) => setTimeout(r, 100));
+    expect(received).toHaveLength(0);
+    await col.stop();
+  });
+
+  it('start: .mount file removed from snapshot → emit delete', async () => {
+    const probe = makeFakeFsProbe({ snapshotResult: [] }); // empty after removal
+    const col = new FilesystemCollector({ probe });
+    // Seed a known prior state
+    col['_knownIds'].add('srv-gone.mount');
+    const received: ObservationDelta[] = [];
+    await col.start((d) => received.push(d));
+    probe._fireWatchEvent('rename', 'srv-gone.mount');
+    await vi.waitFor(() => expect(received.length).toBeGreaterThan(0), { timeout: 500 });
+    expect(received[0]).toMatchObject({ kind: 'Filesystem', id: 'srv-gone.mount', op: 'delete' });
+    await col.stop();
+  });
+
+  it('health: reports running after start', async () => {
+    const probe = makeFakeFsProbe();
+    const col = new FilesystemCollector({ probe });
+    await col.start(() => {});
+    expect(col.health().state).toBe('running');
+    await col.stop();
+  });
+
+  it('pollIntervalMs: is 60000', () => {
+    const probe = makeFakeFsProbe();
+    expect(new FilesystemCollector({ probe }).pollIntervalMs).toBe(60_000);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/collectors/inventory.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/collectors/inventory.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import { InventoryCollector } from '../../../agent/collectors/inventory.js';
+
+function makeFakeInventoryProbe(
+  options: {
+    result?: {
+      hostname: string;
+      os_kernel: string;
+      cpu_model?: string;
+      cpu_cores?: number;
+      cpu_threads?: number;
+      mem_total_kb?: number;
+      arch?: string;
+    };
+  } = {},
+) {
+  return {
+    read: vi.fn().mockResolvedValue(
+      options.result ?? {
+        hostname: 'xinas-node-01',
+        os_kernel: '5.15.0-generic',
+        cpu_model: 'Intel Xeon Gold 6338',
+        cpu_cores: 32,
+        cpu_threads: 64,
+        mem_total_kb: 131072000,
+        arch: 'x86_64',
+      },
+    ),
+  };
+}
+
+describe('InventoryCollector', () => {
+  it('initialSweep: returns singleton upsert at id "snapshot"', async () => {
+    const probe = makeFakeInventoryProbe();
+    const col = new InventoryCollector({ probe });
+    const deltas = await col.initialSweep();
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]).toMatchObject({ kind: 'inventory', id: 'snapshot', op: 'upsert' });
+  });
+
+  it('initialSweep: value includes all inventory fields + observed_at', async () => {
+    const probe = makeFakeInventoryProbe({
+      result: {
+        hostname: 'xinas-node-01',
+        os_kernel: '5.15.0',
+        cpu_model: 'Intel Xeon Gold 6338',
+        cpu_cores: 32,
+        cpu_threads: 64,
+        mem_total_kb: 131_072_000,
+        arch: 'x86_64',
+      },
+    });
+    const col = new InventoryCollector({ probe });
+    const deltas = await col.initialSweep();
+    const status = deltas[0]?.value?.status as Record<string, unknown>;
+    expect(status?.hostname).toBe('xinas-node-01');
+    expect(status?.cpu_cores).toBe(32);
+    expect(status?.mem_total_kb).toBe(131_072_000);
+    expect(typeof status?.observed_at).toBe('string');
+  });
+
+  it('start: no event subscription (inventory is poll-only)', async () => {
+    const probe = makeFakeInventoryProbe();
+    const col = new InventoryCollector({ probe });
+    const received: unknown[] = [];
+    await col.start((d) => received.push(d));
+    // No events should be fired from start() itself
+    await new Promise((r) => setTimeout(r, 100));
+    expect(received).toHaveLength(0);
+    await col.stop();
+  });
+
+  it('health: reports running after start', async () => {
+    const probe = makeFakeInventoryProbe();
+    const col = new InventoryCollector({ probe });
+    await col.start(() => {});
+    expect(col.health().state).toBe('running');
+    await col.stop();
+  });
+
+  it('pollIntervalMs: is 300000', () => {
+    const probe = makeFakeInventoryProbe();
+    expect(new InventoryCollector({ probe }).pollIntervalMs).toBe(300_000);
+  });
+
+  it('health: error if probe throws', async () => {
+    const probe = makeFakeInventoryProbe();
+    probe.read.mockRejectedValueOnce(new Error('readFile failed'));
+    const col = new InventoryCollector({ probe });
+    await col.initialSweep().catch(() => {});
+    expect(col.health().state).toBe('error');
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/collectors/network.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/collectors/network.test.ts
@@ -23,20 +23,18 @@ function makeFakeNetworkProbe(
         },
       })),
     ),
-    startEventStream: vi
-      .fn()
-      .mockImplementation(
-        (
-          onEvent: (event: {
-            id: string;
-            op: 'upsert' | 'delete';
-            attrs: Record<string, unknown>;
-          }) => void,
-        ) => {
-          _onEvent = onEvent;
-          return { stop: vi.fn() };
-        },
-      ),
+    startEventStream: vi.fn().mockImplementation(
+      (
+        onEvent: (event: {
+          id: string;
+          op: 'upsert' | 'delete';
+          attrs: Record<string, unknown>;
+        }) => void,
+      ) => {
+        _onEvent = onEvent;
+        return { stop: vi.fn() };
+      },
+    ),
     _fireEvent(id: string, op: 'upsert' | 'delete', attrs: Record<string, unknown> = {}) {
       _onEvent?.({ id, op, attrs });
     },

--- a/xiNAS-MCP/src/__tests__/agent/collectors/network.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/collectors/network.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ObservationDelta } from '../../../agent/collectors/base.js';
+import { NetworkInterfaceCollector } from '../../../agent/collectors/network.js';
+
+function makeFakeNetworkProbe(
+  options: {
+    snapshotResult?: Array<{ id: string; operstate?: string }>;
+  } = {},
+) {
+  let _onEvent:
+    | ((event: { id: string; op: 'upsert' | 'delete'; attrs: Record<string, unknown> }) => void)
+    | null = null;
+
+  return {
+    snapshot: vi.fn().mockResolvedValue(
+      (options.snapshotResult ?? [{ id: 'eth0', operstate: 'UP' }]).map((iface) => ({
+        kind: 'NetworkInterface' as const,
+        id: iface.id,
+        status: {
+          name: iface.id,
+          operstate: iface.operstate ?? 'UNKNOWN',
+          observed_at: new Date().toISOString(),
+        },
+      })),
+    ),
+    startEventStream: vi
+      .fn()
+      .mockImplementation(
+        (
+          onEvent: (event: {
+            id: string;
+            op: 'upsert' | 'delete';
+            attrs: Record<string, unknown>;
+          }) => void,
+        ) => {
+          _onEvent = onEvent;
+          return { stop: vi.fn() };
+        },
+      ),
+    _fireEvent(id: string, op: 'upsert' | 'delete', attrs: Record<string, unknown> = {}) {
+      _onEvent?.({ id, op, attrs });
+    },
+  };
+}
+
+describe('NetworkInterfaceCollector', () => {
+  it('initialSweep: returns upsert deltas for each interface', async () => {
+    const probe = makeFakeNetworkProbe({
+      snapshotResult: [
+        { id: 'eth0', operstate: 'UP' },
+        { id: 'ibp0s4', operstate: 'DOWN' },
+      ],
+    });
+    const col = new NetworkInterfaceCollector({ probe });
+    const deltas = await col.initialSweep();
+    expect(deltas).toHaveLength(2);
+    expect(deltas[0]).toMatchObject({ kind: 'NetworkInterface', id: 'eth0', op: 'upsert' });
+    expect(typeof (deltas[0]?.value?.status as Record<string, unknown>)?.observed_at).toBe(
+      'string',
+    );
+  });
+
+  it('start: ip-monitor upsert event → emit upsert delta', async () => {
+    const probe = makeFakeNetworkProbe({ snapshotResult: [] });
+    const col = new NetworkInterfaceCollector({ probe });
+    const received: ObservationDelta[] = [];
+    await col.start((d) => received.push(d));
+    probe._fireEvent('eth0', 'upsert', { operstate: 'UP', mtu: 1500 });
+    await vi.waitFor(() => expect(received.length).toBeGreaterThan(0), { timeout: 500 });
+    expect(received[0]).toMatchObject({ kind: 'NetworkInterface', id: 'eth0', op: 'upsert' });
+    await col.stop();
+  });
+
+  it('start: ip-monitor delete event → emit delete delta', async () => {
+    const probe = makeFakeNetworkProbe({ snapshotResult: [] });
+    const col = new NetworkInterfaceCollector({ probe });
+    const received: ObservationDelta[] = [];
+    await col.start((d) => received.push(d));
+    probe._fireEvent('eth1', 'delete', {});
+    await vi.waitFor(() => expect(received.length).toBeGreaterThan(0), { timeout: 500 });
+    expect(received[0]).toMatchObject({ kind: 'NetworkInterface', id: 'eth1', op: 'delete' });
+    await col.stop();
+  });
+
+  it('health: reports running after start', async () => {
+    const probe = makeFakeNetworkProbe();
+    const col = new NetworkInterfaceCollector({ probe });
+    await col.start(() => {});
+    expect(col.health().state).toBe('running');
+    await col.stop();
+  });
+
+  it('pollIntervalMs: is 30000', () => {
+    const probe = makeFakeNetworkProbe();
+    expect(new NetworkInterfaceCollector({ probe }).pollIntervalMs).toBe(30_000);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/collectors/nfs-idmap.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/collectors/nfs-idmap.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ObservationDelta } from '../../../agent/collectors/base.js';
+import { NfsIdmapCollector } from '../../../agent/collectors/nfs-idmap.js';
+
+function makeFakeIdmapProbe(
+  options: {
+    result?: {
+      conf_present: boolean;
+      domain?: string;
+      local_realms?: string[];
+      method?: string;
+      idmapd_active: boolean;
+      idmapd_unit_state?: string;
+    };
+  } = {},
+) {
+  let _watchCallback: (() => void) | null = null;
+  let _dbusCallback: (() => void) | null = null;
+
+  const defaultResult = {
+    conf_present: true,
+    domain: 'localdomain',
+    local_realms: [],
+    method: 'nsswitch',
+    idmapd_active: true,
+    idmapd_unit_state: 'active',
+  };
+
+  return {
+    read: vi.fn().mockResolvedValue(options.result ?? defaultResult),
+    watchIdmapdConf: vi.fn().mockImplementation((cb: () => void) => {
+      _watchCallback = cb;
+      return { stop: vi.fn() };
+    }),
+    subscribeIdmapdUnit: vi.fn().mockImplementation((cb: () => void) => {
+      _dbusCallback = cb;
+      return { stop: vi.fn() };
+    }),
+    _fireConfChange() {
+      _watchCallback?.();
+    },
+    _fireDbusEvent() {
+      _dbusCallback?.();
+    },
+  };
+}
+
+describe('NfsIdmapCollector', () => {
+  it('initialSweep: returns singleton upsert at id "snapshot"', async () => {
+    const probe = makeFakeIdmapProbe();
+    const col = new NfsIdmapCollector({ probe });
+    const deltas = await col.initialSweep();
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]).toMatchObject({ kind: 'NfsIdmap', id: 'snapshot', op: 'upsert' });
+    const status = deltas[0]?.value?.status as Record<string, unknown>;
+    expect(status?.conf_present).toBe(true);
+    expect(status?.domain).toBe('localdomain');
+    expect(status?.idmapd_active).toBe(true);
+    expect(typeof status?.observed_at).toBe('string');
+  });
+
+  it('start: /etc/idmapd.conf change → re-read → emit upsert at "snapshot"', async () => {
+    const probe = makeFakeIdmapProbe();
+    const col = new NfsIdmapCollector({ probe });
+    const received: ObservationDelta[] = [];
+    await col.start((d) => received.push(d));
+    probe._fireConfChange();
+    await vi.waitFor(() => expect(received.length).toBeGreaterThan(0), { timeout: 500 });
+    expect(received[0]).toMatchObject({ kind: 'NfsIdmap', id: 'snapshot', op: 'upsert' });
+    await col.stop();
+  });
+
+  it('start: dbus nfs-idmapd.service PropertiesChanged → re-read → emit upsert', async () => {
+    const probe = makeFakeIdmapProbe({
+      result: { conf_present: true, idmapd_active: false, idmapd_unit_state: 'inactive' },
+    });
+    const col = new NfsIdmapCollector({ probe });
+    const received: ObservationDelta[] = [];
+    await col.start((d) => received.push(d));
+    probe._fireDbusEvent();
+    await vi.waitFor(() => expect(received.length).toBeGreaterThan(0), { timeout: 500 });
+    expect((received[0]?.value?.status as Record<string, unknown>)?.idmapd_active).toBe(false);
+    await col.stop();
+  });
+
+  it('health: reports running after start', async () => {
+    const probe = makeFakeIdmapProbe();
+    const col = new NfsIdmapCollector({ probe });
+    await col.start(() => {});
+    expect(col.health().state).toBe('running');
+    await col.stop();
+  });
+
+  it('pollIntervalMs: is 60000', () => {
+    const probe = makeFakeIdmapProbe();
+    expect(new NfsIdmapCollector({ probe }).pollIntervalMs).toBe(60_000);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/collectors/nfs.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/collectors/nfs.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ObservationDelta } from '../../../agent/collectors/base.js';
+import { NfsCollector } from '../../../agent/collectors/nfs.js';
+
+function makeFakeNfsProbe(
+  options: {
+    sessions?: Array<{
+      client_addr: string;
+      export_path: string;
+      proto_version?: string;
+      locked_files?: number;
+    }>;
+    exports?: Array<{ export_path: string; host_pattern: string; options: string[] }>;
+  } = {},
+) {
+  return {
+    listSessions: vi.fn().mockResolvedValue(
+      (
+        options.sessions ?? [
+          {
+            client_addr: '10.1.2.3',
+            export_path: '/srv/share01',
+            proto_version: 'v4.1',
+            locked_files: 2,
+          },
+        ]
+      ).map((s) => ({
+        kind: 'NfsSession' as const,
+        id: `${s.client_addr}:${s.export_path}`,
+        spec: { client_addr: s.client_addr, export_path: s.export_path },
+        status: {
+          proto_version: s.proto_version ?? 'v4',
+          locked_files: s.locked_files ?? 0,
+          observed_at: new Date().toISOString(),
+        },
+      })),
+    ),
+    listExports: vi.fn().mockResolvedValue(
+      (
+        options.exports ?? [
+          { export_path: '/srv/share01', host_pattern: '*', options: ['rw', 'no_root_squash'] },
+        ]
+      ).map((e) => ({
+        export_path: e.export_path,
+        host_pattern: e.host_pattern,
+        options: e.options,
+      })),
+    ),
+  };
+}
+
+describe('NfsCollector', () => {
+  it('initialSweep: returns NfsSession upsert deltas', async () => {
+    const probe = makeFakeNfsProbe({
+      sessions: [
+        {
+          client_addr: '10.1.2.3',
+          export_path: '/srv/share01',
+          proto_version: 'v4.1',
+          locked_files: 2,
+        },
+      ],
+      exports: [],
+    });
+    const col = new NfsCollector({ probe });
+    const deltas = await col.initialSweep();
+    const sessionDelta = deltas.find((d) => d.kind === 'NfsSession');
+    expect(sessionDelta).toBeDefined();
+    expect(sessionDelta).toMatchObject({
+      kind: 'NfsSession',
+      id: '10.1.2.3:/srv/share01',
+      op: 'upsert',
+    });
+    expect(typeof (sessionDelta?.value?.status as Record<string, unknown>)?.observed_at).toBe(
+      'string',
+    );
+  });
+
+  it('initialSweep: emits a real ExportRule delta keyed by export_path', async () => {
+    const probe = makeFakeNfsProbe({
+      sessions: [],
+      exports: [
+        {
+          export_path: '/srv/share01',
+          host_pattern: '10.1.0.0/16',
+          options: ['rw', 'root_squash'],
+        },
+      ],
+    });
+    const col = new NfsCollector({ probe });
+    const deltas = await col.initialSweep();
+    const exportDelta = deltas.find((d) => d.kind === 'ExportRule');
+    expect(exportDelta).toMatchObject({
+      kind: 'ExportRule',
+      id: '/srv/share01',
+      op: 'upsert',
+    });
+    const status = (exportDelta?.value as Record<string, unknown>).status as Record<
+      string,
+      unknown
+    >;
+    expect(status.rules).toHaveLength(1);
+    expect((status.rules as Array<{ host_pattern: string }>)[0]?.host_pattern).toBe('10.1.0.0/16');
+    expect(typeof status.observed_at).toBe('string');
+    // The collector implements Collector<'NfsSession'> but emits a second kind
+    // (ExportRule) — same dual-kind pattern as E8 (User+Group). No Share rows touched.
+    expect(deltas.find((d) => d.kind === 'NfsSession')).toBeUndefined();
+  });
+
+  it('start: polls every 30 s (pollIntervalMs = 30000)', () => {
+    const probe = makeFakeNfsProbe();
+    const col = new NfsCollector({ probe });
+    expect(col.pollIntervalMs).toBe(30_000);
+  });
+
+  it('start: each poll emits fresh session deltas', async () => {
+    const probe = makeFakeNfsProbe({
+      sessions: [
+        {
+          client_addr: '10.1.2.3',
+          export_path: '/srv/share01',
+          proto_version: 'v4',
+          locked_files: 0,
+        },
+      ],
+      exports: [],
+    });
+    const col = new NfsCollector({ probe });
+    const received: ObservationDelta[] = [];
+    await col.start((d) => received.push(d));
+    // Manually trigger a poll (simulated via the internal _poll method)
+    await col['_poll'](received.push.bind(received));
+    const sessionDeltas = received.filter((d) => d.kind === 'NfsSession');
+    expect(sessionDeltas.length).toBeGreaterThan(0);
+    await col.stop();
+  });
+
+  it('health: reports running after start', async () => {
+    const probe = makeFakeNfsProbe();
+    const col = new NfsCollector({ probe });
+    await col.start(() => {});
+    expect(col.health().state).toBe('running');
+    await col.stop();
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/collectors/stubs.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/collectors/stubs.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ManagedFilesStubCollector,
+  XiraidArrayStubCollector,
+} from '../../../agent/collectors/stubs.js';
+
+describe('XiraidArrayStubCollector', () => {
+  it('initialSweep: returns a single meta-delta at id "_stub"', async () => {
+    const col = new XiraidArrayStubCollector();
+    const deltas = await col.initialSweep();
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]).toMatchObject({
+      kind: 'XiraidArray',
+      id: '_stub',
+      op: 'upsert',
+    });
+  });
+
+  it('initialSweep: meta-delta carries status.deferred=true and reason=XIRAID_ADAPTER_DEFERRED', async () => {
+    const col = new XiraidArrayStubCollector();
+    const [delta] = await col.initialSweep();
+    const status = delta?.value?.status as Record<string, unknown>;
+    expect(status?.deferred).toBe(true);
+    expect(status?.reason).toBe('XIRAID_ADAPTER_DEFERRED');
+    expect(typeof status?.observed_at).toBe('string');
+  });
+
+  it('start: emits nothing (no events, no poll)', async () => {
+    const col = new XiraidArrayStubCollector();
+    const received: unknown[] = [];
+    await col.start((d) => received.push(d));
+    await new Promise((r) => setTimeout(r, 100));
+    expect(received).toHaveLength(0);
+    await col.stop();
+  });
+
+  it('health: reports stubbed', () => {
+    const col = new XiraidArrayStubCollector();
+    const h = col.health();
+    expect(h.state).toBe('stubbed');
+    expect(h.reason).toBe('XIRAID_ADAPTER_DEFERRED');
+  });
+
+  it('pollIntervalMs: undefined (no poll)', () => {
+    const col = new XiraidArrayStubCollector();
+    expect(col.pollIntervalMs).toBeUndefined();
+  });
+});
+
+describe('ManagedFilesStubCollector', () => {
+  it('initialSweep: returns a single meta-delta at id "_stub"', async () => {
+    const col = new ManagedFilesStubCollector();
+    const deltas = await col.initialSweep();
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]).toMatchObject({
+      kind: 'managed_files',
+      id: '_stub',
+      op: 'upsert',
+    });
+  });
+
+  it('initialSweep: meta-delta carries status.deferred=true and reason=DRIFT_FRAMEWORK_DEFERRED', async () => {
+    const col = new ManagedFilesStubCollector();
+    const [delta] = await col.initialSweep();
+    const status = delta?.value?.status as Record<string, unknown>;
+    expect(status?.deferred).toBe(true);
+    expect(status?.reason).toBe('DRIFT_FRAMEWORK_DEFERRED');
+  });
+
+  it('start: emits nothing', async () => {
+    const col = new ManagedFilesStubCollector();
+    const received: unknown[] = [];
+    await col.start((d) => received.push(d));
+    await new Promise((r) => setTimeout(r, 100));
+    expect(received).toHaveLength(0);
+    await col.stop();
+  });
+
+  it('health: reports stubbed with DRIFT_FRAMEWORK_DEFERRED', () => {
+    const col = new ManagedFilesStubCollector();
+    const h = col.health();
+    expect(h.state).toBe('stubbed');
+    expect(h.reason).toBe('DRIFT_FRAMEWORK_DEFERRED');
+  });
+
+  it('pollIntervalMs: undefined (no poll)', () => {
+    const col = new ManagedFilesStubCollector();
+    expect(col.pollIntervalMs).toBeUndefined();
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/collectors/systemd.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/collectors/systemd.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ObservationDelta } from '../../../agent/collectors/base.js';
+import { SystemdUnitCollector } from '../../../agent/collectors/systemd.js';
+
+function makeFakeSystemdProbe(
+  options: {
+    allowList?: string[];
+    unitStates?: Record<
+      string,
+      { load_state: string; active_state: string; sub_state: string; unit_file_state?: string }
+    >;
+  } = {},
+) {
+  const allowList = options.allowList ?? ['nfs-server.service', 'nfs-idmapd.service'];
+  const states = options.unitStates ?? {
+    'nfs-server.service': {
+      load_state: 'loaded',
+      active_state: 'active',
+      sub_state: 'running',
+      unit_file_state: 'enabled',
+    },
+    'nfs-idmapd.service': {
+      load_state: 'loaded',
+      active_state: 'inactive',
+      sub_state: 'dead',
+      unit_file_state: 'enabled',
+    },
+  };
+
+  let _onPropertiesChanged: ((unitName: string) => void) | null = null;
+
+  return {
+    allowList,
+    getUnitState: vi.fn().mockImplementation(async (name: string) => {
+      return (
+        states[name] ?? { load_state: 'not-found', active_state: 'inactive', sub_state: 'dead' }
+      );
+    }),
+    subscribeAllowListed: vi
+      .fn()
+      .mockImplementation((units: string[], onChanged: (unitName: string) => void) => {
+        _onPropertiesChanged = onChanged;
+        return { stop: vi.fn() };
+      }),
+    _firePropertiesChanged(unitName: string) {
+      _onPropertiesChanged?.(unitName);
+    },
+  };
+}
+
+describe('SystemdUnitCollector', () => {
+  it('initialSweep: returns one upsert per allow-listed unit', async () => {
+    const probe = makeFakeSystemdProbe({
+      allowList: ['nfs-server.service', 'nfs-idmapd.service'],
+    });
+    const col = new SystemdUnitCollector({ probe });
+    const deltas = await col.initialSweep();
+    expect(deltas).toHaveLength(2);
+    expect(deltas[0]).toMatchObject({ kind: 'SystemdUnit', op: 'upsert' });
+    const nfsServer = deltas.find((d) => d.id === 'nfs-server.service');
+    expect(nfsServer).toBeDefined();
+    expect((nfsServer?.value?.status as Record<string, unknown>)?.active_state).toBe('active');
+    expect(typeof (nfsServer?.value?.status as Record<string, unknown>)?.observed_at).toBe(
+      'string',
+    );
+  });
+
+  it('start: PropertiesChanged for allow-listed unit → emit upsert', async () => {
+    const probe = makeFakeSystemdProbe();
+    const col = new SystemdUnitCollector({ probe });
+    const received: ObservationDelta[] = [];
+    await col.start((d) => received.push(d));
+    probe._firePropertiesChanged('nfs-server.service');
+    await vi.waitFor(() => expect(received.length).toBeGreaterThan(0), { timeout: 500 });
+    expect(received[0]).toMatchObject({
+      kind: 'SystemdUnit',
+      id: 'nfs-server.service',
+      op: 'upsert',
+    });
+    await col.stop();
+  });
+
+  it('start: PropertiesChanged for non-allow-listed unit → no emit', async () => {
+    const probe = makeFakeSystemdProbe({
+      allowList: ['nfs-server.service'],
+    });
+    const col = new SystemdUnitCollector({ probe });
+    const received: ObservationDelta[] = [];
+    await col.start((d) => received.push(d));
+    probe._firePropertiesChanged('unrelated.service');
+    await new Promise((r) => setTimeout(r, 100));
+    expect(received).toHaveLength(0);
+    await col.stop();
+  });
+
+  it('health: reports running after start', async () => {
+    const probe = makeFakeSystemdProbe();
+    const col = new SystemdUnitCollector({ probe });
+    await col.start(() => {});
+    expect(col.health().state).toBe('running');
+    await col.stop();
+  });
+
+  it('pollIntervalMs: is 30000', () => {
+    const probe = makeFakeSystemdProbe();
+    expect(new SystemdUnitCollector({ probe }).pollIntervalMs).toBe(30_000);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/collectors/users.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/collectors/users.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ObservationDelta } from '../../../agent/collectors/base.js';
+import { UsersCollector } from '../../../agent/collectors/users.js';
+
+function makeFakeUsersProbe(
+  options: {
+    users?: Array<{ uid: number; name: string; gid: number; home: string; shell: string }>;
+    groups?: Array<{ gid: number; name: string; members: string[] }>;
+  } = {},
+) {
+  let _watchCallback: (() => void) | null = null;
+
+  return {
+    getentPasswd: vi.fn().mockResolvedValue(
+      (
+        options.users ?? [
+          { uid: 1000, name: 'alice', gid: 1000, home: '/home/alice', shell: '/bin/bash' },
+        ]
+      ).map((u) => ({
+        uid: u.uid,
+        name: u.name,
+        gid: u.gid,
+        gecos: '',
+        home: u.home,
+        shell: u.shell,
+        source: 'local' as const,
+      })),
+    ),
+    getentGroup: vi.fn().mockResolvedValue(
+      (options.groups ?? [{ gid: 1000, name: 'alice', members: [] }]).map((g) => ({
+        gid: g.gid,
+        name: g.name,
+        members: g.members,
+        source: 'local' as const,
+      })),
+    ),
+    watchPasswdFiles: vi.fn().mockImplementation((cb: () => void) => {
+      _watchCallback = cb;
+      return { stop: vi.fn() };
+    }),
+    _fireWatch() {
+      _watchCallback?.();
+    },
+  };
+}
+
+describe('UsersCollector', () => {
+  it('initialSweep: emits User deltas + Group deltas from one sweep', async () => {
+    const probe = makeFakeUsersProbe({
+      users: [{ uid: 1000, name: 'alice', gid: 1000, home: '/home/alice', shell: '/bin/bash' }],
+      groups: [
+        { gid: 1000, name: 'alice', members: [] },
+        { gid: 27, name: 'sudo', members: ['alice'] },
+      ],
+    });
+    const col = new UsersCollector({ probe });
+    const deltas = await col.initialSweep();
+    const userDeltas = deltas.filter((d) => d.kind === 'User');
+    const groupDeltas = deltas.filter((d) => d.kind === 'Group');
+    expect(userDeltas).toHaveLength(1);
+    expect(groupDeltas).toHaveLength(2);
+    expect(userDeltas[0]).toMatchObject({ kind: 'User', id: '1000', op: 'upsert' });
+    expect((userDeltas[0]?.value?.spec as Record<string, unknown>)?.name).toBe('alice');
+    expect(typeof (userDeltas[0]?.value?.status as Record<string, unknown>)?.observed_at).toBe(
+      'string',
+    );
+    expect(groupDeltas[0]).toMatchObject({ kind: 'Group', op: 'upsert' });
+  });
+
+  it('start: inotify /etc/passwd change → re-probe → emit User + Group deltas', async () => {
+    const probe = makeFakeUsersProbe({
+      users: [{ uid: 1001, name: 'bob', gid: 1001, home: '/home/bob', shell: '/bin/sh' }],
+      groups: [{ gid: 1001, name: 'bob', members: [] }],
+    });
+    const col = new UsersCollector({ probe });
+    const received: ObservationDelta[] = [];
+    await col.start((d) => received.push(d));
+    probe._fireWatch();
+    await vi.waitFor(() => expect(received.length).toBeGreaterThanOrEqual(2), { timeout: 500 });
+    expect(received.some((d) => d.kind === 'User')).toBe(true);
+    expect(received.some((d) => d.kind === 'Group')).toBe(true);
+    await col.stop();
+  });
+
+  it('User id is the decimal uid string', async () => {
+    const probe = makeFakeUsersProbe({
+      users: [
+        {
+          uid: 65534,
+          name: 'nobody',
+          gid: 65534,
+          home: '/nonexistent',
+          shell: '/usr/sbin/nologin',
+        },
+      ],
+      groups: [],
+    });
+    const col = new UsersCollector({ probe });
+    const deltas = await col.initialSweep();
+    expect(deltas[0]?.id).toBe('65534');
+  });
+
+  it('Group id is the decimal gid string', async () => {
+    const probe = makeFakeUsersProbe({
+      users: [],
+      groups: [{ gid: 27, name: 'sudo', members: ['alice'] }],
+    });
+    const col = new UsersCollector({ probe });
+    const deltas = await col.initialSweep();
+    expect(deltas[0]?.id).toBe('27');
+    expect((deltas[0]?.value?.spec as Record<string, unknown>)?.members).toEqual(['alice']);
+  });
+
+  it('health: reports running after start', async () => {
+    const probe = makeFakeUsersProbe();
+    const col = new UsersCollector({ probe });
+    await col.start(() => {});
+    expect(col.health().state).toBe('running');
+    await col.stop();
+  });
+
+  it('pollIntervalMs: is 300000', () => {
+    const probe = makeFakeUsersProbe();
+    expect(new UsersCollector({ probe }).pollIntervalMs).toBe(300_000);
+  });
+});

--- a/xiNAS-MCP/src/agent/collectors/base.ts
+++ b/xiNAS-MCP/src/agent/collectors/base.ts
@@ -1,0 +1,107 @@
+/**
+ * Collector<K> interface and CollectorRegistry.
+ *
+ * Collectors orchestrate probe calls + parse helpers to emit typed
+ * ObservationDelta values. This module is pure orchestration — no system
+ * calls allowed here. Those live in src/agent/probe/.
+ */
+
+export type Kind =
+  | 'Disk'
+  | 'NetworkInterface'
+  | 'Filesystem'
+  | 'NfsSession'
+  | 'ExportRule' // internal observed kind; no public REST endpoint.
+  // Joined into Share.status.exports[] at read time (see I6).
+  | 'NfsIdmap'
+  | 'SystemdUnit'
+  | 'User'
+  | 'Group'
+  | 'XiraidArray'
+  | 'managed_files'
+  | 'inventory';
+
+export interface ObservationDelta {
+  kind: Kind;
+  id: string;
+  op: 'upsert' | 'delete';
+  value?: Record<string, unknown>;
+}
+
+/**
+ * The observed-state KV path segment for a kind.
+ *
+ * The object's `kind` field is the api-v1.yaml PascalCase const, but a few
+ * singletons store under a different segment: kinds whose const is already
+ * lowercase (`inventory`, `managed_files`) store as-is, and `NfsIdmap`
+ * stores under `nfs_idmap` to match ADR-0003's locked path + the public
+ * /api/v1/nfs-idmap route. Both the write path (H3 observed handler) and
+ * every read path (I3, I6, etc.) MUST derive the segment through this
+ * function so writer and reader never disagree.
+ */
+const PATH_SEGMENT: Partial<Record<Kind, string>> = { NfsIdmap: 'nfs_idmap' };
+export function observedSegment(kind: Kind): string {
+  return PATH_SEGMENT[kind] ?? kind;
+}
+
+export interface Collector<K extends Kind = Kind> {
+  kind: K;
+  /** Full current state. Emitted on boot with complete_snapshots: [kind]. */
+  initialSweep(): Promise<ObservationDelta[]>;
+  /** Start event subscriptions. Call emit() each time state changes. */
+  start(emit: (delta: ObservationDelta) => void): Promise<void>;
+  /** Tear down all subscriptions and timers. */
+  stop(): Promise<void>;
+  /** If set, the publisher runs this collector on a poll interval as a fallback. */
+  pollIntervalMs?: number;
+  /** Current collector health for surfacing in agent.health. */
+  health(): { state: 'running' | 'stubbed' | 'error'; reason?: string };
+}
+
+/** Serialises a health() result to the string format returned by agent.health. */
+function healthString(h: { state: 'running' | 'stubbed' | 'error'; reason?: string }): string {
+  if (h.state === 'error') {
+    return `error: ${h.reason ?? 'unknown'}`;
+  }
+  return h.state;
+}
+
+/**
+ * CollectorRegistry holds all registered collectors and coordinates
+ * lifecycle (start / stop / initialSweep) and health reporting.
+ */
+export class CollectorRegistry {
+  private readonly collectors: Collector[] = [];
+
+  register(collector: Collector): void {
+    this.collectors.push(collector);
+  }
+
+  /** Returns deltas from every registered collector's initialSweep(). */
+  async initialSweep(): Promise<ObservationDelta[]> {
+    const results = await Promise.all(this.collectors.map((c) => c.initialSweep()));
+    return results.flat();
+  }
+
+  /** Starts all collectors, routing their emits through the shared emit callback. */
+  async start(emit: (delta: ObservationDelta) => void): Promise<void> {
+    await Promise.all(this.collectors.map((c) => c.start(emit)));
+  }
+
+  /** Stops all collectors. */
+  async stop(): Promise<void> {
+    await Promise.all(this.collectors.map((c) => c.stop()));
+  }
+
+  /**
+   * Returns a snapshot of per-collector health for agent.health.
+   * Format: { '<Kind>': 'running' | 'stubbed' | 'error: <reason>' }
+   */
+  healthSnapshot(): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const col of this.collectors) {
+      out[col.kind] = healthString(col.health());
+    }
+    return out;
+  }
+}

--- a/xiNAS-MCP/src/agent/collectors/base.ts
+++ b/xiNAS-MCP/src/agent/collectors/base.ts
@@ -56,6 +56,14 @@ export interface Collector<K extends Kind = Kind> {
   pollIntervalMs?: number;
   /** Current collector health for surfacing in agent.health. */
   health(): { state: 'running' | 'stubbed' | 'error'; reason?: string };
+  /**
+   * The observed kinds whose health this collector represents in
+   * agent.health. Defaults to [kind]. A collector that emits more than one
+   * kind (e.g. Users emits User + Group) returns all of them so each gets
+   * its own row in healthSnapshot(), matching the spec's collectors map.
+   * Internal-only kinds (e.g. ExportRule) are intentionally omitted.
+   */
+  healthKinds?(): Kind[];
 }
 
 /** Serialises a health() result to the string format returned by agent.health. */
@@ -77,20 +85,39 @@ export class CollectorRegistry {
     this.collectors.push(collector);
   }
 
-  /** Returns deltas from every registered collector's initialSweep(). */
+  /**
+   * Returns deltas from every registered collector's initialSweep().
+   * Uses allSettled so one failing collector (e.g. nfs-helper down) cannot
+   * blind the whole fleet: a rejected collector has already set its own
+   * health=error before rethrowing, so healthSnapshot() still surfaces it,
+   * while every healthy collector's deltas are returned. Per spec, one
+   * collector in error degrades the node — it does not lose all data.
+   */
   async initialSweep(): Promise<ObservationDelta[]> {
-    const results = await Promise.all(this.collectors.map((c) => c.initialSweep()));
-    return results.flat();
+    const results = await Promise.allSettled(this.collectors.map((c) => c.initialSweep()));
+    const deltas: ObservationDelta[] = [];
+    for (const r of results) {
+      if (r.status === 'fulfilled') deltas.push(...r.value);
+    }
+    return deltas;
   }
 
-  /** Starts all collectors, routing their emits through the shared emit callback. */
+  /**
+   * Starts all collectors, routing their emits through the shared emit
+   * callback. allSettled so a failing start() doesn't abort the fleet and
+   * leave later collectors unsubscribed.
+   */
   async start(emit: (delta: ObservationDelta) => void): Promise<void> {
-    await Promise.all(this.collectors.map((c) => c.start(emit)));
+    await Promise.allSettled(this.collectors.map((c) => c.start(emit)));
   }
 
-  /** Stops all collectors. */
+  /**
+   * Stops all collectors. allSettled is critical here: a failed stop() on
+   * one collector must not prevent stopping the rest, or their event
+   * subprocesses (udevadm/ip monitor) would survive shutdown.
+   */
   async stop(): Promise<void> {
-    await Promise.all(this.collectors.map((c) => c.stop()));
+    await Promise.allSettled(this.collectors.map((c) => c.stop()));
   }
 
   /**
@@ -100,7 +127,11 @@ export class CollectorRegistry {
   healthSnapshot(): Record<string, string> {
     const out: Record<string, string> = {};
     for (const col of this.collectors) {
-      out[col.kind] = healthString(col.health());
+      const h = healthString(col.health());
+      const kinds = col.healthKinds ? col.healthKinds() : [col.kind];
+      for (const k of kinds) {
+        out[k] = h;
+      }
     }
     return out;
   }

--- a/xiNAS-MCP/src/agent/collectors/disk.ts
+++ b/xiNAS-MCP/src/agent/collectors/disk.ts
@@ -1,0 +1,132 @@
+import type { Collector, ObservationDelta } from './base.js';
+
+interface DiskStatus {
+  name: string;
+  model?: string;
+  serial?: string;
+  transport?: string;
+  wwn?: string;
+  size_text?: string;
+  observed_at: string;
+}
+
+interface ObservedDisk {
+  kind: 'Disk';
+  id: string;
+  status: DiskStatus;
+}
+
+interface UdevEvent {
+  action: string;
+  devname: string;
+}
+
+interface EventStream {
+  stop(): void;
+}
+
+interface DiskProbe {
+  snapshot(): Promise<ObservedDisk[]>;
+  startEventStream(onDelta: (event: UdevEvent) => void): EventStream;
+}
+
+interface DiskCollectorOptions {
+  probe: DiskProbe;
+}
+
+/**
+ * Disk collector. Wires the disk probe (D2) and lsblk parser (B1).
+ *
+ * Event source: udevadm monitor (one blank-line-terminated record per event).
+ * Poll fallback: 60 s (probe snapshot re-emitted as upserts).
+ * On "add" or "change": re-probes via snapshot(), emits upsert for the device.
+ * On "remove": emits delete without re-probing.
+ */
+export class DiskCollector implements Collector<'Disk'> {
+  readonly kind = 'Disk' as const;
+  readonly pollIntervalMs = 60_000;
+
+  private readonly probe: DiskProbe;
+  private _health: { state: 'running' | 'stubbed' | 'error'; reason?: string } = {
+    state: 'running',
+  };
+  private _stream: EventStream | null = null;
+
+  constructor({ probe }: DiskCollectorOptions) {
+    this.probe = probe;
+  }
+
+  async initialSweep(): Promise<ObservationDelta[]> {
+    try {
+      const disks = await this.probe.snapshot();
+      return disks.map((disk) => this._diskToUpsert(disk));
+    } catch (err) {
+      this._health = { state: 'error', reason: err instanceof Error ? err.message : String(err) };
+      throw err;
+    }
+  }
+
+  async start(emit: (delta: ObservationDelta) => void): Promise<void> {
+    this._health = { state: 'running' };
+    this._stream = this.probe.startEventStream(async (event) => {
+      try {
+        if (event.action === 'remove') {
+          emit({ kind: 'Disk', id: event.devname, op: 'delete' });
+        } else {
+          // add or change — re-snapshot and emit upsert for the affected device
+          const disks = await this.probe.snapshot();
+          const affected = disks.find((d) => d.id === event.devname);
+          if (affected) {
+            emit(this._diskToUpsert(affected));
+          } else {
+            // device not found in snapshot after add — treat as upsert with minimal info
+            emit({
+              kind: 'Disk',
+              id: event.devname,
+              op: 'upsert',
+              value: {
+                status: {
+                  name: event.devname,
+                  observed_at: new Date().toISOString(),
+                },
+              },
+            });
+          }
+        }
+      } catch (err) {
+        this._health = { state: 'error', reason: err instanceof Error ? err.message : String(err) };
+      }
+    });
+  }
+
+  async stop(): Promise<void> {
+    this._stream?.stop();
+    this._stream = null;
+  }
+
+  health(): { state: 'running' | 'stubbed' | 'error'; reason?: string } {
+    return this._health;
+  }
+
+  private _diskToUpsert(disk: ObservedDisk): ObservationDelta {
+    const observedAt = disk.status.observed_at ?? new Date().toISOString();
+    return {
+      kind: 'Disk',
+      id: disk.id,
+      op: 'upsert',
+      value: {
+        kind: 'Disk',
+        id: disk.id,
+        status: {
+          name: disk.status.name,
+          observed_at: observedAt,
+          ...(disk.status.model !== undefined ? { model: disk.status.model } : {}),
+          ...(disk.status.serial !== undefined ? { serial: disk.status.serial } : {}),
+          ...(disk.status.transport !== undefined ? { transport: disk.status.transport } : {}),
+          ...(disk.status.wwn !== undefined ? { wwn: disk.status.wwn } : {}),
+          ...(disk.status.size_text !== undefined ? { size_text: disk.status.size_text } : {}),
+        },
+      },
+    };
+  }
+}

--- a/xiNAS-MCP/src/agent/collectors/filesystem.ts
+++ b/xiNAS-MCP/src/agent/collectors/filesystem.ts
@@ -1,0 +1,154 @@
+import type { Collector, ObservationDelta } from './base.js';
+
+interface FilesystemStatus {
+  mountpoint?: string;
+  fs_type?: string;
+  backing_device?: string;
+  currently_mounted?: boolean;
+  mount_options?: string[];
+  mount_unit_name?: string;
+  mount_unit_state?: string;
+  observed_at: string;
+}
+
+interface ObservedFilesystem {
+  kind: 'Filesystem';
+  id: string;
+  status: FilesystemStatus;
+}
+
+interface WatchHandle {
+  stop(): void;
+}
+
+interface FilesystemProbe {
+  /**
+   * Snapshot: reads /etc/systemd/system/*.mount + cross-references
+   * /proc/self/mountinfo to fill currently_mounted + mount_options.
+   */
+  snapshot(): Promise<ObservedFilesystem[]>;
+  /**
+   * Starts inotify on /etc/systemd/system/ (filter *.mount) + dbus on
+   * .mount units. Fires callback on any change with (eventType, filename).
+   */
+  watchMountUnits(cb: (eventType: string, filename: string) => void): WatchHandle;
+}
+
+interface FilesystemCollectorOptions {
+  probe: FilesystemProbe;
+}
+
+/**
+ * Filesystem collector. Wires D4 probe + B4 mount-unit parser + B5
+ * mountinfo cross-reference.
+ *
+ * Event source: inotify on /etc/systemd/system/ (*.mount files) + dbus
+ * on .mount units for active-state changes.
+ * Poll fallback: 60 s (5-minute backstop reconcile per spec F1).
+ *
+ * Delta logic:
+ *   - A .mount file appears or changes → re-snapshot → upsert.
+ *   - A .mount file is no longer in snapshot but was previously known → delete.
+ *   - Non-.mount files are ignored.
+ */
+export class FilesystemCollector implements Collector<'Filesystem'> {
+  readonly kind = 'Filesystem' as const;
+  readonly pollIntervalMs = 60_000;
+
+  /** Tracks known .mount unit ids so we can emit deletes when they vanish. */
+  readonly _knownIds: Set<string> = new Set();
+
+  private readonly probe: FilesystemProbe;
+  private _health: { state: 'running' | 'stubbed' | 'error'; reason?: string } = {
+    state: 'running',
+  };
+  private _watch: WatchHandle | null = null;
+
+  constructor({ probe }: FilesystemCollectorOptions) {
+    this.probe = probe;
+  }
+
+  async initialSweep(): Promise<ObservationDelta[]> {
+    try {
+      const filesystems = await this.probe.snapshot();
+      this._knownIds.clear();
+      return filesystems.map((fs) => {
+        this._knownIds.add(fs.id);
+        return this._fsToUpsert(fs);
+      });
+    } catch (err) {
+      this._health = { state: 'error', reason: err instanceof Error ? err.message : String(err) };
+      throw err;
+    }
+  }
+
+  async start(emit: (delta: ObservationDelta) => void): Promise<void> {
+    this._health = { state: 'running' };
+    this._watch = this.probe.watchMountUnits(async (eventType, filename) => {
+      // Filter: only react to .mount files
+      if (!filename.endsWith('.mount')) return;
+      try {
+        const filesystems = await this.probe.snapshot();
+        const newIds = new Set(filesystems.map((fs) => fs.id));
+
+        // Emit upserts for all current filesystems
+        for (const fs of filesystems) {
+          this._knownIds.add(fs.id);
+          emit(this._fsToUpsert(fs));
+        }
+
+        // Emit deletes for ids that were known but are no longer in snapshot
+        for (const knownId of this._knownIds) {
+          if (!newIds.has(knownId)) {
+            this._knownIds.delete(knownId);
+            emit({ kind: 'Filesystem', id: knownId, op: 'delete' });
+          }
+        }
+      } catch (err) {
+        this._health = { state: 'error', reason: err instanceof Error ? err.message : String(err) };
+      }
+    });
+  }
+
+  async stop(): Promise<void> {
+    this._watch?.stop();
+    this._watch = null;
+  }
+
+  health(): { state: 'running' | 'stubbed' | 'error'; reason?: string } {
+    return this._health;
+  }
+
+  private _fsToUpsert(fs: ObservedFilesystem): ObservationDelta {
+    const observedAt = fs.status.observed_at ?? new Date().toISOString();
+    return {
+      kind: 'Filesystem',
+      id: fs.id,
+      op: 'upsert',
+      value: {
+        kind: 'Filesystem',
+        id: fs.id,
+        status: {
+          observed_at: observedAt,
+          ...(fs.status.mountpoint !== undefined ? { mountpoint: fs.status.mountpoint } : {}),
+          ...(fs.status.fs_type !== undefined ? { fs_type: fs.status.fs_type } : {}),
+          ...(fs.status.backing_device !== undefined
+            ? { backing_device: fs.status.backing_device }
+            : {}),
+          ...(fs.status.currently_mounted !== undefined
+            ? { currently_mounted: fs.status.currently_mounted }
+            : {}),
+          ...(fs.status.mount_options !== undefined
+            ? { mount_options: fs.status.mount_options }
+            : {}),
+          ...(fs.status.mount_unit_name !== undefined
+            ? { mount_unit_name: fs.status.mount_unit_name }
+            : {}),
+          ...(fs.status.mount_unit_state !== undefined
+            ? { mount_unit_state: fs.status.mount_unit_state }
+            : {}),
+        },
+      },
+    };
+  }
+}

--- a/xiNAS-MCP/src/agent/collectors/inventory.ts
+++ b/xiNAS-MCP/src/agent/collectors/inventory.ts
@@ -1,0 +1,92 @@
+import type { Collector, ObservationDelta } from './base.js';
+
+interface InventoryResult {
+  hostname: string;
+  os_kernel: string;
+  cpu_model?: string;
+  cpu_cores?: number;
+  cpu_threads?: number;
+  mem_total_kb?: number;
+  arch?: string;
+}
+
+interface InventoryProbe {
+  /**
+   * Reads /proc/cpuinfo + /proc/meminfo + os.uname().
+   * Parses via B10 helpers.
+   */
+  read(): Promise<InventoryResult>;
+}
+
+interface InventoryCollectorOptions {
+  probe: InventoryProbe;
+}
+
+/**
+ * Inventory collector. Wires D9 probe + B10 parsers.
+ *
+ * Singleton: always emits to id "snapshot".
+ * Path: /xinas/v1/observed/inventory/snapshot
+ *
+ * No event source. Pure poll at 300 s.
+ * Preserves the PR #201 inventory shape (hostname, kernel, cpu, mem).
+ */
+export class InventoryCollector implements Collector<'inventory'> {
+  readonly kind = 'inventory' as const;
+  readonly pollIntervalMs = 300_000;
+
+  private readonly probe: InventoryProbe;
+  private _health: { state: 'running' | 'stubbed' | 'error'; reason?: string } = {
+    state: 'running',
+  };
+
+  constructor({ probe }: InventoryCollectorOptions) {
+    this.probe = probe;
+  }
+
+  async initialSweep(): Promise<ObservationDelta[]> {
+    try {
+      return [await this._buildDelta()];
+    } catch (err) {
+      this._health = { state: 'error', reason: err instanceof Error ? err.message : String(err) };
+      throw err;
+    }
+  }
+
+  /** No events for inventory — start() is a no-op. Publisher drives poll via pollIntervalMs. */
+  async start(_emit: (delta: ObservationDelta) => void): Promise<void> {
+    this._health = { state: 'running' };
+  }
+
+  async stop(): Promise<void> {
+    // Nothing to tear down.
+  }
+
+  health(): { state: 'running' | 'stubbed' | 'error'; reason?: string } {
+    return this._health;
+  }
+
+  private async _buildDelta(): Promise<ObservationDelta> {
+    const result = await this.probe.read();
+    const observedAt = new Date().toISOString();
+    return {
+      kind: 'inventory',
+      id: 'snapshot',
+      op: 'upsert',
+      value: {
+        kind: 'inventory',
+        id: 'snapshot',
+        status: {
+          hostname: result.hostname,
+          os_kernel: result.os_kernel,
+          ...(result.cpu_model !== undefined ? { cpu_model: result.cpu_model } : {}),
+          ...(result.cpu_cores !== undefined ? { cpu_cores: result.cpu_cores } : {}),
+          ...(result.cpu_threads !== undefined ? { cpu_threads: result.cpu_threads } : {}),
+          ...(result.mem_total_kb !== undefined ? { mem_total_kb: result.mem_total_kb } : {}),
+          ...(result.arch !== undefined ? { arch: result.arch } : {}),
+          observed_at: observedAt,
+        },
+      },
+    };
+  }
+}

--- a/xiNAS-MCP/src/agent/collectors/network.ts
+++ b/xiNAS-MCP/src/agent/collectors/network.ts
@@ -1,0 +1,123 @@
+import type { Collector, ObservationDelta } from './base.js';
+
+interface NetworkInterfaceStatus {
+  name: string;
+  operstate?: string;
+  mac?: string;
+  mtu?: number;
+  observed_at: string;
+}
+
+interface ObservedNetworkInterface {
+  kind: 'NetworkInterface';
+  id: string;
+  status: NetworkInterfaceStatus;
+}
+
+interface NetworkEvent {
+  id: string;
+  op: 'upsert' | 'delete';
+  attrs: Record<string, unknown>;
+}
+
+interface EventStream {
+  stop(): void;
+}
+
+interface NetworkProbe {
+  snapshot(): Promise<ObservedNetworkInterface[]>;
+  startEventStream(onEvent: (event: NetworkEvent) => void): EventStream;
+}
+
+interface NetworkInterfaceCollectorOptions {
+  probe: NetworkProbe;
+}
+
+/**
+ * NetworkInterface collector. Wires D3 network probe + B2 ip-json parser.
+ *
+ * Event source: `ip -j monitor link addr` subprocess.
+ * Poll fallback: 30 s (ibstat snapshot for IB-specific fields is also on 30 s).
+ * Events from the probe are pre-parsed into { id, op, attrs } by the probe layer.
+ */
+export class NetworkInterfaceCollector implements Collector<'NetworkInterface'> {
+  readonly kind = 'NetworkInterface' as const;
+  readonly pollIntervalMs = 30_000;
+
+  private readonly probe: NetworkProbe;
+  private _state: 'running' | 'stubbed' | 'error' = 'running';
+  private _reason: string | undefined = undefined;
+  private _stream: EventStream | null = null;
+
+  constructor({ probe }: NetworkInterfaceCollectorOptions) {
+    this.probe = probe;
+  }
+
+  async initialSweep(): Promise<ObservationDelta[]> {
+    try {
+      const ifaces = await this.probe.snapshot();
+      return ifaces.map((iface) => this._ifaceToUpsert(iface));
+    } catch (err) {
+      this._state = 'error';
+      this._reason = err instanceof Error ? err.message : String(err);
+      throw err;
+    }
+  }
+
+  async start(emit: (delta: ObservationDelta) => void): Promise<void> {
+    this._state = 'running';
+    this._reason = undefined;
+    this._stream = this.probe.startEventStream((event) => {
+      try {
+        if (event.op === 'delete') {
+          emit({ kind: 'NetworkInterface', id: event.id, op: 'delete' });
+        } else {
+          const observedAt = new Date().toISOString();
+          emit({
+            kind: 'NetworkInterface',
+            id: event.id,
+            op: 'upsert',
+            value: {
+              kind: 'NetworkInterface',
+              id: event.id,
+              status: {
+                name: event.id,
+                ...event.attrs,
+                observed_at: observedAt,
+              },
+            },
+          });
+        }
+      } catch (err) {
+        this._state = 'error';
+        this._reason = err instanceof Error ? err.message : String(err);
+      }
+    });
+  }
+
+  async stop(): Promise<void> {
+    this._stream?.stop();
+    this._stream = null;
+  }
+
+  health(): { state: 'running' | 'stubbed' | 'error'; reason?: string } {
+    return {
+      state: this._state,
+      ...(this._reason !== undefined ? { reason: this._reason } : {}),
+    };
+  }
+
+  private _ifaceToUpsert(iface: ObservedNetworkInterface): ObservationDelta {
+    const observedAt = iface.status.observed_at ?? new Date().toISOString();
+    return {
+      kind: 'NetworkInterface',
+      id: iface.id,
+      op: 'upsert',
+      value: {
+        kind: 'NetworkInterface',
+        id: iface.id,
+        status: { ...iface.status, observed_at: observedAt },
+      },
+    };
+  }
+}

--- a/xiNAS-MCP/src/agent/collectors/nfs-idmap.ts
+++ b/xiNAS-MCP/src/agent/collectors/nfs-idmap.ts
@@ -1,0 +1,109 @@
+import type { Collector, ObservationDelta } from './base.js';
+
+interface IdmapResult {
+  conf_present: boolean;
+  domain?: string;
+  local_realms?: string[];
+  method?: string;
+  idmapd_active: boolean;
+  idmapd_unit_state?: string;
+}
+
+interface WatchHandle {
+  stop(): void;
+}
+
+interface IdmapProbe {
+  /** Reads /etc/idmapd.conf (via B7 parser) + systemctl is-active nfs-idmapd. */
+  read(): Promise<IdmapResult>;
+  /** inotify on /etc/idmapd.conf. */
+  watchIdmapdConf(cb: () => void): WatchHandle;
+  /** dbus subscription for nfs-idmapd.service PropertiesChanged. */
+  subscribeIdmapdUnit(cb: () => void): WatchHandle;
+}
+
+interface NfsIdmapCollectorOptions {
+  probe: IdmapProbe;
+}
+
+/**
+ * NfsIdmap collector. Wires D6 idmap probe + B7 idmapd.conf parser.
+ *
+ * Singleton: always emits to id "snapshot".
+ * Path: /xinas/v1/observed/nfs_idmap/snapshot
+ *
+ * Event sources: inotify on /etc/idmapd.conf + dbus on nfs-idmapd.service.
+ * Poll fallback: 60 s.
+ */
+export class NfsIdmapCollector implements Collector<'NfsIdmap'> {
+  readonly kind = 'NfsIdmap' as const;
+  readonly pollIntervalMs = 60_000;
+
+  private readonly probe: IdmapProbe;
+  private _health: { state: 'running' | 'stubbed' | 'error'; reason?: string } = {
+    state: 'running',
+  };
+  private _confWatch: WatchHandle | null = null;
+  private _dbusWatch: WatchHandle | null = null;
+
+  constructor({ probe }: NfsIdmapCollectorOptions) {
+    this.probe = probe;
+  }
+
+  async initialSweep(): Promise<ObservationDelta[]> {
+    try {
+      return [await this._buildDelta()];
+    } catch (err) {
+      this._health = { state: 'error', reason: err instanceof Error ? err.message : String(err) };
+      throw err;
+    }
+  }
+
+  async start(emit: (delta: ObservationDelta) => void): Promise<void> {
+    this._health = { state: 'running' };
+    const onChange = async () => {
+      try {
+        emit(await this._buildDelta());
+      } catch (err) {
+        this._health = { state: 'error', reason: err instanceof Error ? err.message : String(err) };
+      }
+    };
+    this._confWatch = this.probe.watchIdmapdConf(onChange);
+    this._dbusWatch = this.probe.subscribeIdmapdUnit(onChange);
+  }
+
+  async stop(): Promise<void> {
+    this._confWatch?.stop();
+    this._dbusWatch?.stop();
+    this._confWatch = null;
+    this._dbusWatch = null;
+  }
+
+  health(): { state: 'running' | 'stubbed' | 'error'; reason?: string } {
+    return this._health;
+  }
+
+  private async _buildDelta(): Promise<ObservationDelta> {
+    const result = await this.probe.read();
+    const observedAt = new Date().toISOString();
+    return {
+      kind: 'NfsIdmap',
+      id: 'snapshot',
+      op: 'upsert',
+      value: {
+        kind: 'NfsIdmap',
+        status: {
+          conf_present: result.conf_present,
+          ...(result.domain !== undefined ? { domain: result.domain } : {}),
+          ...(result.local_realms !== undefined ? { local_realms: result.local_realms } : {}),
+          ...(result.method !== undefined ? { method: result.method } : {}),
+          idmapd_active: result.idmapd_active,
+          ...(result.idmapd_unit_state !== undefined
+            ? { idmapd_unit_state: result.idmapd_unit_state }
+            : {}),
+          observed_at: observedAt,
+        },
+      },
+    };
+  }
+}

--- a/xiNAS-MCP/src/agent/collectors/nfs.ts
+++ b/xiNAS-MCP/src/agent/collectors/nfs.ts
@@ -1,0 +1,151 @@
+import type { Collector, ObservationDelta } from './base.js';
+
+interface ObservedNfsSession {
+  kind: 'NfsSession';
+  id: string;
+  spec: { client_addr: string; export_path: string; client_hostname?: string };
+  status: {
+    proto_version: string;
+    locked_files: number;
+    observed_at: string;
+  };
+}
+
+interface ObservedExportEntry {
+  export_path: string;
+  host_pattern: string;
+  options: string[];
+  squash_mode?: string;
+  anon_uid?: number;
+  anon_gid?: number;
+}
+
+interface NfsProbe {
+  listSessions(): Promise<ObservedNfsSession[]>;
+  listExports(): Promise<ObservedExportEntry[]>;
+}
+
+interface NfsCollectorOptions {
+  probe: NfsProbe;
+}
+
+/**
+ * NFS collector. Wires D5 helper probe + B6 parser.
+ *
+ * Emits two kinds of deltas (same two-kind pattern E8 uses for User+Group):
+ *   1. NfsSession upserts / deletes (client connections).
+ *   2. ExportRule upserts keyed by export_path. ExportRule is an internal
+ *      observed kind (no public REST endpoint); the api joins it into
+ *      Share.status.exports[] at read time (Task I6). The collector does
+ *      NOT touch Share rows.
+ *
+ * No event source from the helper → 30 s poll only.
+ */
+export class NfsCollector implements Collector<'NfsSession'> {
+  readonly kind = 'NfsSession' as const;
+  readonly pollIntervalMs = 30_000;
+
+  private readonly probe: NfsProbe;
+  private _health: { state: 'running' | 'stubbed' | 'error'; reason?: string } = {
+    state: 'running',
+  };
+  private _pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor({ probe }: NfsCollectorOptions) {
+    this.probe = probe;
+  }
+
+  async initialSweep(): Promise<ObservationDelta[]> {
+    try {
+      return await this._buildDeltas();
+    } catch (err) {
+      this._health = { state: 'error', reason: err instanceof Error ? err.message : String(err) };
+      throw err;
+    }
+  }
+
+  async start(emit: (delta: ObservationDelta) => void): Promise<void> {
+    this._health = { state: 'running' };
+    // NFS helper has no event source; rely on pollIntervalMs backstop from publisher.
+    // Expose _poll for testing.
+  }
+
+  /** Exposed for test injection; the publisher drives polling via pollIntervalMs. */
+  async _poll(emit: (delta: ObservationDelta) => void): Promise<void> {
+    try {
+      const deltas = await this._buildDeltas();
+      for (const delta of deltas) emit(delta);
+    } catch (err) {
+      this._health = { state: 'error', reason: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this._pollTimer) {
+      clearInterval(this._pollTimer);
+      this._pollTimer = null;
+    }
+  }
+
+  health(): { state: 'running' | 'stubbed' | 'error'; reason?: string } {
+    return this._health;
+  }
+
+  private async _buildDeltas(): Promise<ObservationDelta[]> {
+    const observedAt = new Date().toISOString();
+    const [sessions, exports_] = await Promise.all([
+      this.probe.listSessions(),
+      this.probe.listExports(),
+    ]);
+
+    const deltas: ObservationDelta[] = [];
+
+    // NfsSession upserts
+    for (const session of sessions) {
+      deltas.push({
+        kind: 'NfsSession',
+        id: session.id,
+        op: 'upsert',
+        value: {
+          kind: 'NfsSession',
+          id: session.id,
+          spec: session.spec,
+          status: { ...session.status, observed_at: observedAt },
+        },
+      });
+    }
+
+    // Export-rule fold-in: group exports by export_path, emit one ExportRule upsert per path
+    // carrying { rules: ExportEntry[], observed_at } so the api can merge into Share.status.exports[].
+    const byPath = new Map<string, ObservedExportEntry[]>();
+    for (const entry of exports_) {
+      const list = byPath.get(entry.export_path) ?? [];
+      list.push(entry);
+      byPath.set(entry.export_path, list);
+    }
+    for (const [exportPath, rules] of byPath) {
+      deltas.push({
+        kind: 'ExportRule', // internal observed kind (no public REST endpoint).
+        id: exportPath, // KV: /xinas/v1/observed/ExportRule/<export_path>
+        op: 'upsert',
+        value: {
+          kind: 'ExportRule',
+          id: exportPath,
+          spec: { export_path: exportPath },
+          status: {
+            rules: rules.map((r) => ({
+              host_pattern: r.host_pattern,
+              options: r.options,
+              ...(r.squash_mode !== undefined ? { squash_mode: r.squash_mode } : {}),
+              ...(r.anon_uid !== undefined ? { anon_uid: r.anon_uid } : {}),
+              ...(r.anon_gid !== undefined ? { anon_gid: r.anon_gid } : {}),
+            })),
+            observed_at: observedAt,
+          },
+        },
+      });
+    }
+
+    return deltas;
+  }
+}

--- a/xiNAS-MCP/src/agent/collectors/stubs.ts
+++ b/xiNAS-MCP/src/agent/collectors/stubs.ts
@@ -1,0 +1,79 @@
+import type { Collector, ObservationDelta } from './base.js';
+
+/**
+ * Stub base: common no-op lifecycle + health for deferred collectors.
+ *
+ * initialSweep emits a single meta-delta at id "_stub" so the kind's
+ * path in the state store is populated with a status row indicating the
+ * deferral. This lets the api's GET endpoints return a well-formed
+ * (though empty) result instead of a 404, and gives operators a clear
+ * signal that the capability is deferred.
+ *
+ * No event source, no poll — pollIntervalMs is undefined.
+ * health() always reports 'stubbed' with the reason code.
+ */
+abstract class StubCollector<K extends 'XiraidArray' | 'managed_files'> implements Collector<K> {
+  abstract readonly kind: K;
+  abstract readonly _reasonCode: string;
+
+  // Stubs never poll. Declared (optional, always undefined) so the
+  // Collector contract's optional field is visible on the concrete type.
+  readonly pollIntervalMs?: number;
+
+  async initialSweep(): Promise<ObservationDelta[]> {
+    const observedAt = new Date().toISOString();
+    return [
+      {
+        kind: this.kind,
+        id: '_stub',
+        op: 'upsert',
+        value: {
+          kind: this.kind,
+          id: '_stub',
+          status: {
+            deferred: true,
+            reason: this._reasonCode,
+            observed_at: observedAt,
+          },
+        },
+      },
+    ];
+  }
+
+  /** No-op: stubs have no event source. */
+  async start(_emit: (delta: ObservationDelta) => void): Promise<void> {}
+
+  async stop(): Promise<void> {}
+
+  health(): { state: 'running' | 'stubbed' | 'error'; reason?: string } {
+    return { state: 'stubbed', reason: this._reasonCode };
+  }
+}
+
+/**
+ * XiraidArray stub collector.
+ *
+ * Deferred: xiRAID gRPC client moves from api → agent in S3/WS5.
+ * Until then, the state store carries a _stub entry so the api's
+ * /api/v1/arrays endpoint can report the deferral rather than 404.
+ *
+ * Reason code: XIRAID_ADAPTER_DEFERRED
+ */
+export class XiraidArrayStubCollector extends StubCollector<'XiraidArray'> {
+  readonly kind = 'XiraidArray' as const;
+  readonly _reasonCode = 'XIRAID_ADAPTER_DEFERRED';
+}
+
+/**
+ * ManagedFiles stub collector.
+ *
+ * Deferred: drift framework lands in WS9.
+ * Path conforms to ADR-0003 line 101's locked layout (snake_case
+ * singular noun, used by xinas_history.drift).
+ *
+ * Reason code: DRIFT_FRAMEWORK_DEFERRED
+ */
+export class ManagedFilesStubCollector extends StubCollector<'managed_files'> {
+  readonly kind = 'managed_files' as const;
+  readonly _reasonCode = 'DRIFT_FRAMEWORK_DEFERRED';
+}

--- a/xiNAS-MCP/src/agent/collectors/systemd.ts
+++ b/xiNAS-MCP/src/agent/collectors/systemd.ts
@@ -1,0 +1,106 @@
+import type { Collector, ObservationDelta } from './base.js';
+
+interface UnitState {
+  load_state: string;
+  active_state: string;
+  sub_state: string;
+  unit_file_state?: string;
+}
+
+interface WatchHandle {
+  stop(): void;
+}
+
+interface SystemdProbe {
+  /** The allow-listed unit names to observe. */
+  allowList: string[];
+  /** Reads current state of a unit via systemctl show or dbus. */
+  getUnitState(name: string): Promise<UnitState>;
+  /** Subscribes to dbus PropertiesChanged for the given unit names. */
+  subscribeAllowListed(units: string[], onChanged: (unitName: string) => void): WatchHandle;
+}
+
+interface SystemdUnitCollectorOptions {
+  probe: SystemdProbe;
+}
+
+/**
+ * SystemdUnit collector. Wires D7 dbus probe.
+ *
+ * Only emits for allow-listed units (e.g. nfs-server.service, nfs-idmapd.service,
+ * nfs-mountd.service, plus any *.mount units discovered by D4).
+ * Units outside the allow-list are silently ignored even if dbus fires for them.
+ *
+ * Event source: dbus PropertiesChanged (no poll alternative from dbus).
+ * Poll fallback: 30 s (catches stuck-state units that didn't fire PropertiesChanged).
+ */
+export class SystemdUnitCollector implements Collector<'SystemdUnit'> {
+  readonly kind = 'SystemdUnit' as const;
+  readonly pollIntervalMs = 30_000;
+
+  private readonly probe: SystemdProbe;
+  private _health: { state: 'running' | 'stubbed' | 'error'; reason?: string } = {
+    state: 'running',
+  };
+  private _subscription: WatchHandle | null = null;
+  private readonly _allowSet: Set<string>;
+
+  constructor({ probe }: SystemdUnitCollectorOptions) {
+    this.probe = probe;
+    this._allowSet = new Set(probe.allowList);
+  }
+
+  async initialSweep(): Promise<ObservationDelta[]> {
+    try {
+      const deltas = await Promise.all(this.probe.allowList.map((unit) => this._buildDelta(unit)));
+      return deltas;
+    } catch (err) {
+      this._health = { state: 'error', reason: err instanceof Error ? err.message : String(err) };
+      throw err;
+    }
+  }
+
+  async start(emit: (delta: ObservationDelta) => void): Promise<void> {
+    this._health = { state: 'running' };
+    this._subscription = this.probe.subscribeAllowListed(this.probe.allowList, async (unitName) => {
+      if (!this._allowSet.has(unitName)) return;
+      try {
+        emit(await this._buildDelta(unitName));
+      } catch (err) {
+        this._health = { state: 'error', reason: err instanceof Error ? err.message : String(err) };
+      }
+    });
+  }
+
+  async stop(): Promise<void> {
+    this._subscription?.stop();
+    this._subscription = null;
+  }
+
+  health(): { state: 'running' | 'stubbed' | 'error'; reason?: string } {
+    return this._health;
+  }
+
+  private async _buildDelta(unitName: string): Promise<ObservationDelta> {
+    const state = await this.probe.getUnitState(unitName);
+    const observedAt = new Date().toISOString();
+    return {
+      kind: 'SystemdUnit',
+      id: unitName,
+      op: 'upsert',
+      value: {
+        kind: 'SystemdUnit',
+        id: unitName,
+        status: {
+          load_state: state.load_state,
+          active_state: state.active_state,
+          sub_state: state.sub_state,
+          ...(state.unit_file_state !== undefined
+            ? { unit_file_state: state.unit_file_state }
+            : {}),
+          observed_at: observedAt,
+        },
+      },
+    };
+  }
+}

--- a/xiNAS-MCP/src/agent/collectors/users.ts
+++ b/xiNAS-MCP/src/agent/collectors/users.ts
@@ -1,4 +1,4 @@
-import type { Collector, ObservationDelta } from './base.js';
+import type { Collector, Kind, ObservationDelta } from './base.js';
 
 interface PasswdEntry {
   uid: number;
@@ -92,6 +92,11 @@ export class UsersCollector implements Collector<'User'> {
 
   health(): { state: 'running' | 'stubbed' | 'error'; reason?: string } {
     return this._health;
+  }
+
+  /** This one collector observes both User and Group; report health for both. */
+  healthKinds(): Kind[] {
+    return ['User', 'Group'];
   }
 
   private async _buildDeltas(): Promise<ObservationDelta[]> {

--- a/xiNAS-MCP/src/agent/collectors/users.ts
+++ b/xiNAS-MCP/src/agent/collectors/users.ts
@@ -1,0 +1,155 @@
+import type { Collector, ObservationDelta } from './base.js';
+
+interface PasswdEntry {
+  uid: number;
+  name: string;
+  gid: number;
+  gecos?: string;
+  home?: string;
+  shell?: string;
+  source: 'local' | 'nss';
+}
+
+interface GroupEntry {
+  gid: number;
+  name: string;
+  members: string[];
+  source: 'local' | 'nss';
+}
+
+interface WatchHandle {
+  stop(): void;
+}
+
+interface UsersProbe {
+  /** Runs `getent passwd`; parses via B8. */
+  getentPasswd(): Promise<PasswdEntry[]>;
+  /** Runs `getent group`; parses via B9. */
+  getentGroup(): Promise<GroupEntry[]>;
+  /**
+   * inotify on /etc/passwd, /etc/group, /etc/nsswitch.conf, /etc/sssd/
+   * (all changes that could affect local user/group enumeration).
+   */
+  watchPasswdFiles(cb: () => void): WatchHandle;
+}
+
+interface UsersCollectorOptions {
+  probe: UsersProbe;
+}
+
+/**
+ * Users collector. Wires D8 probe + B8 passwd parser + B9 group parser.
+ *
+ * One collector emits BOTH User and Group kind deltas. This is intentional:
+ * the probes are entangled (getent does both; watch covers both files);
+ * splitting them would double the system calls for no benefit.
+ *
+ * id for User: decimal uid string.
+ * id for Group: decimal gid string.
+ *
+ * Event source: inotify on /etc/passwd + /etc/group + /etc/nsswitch.conf + /etc/sssd/.
+ * Poll fallback: 300 s.
+ */
+export class UsersCollector implements Collector<'User'> {
+  readonly kind = 'User' as const;
+  readonly pollIntervalMs = 300_000;
+
+  private readonly probe: UsersProbe;
+  private _health: { state: 'running' | 'stubbed' | 'error'; reason?: string } = {
+    state: 'running',
+  };
+  private _watch: WatchHandle | null = null;
+
+  constructor({ probe }: UsersCollectorOptions) {
+    this.probe = probe;
+  }
+
+  async initialSweep(): Promise<ObservationDelta[]> {
+    try {
+      return await this._buildDeltas();
+    } catch (err) {
+      this._health = { state: 'error', reason: err instanceof Error ? err.message : String(err) };
+      throw err;
+    }
+  }
+
+  async start(emit: (delta: ObservationDelta) => void): Promise<void> {
+    this._health = { state: 'running' };
+    this._watch = this.probe.watchPasswdFiles(async () => {
+      try {
+        const deltas = await this._buildDeltas();
+        for (const delta of deltas) emit(delta);
+      } catch (err) {
+        this._health = { state: 'error', reason: err instanceof Error ? err.message : String(err) };
+      }
+    });
+  }
+
+  async stop(): Promise<void> {
+    this._watch?.stop();
+    this._watch = null;
+  }
+
+  health(): { state: 'running' | 'stubbed' | 'error'; reason?: string } {
+    return this._health;
+  }
+
+  private async _buildDeltas(): Promise<ObservationDelta[]> {
+    const observedAt = new Date().toISOString();
+    const [users, groups] = await Promise.all([
+      this.probe.getentPasswd(),
+      this.probe.getentGroup(),
+    ]);
+
+    const deltas: ObservationDelta[] = [];
+
+    for (const u of users) {
+      deltas.push({
+        kind: 'User',
+        id: String(u.uid),
+        op: 'upsert',
+        value: {
+          kind: 'User',
+          id: String(u.uid),
+          spec: {
+            name: u.name,
+            uid: u.uid,
+            gid: u.gid,
+            ...(u.gecos !== undefined ? { gecos: u.gecos } : {}),
+            ...(u.home !== undefined ? { home: u.home } : {}),
+            ...(u.shell !== undefined ? { shell: u.shell } : {}),
+          },
+          status: {
+            resolvable: true,
+            source: u.source,
+            observed_at: observedAt,
+          },
+        },
+      });
+    }
+
+    for (const g of groups) {
+      deltas.push({
+        kind: 'Group',
+        id: String(g.gid),
+        op: 'upsert',
+        value: {
+          kind: 'Group',
+          id: String(g.gid),
+          spec: {
+            name: g.name,
+            gid: g.gid,
+            members: g.members,
+          },
+          status: {
+            resolvable: true,
+            source: g.source,
+            observed_at: observedAt,
+          },
+        },
+      });
+    }
+
+    return deltas;
+  }
+}


### PR DESCRIPTION
## Phase E — collector layer (stacked on #208)

Fifth execution slice of the xinas-agent S0+S1 plan. **Base is #208's branch** (Phase D probes), so this PR's diff is the 11 Phase E commits. Rebase down the stack as #204→…→#208 land.

Collectors are **pure orchestration** (no system calls) — each wraps a probe (injected via a local structural interface, decoupled from `../probe/`) and emits typed `ObservationDelta` (`{kind, id, op:'upsert'|'delete', value?}`) with `status.observed_at` stamped fresh at probe-time. Real probe→collector wiring lands in Phase F.

### What's here
| Commit | Collector | Notes |
|--------|-----------|-------|
| `df5d652` | E1 base + registry | `Collector<K>`, `ObservationDelta`, `observedSegment` (PCR-0 path mapper), `CollectorRegistry` |
| `f821fdb` | Disk (E2) | udevadm events: remove→delete, add/change→re-probe upsert; 60s poll |
| `49a537a` | NetworkInterface (E3) | ip-monitor stream |
| `b76ebf9` | Filesystem (E4) | carries `status.mount_unit_state` |
| `2dfbe2d` | NFS (E5) | dual-kind: `NfsSession` + internal `ExportRule` (grouped by export_path, folded into Share at read-time in Phase I) |
| `486b71e` | NfsIdmap (E6) | singleton, id `snapshot` |
| `892268d` | SystemdUnit (E7) | |
| `a4a8a6c` | Users (E8) | dual-kind: `User` (id=uid) + `Group` (id=gid) |
| `a8e1f0b` | Inventory (E9) | singleton, poll-only (300s) |
| `66c31d4` | stubs (E10) | XiraidArray + managed_files → `stubbed` health |

Built via 9 parallel implementers + E1 first. A recurring plan bug — `{ ...status }` spreading optional fields violates `exactOptionalPropertyTypes` — was fixed consistently with per-field conditional spreads.

### Review → fixes (`24e835f`)
Verdict **FIX-FIRST**; no P0s. Two real robustness gaps fixed:
- **`Promise.all` → `Promise.allSettled`** in the registry's `initialSweep`/`start`/`stop`. One throwing collector (e.g. nfs-helper down) was rejecting the whole fleet — losing *all* observed data on boot, aborting `start()` mid-fleet, and (worst) a failed `stop()` leaking the other collectors' event subprocesses past shutdown. Now one collector in error degrades the node (per spec) while the rest proceed; the failing one still surfaces via `healthSnapshot()`.
- **Per-kind health** (`Collector.healthKinds()`): the Users collector emits both `User` and `Group` but `healthSnapshot` only keyed by `col.kind`, so `Group` never got a health row the spec's collectors map expects. Fixed.

Deferred per review: nfs dual-probe all-or-nothing (both calls share one helper socket → fail together in the common case); two P2 nits.

### Verification
- `tsc --noEmit` exit 0 · **380 tests / 71 files pass** (+63 / +10 over Phase D) · `biome lint` warnings-only
- Pure agent orchestration; no `Requires-Rebuild` trailer.

### Not in this PR
Phases F–L (publisher, api-v1.yaml contract, api internal routes + heartbeat, public routes, tests, Ansible role, sanity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)