### PR TITLE
feat(phase0): xinas-agent S0+S1 — Phase F publisher (DRAFT, stacked on #209)

### DIFF
--- a/xiNAS-MCP/src/__tests__/agent/boot-sequence.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/boot-sequence.test.ts
@@ -1,0 +1,172 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { type Server, createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runBootSequence } from '../../agent/boot.js';
+import {
+  type Collector,
+  CollectorRegistry,
+  type Kind,
+  type ObservationDelta,
+} from '../../agent/collectors/base.js';
+import { Publisher } from '../../agent/publisher.js';
+
+/** A minimal stub collector for testing boot sequence. */
+function makeStubCollector(kind: Kind, deltas: ObservationDelta[]): Collector<Kind> {
+  return {
+    kind,
+    async initialSweep() {
+      return deltas;
+    },
+    async start(_emit) {
+      /* no-op */
+    },
+    async stop() {
+      /* no-op */
+    },
+    health() {
+      return { state: 'running' };
+    },
+  };
+}
+
+describe('Boot sequence — initial sweep + agent_started', () => {
+  let dir: string;
+  let socketPath: string;
+  let server: Server;
+  let requestLog: Array<{ path: string; body: unknown }>;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'xinas-boot-test-'));
+    socketPath = join(dir, 'api.sock');
+    requestLog = [];
+
+    await new Promise<void>((resolve) => {
+      server = createServer((req, res) => {
+        let body = '';
+        req.on('data', (c) => {
+          body += String(c);
+        });
+        req.on('end', () => {
+          requestLog.push({ path: req.url ?? '/', body: JSON.parse(body || 'null') });
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          if (req.url === '/internal/v1/observed') {
+            res.end(JSON.stringify({ accepted: 1, deleted_by_reconcile: 0, state_revision: 1 }));
+          } else {
+            res.end('{}');
+          }
+        });
+      });
+      server.listen(socketPath, resolve);
+    });
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('boot: initial sweep per collector → POST /observed with complete_snapshots, then POST /agent_started', async () => {
+    const pub = new Publisher({
+      apiSocketPath: socketPath,
+      agentToken: 'tok',
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+    });
+
+    const registry = new CollectorRegistry();
+    const diskDelta: ObservationDelta = { kind: 'Disk', id: 'nvme0n1', op: 'upsert', value: {} };
+    registry.register(makeStubCollector('Disk', [diskDelta]));
+    registry.register(makeStubCollector('User', []));
+
+    await runBootSequence({
+      publisher: pub,
+      registry,
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+    });
+
+    // Should have at least one /observed POST (for Disk, which had deltas)
+    // and one /agent_started POST.
+    const observedPosts = requestLog.filter((r) => r.path === '/internal/v1/observed');
+    const startedPosts = requestLog.filter((r) => r.path === '/internal/v1/agent_started');
+
+    expect(observedPosts.length).toBeGreaterThanOrEqual(1);
+    expect(startedPosts).toHaveLength(1);
+
+    // The Disk sweep batch must carry complete_snapshots: ['Disk'].
+    const diskPost = observedPosts.find((r) => {
+      const b = r.body as { complete_snapshots?: string[] };
+      return b.complete_snapshots?.includes('Disk');
+    });
+    expect(diskPost).toBeDefined();
+
+    // /agent_started must carry controller_id.
+    const startedBody = startedPosts[0]?.body as { controller_id?: string };
+    expect(startedBody.controller_id).toBe('00000000-0000-0000-0000-0000000000aa');
+  });
+
+  it('agent_started is posted AFTER all initial sweep batches', async () => {
+    const callOrder: string[] = [];
+
+    const pub = new Publisher({
+      apiSocketPath: socketPath,
+      agentToken: 'tok',
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+    });
+
+    // Monkey-patch to track call order
+    const origFlushWithSnapshot = pub.flushWithSnapshot.bind(pub);
+    pub.flushWithSnapshot = async (kinds) => {
+      callOrder.push(`flush:${kinds.join(',')}`);
+      return origFlushWithSnapshot(kinds);
+    };
+    const origPostOnce = pub.postOnce.bind(pub);
+    pub.postOnce = async (path, body) => {
+      callOrder.push(`postOnce:${path}`);
+      return origPostOnce(path, body);
+    };
+
+    const registry = new CollectorRegistry();
+    registry.register(
+      makeStubCollector('Disk', [{ kind: 'Disk', id: 'x', op: 'upsert', value: {} }]),
+    );
+
+    await runBootSequence({
+      publisher: pub,
+      registry,
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+    });
+
+    const agentStartedIdx = callOrder.findIndex((c) => c.includes('/internal/v1/agent_started'));
+    const lastFlushIdx = callOrder.filter((c) => c.startsWith('flush:')).length - 1;
+    // agent_started must come after the last flush
+    expect(agentStartedIdx).toBeGreaterThan(lastFlushIdx);
+  });
+
+  it('an empty collector still POSTs a reconcile batch (complete_snapshots, empty deltas)', async () => {
+    const pub = new Publisher({
+      apiSocketPath: socketPath,
+      agentToken: 'tok',
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+    });
+
+    const registry = new CollectorRegistry();
+    registry.register(makeStubCollector('User', []));
+
+    await runBootSequence({
+      publisher: pub,
+      registry,
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+    });
+
+    const observedPosts = requestLog.filter((r) => r.path === '/internal/v1/observed');
+    const userReconcile = observedPosts.find((r) => {
+      const b = r.body as { complete_snapshots?: string[]; deltas?: unknown[] };
+      return b.complete_snapshots?.includes('User');
+    });
+    expect(userReconcile).toBeDefined();
+    const body = userReconcile?.body as { complete_snapshots: string[]; deltas: unknown[] };
+    expect(body.complete_snapshots).toEqual(['User']);
+    expect(body.deltas).toEqual([]);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/publisher-retry.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/publisher-retry.test.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { type Server, createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ObservationDelta } from '../../agent/collectors/base.js';
+import { Publisher } from '../../agent/publisher.js';
+
+describe('Publisher — retry + pendingReconcile', () => {
+  let dir: string;
+  let socketPath: string;
+  let server: Server;
+  let responseQueue: Array<{ status: number; body: string }>;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'xinas-pub-retry-'));
+    socketPath = join(dir, 'api.sock');
+    responseQueue = [];
+    // Use fake timers to control backoff without actually waiting.
+    // shouldAdvanceTime keeps real I/O (HTTP) ticking while fake-timer
+    // calls (setTimeout inside sleep()) are still under test control.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    await new Promise<void>((resolve) => {
+      server = createServer((req, res) => {
+        let body = '';
+        req.on('data', (c) => {
+          body += String(c);
+        });
+        req.on('end', () => {
+          const r = responseQueue.shift() ?? { status: 200, body: '{"accepted":1}' };
+          res.writeHead(r.status, { 'Content-Type': 'application/json' });
+          res.end(r.body);
+        });
+      });
+      server.listen(socketPath, resolve);
+    });
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('retries on 5xx up to 5 times then populates pendingReconcile', async () => {
+    // Queue 5 server-side 503 responses, then a success.
+    // With exhaustion policy: 5 attempts max, so after attempt 5 fails → pendingReconcile.
+    for (let i = 0; i < 5; i++) {
+      responseQueue.push({ status: 503, body: '{"errors":[{"code":"INTERNAL"}]}' });
+    }
+
+    const pub = new Publisher({
+      apiSocketPath: socketPath,
+      agentToken: 'tok',
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+      // In tests we shorten backoff to 0ms so vi.runAllTimersAsync works.
+      retryBaseMs: 0,
+    });
+
+    const delta: ObservationDelta = { kind: 'Disk', id: 'nvme0n1', op: 'upsert', value: {} };
+    pub.enqueue(delta);
+
+    // We need to run timers as the retry loop awaits backoff sleeps.
+    const flushPromise = pub.flushWithSnapshot(['Disk']);
+    await vi.runAllTimersAsync();
+    await flushPromise;
+
+    expect(pub.pendingReconcile.has('Disk')).toBe(true);
+  });
+
+  it('does not retry on 4xx', async () => {
+    responseQueue.push({ status: 400, body: '{"errors":[{"code":"INVALID_ARGUMENT"}]}' });
+
+    const pub = new Publisher({
+      apiSocketPath: socketPath,
+      agentToken: 'tok',
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+      retryBaseMs: 0,
+    });
+
+    const delta: ObservationDelta = { kind: 'Disk', id: 'nvme0n1', op: 'upsert', value: {} };
+    pub.enqueue(delta);
+    await pub.flush();
+
+    // 4xx: no pendingReconcile — the payload is structurally wrong; retrying won't help.
+    expect(pub.pendingReconcile.size).toBe(0);
+    // Only one HTTP hit (no retries).
+    expect(responseQueue).toHaveLength(0); // the one queued response was consumed
+  });
+
+  it('clears pendingReconcile for a kind on successful flush', async () => {
+    // Pre-seed pendingReconcile as if a previous flush exhausted retries.
+    const pub = new Publisher({
+      apiSocketPath: socketPath,
+      agentToken: 'tok',
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+      retryBaseMs: 0,
+    });
+    pub.pendingReconcile.add('Disk');
+
+    const delta: ObservationDelta = { kind: 'Disk', id: 'nvme0n1', op: 'upsert', value: {} };
+    pub.enqueue(delta);
+    // Success response (nothing in responseQueue → default 200)
+    await pub.flushWithSnapshot(['Disk']);
+
+    expect(pub.pendingReconcile.has('Disk')).toBe(false);
+  });
+
+  it('needsReconcile(kind) returns true when kind is in pendingReconcile', () => {
+    const pub = new Publisher({
+      apiSocketPath: socketPath,
+      agentToken: 'tok',
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+    });
+    expect(pub.needsReconcile('Disk')).toBe(false);
+    pub.pendingReconcile.add('Disk');
+    expect(pub.needsReconcile('Disk')).toBe(true);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/publisher.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/publisher.test.ts
@@ -1,0 +1,102 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { type Server, createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ObservationDelta } from '../../agent/collectors/base.js';
+import { Publisher } from '../../agent/publisher.js';
+
+describe('Publisher — core enqueue + flush', () => {
+  let dir: string;
+  let socketPath: string;
+  let server: Server;
+  let receivedBodies: unknown[];
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'xinas-pub-test-'));
+    socketPath = join(dir, 'api.sock');
+    receivedBodies = [];
+
+    await new Promise<void>((resolve) => {
+      server = createServer((req, res) => {
+        let body = '';
+        req.on('data', (chunk) => {
+          body += String(chunk);
+        });
+        req.on('end', () => {
+          receivedBodies.push(JSON.parse(body));
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ accepted: 1, deleted_by_reconcile: 0, state_revision: 1 }));
+        });
+      });
+      server.listen(socketPath, resolve);
+    });
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('enqueues deltas and flush POSTs them to /internal/v1/observed', async () => {
+    const pub = new Publisher({
+      apiSocketPath: socketPath,
+      agentToken: 'test-agent-token',
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+    });
+
+    const delta: ObservationDelta = {
+      kind: 'Disk',
+      id: 'nvme0n1',
+      op: 'upsert',
+      value: { name: 'nvme0n1' },
+    };
+
+    pub.enqueue(delta);
+    await pub.flush();
+
+    expect(receivedBodies).toHaveLength(1);
+    const body = receivedBodies[0] as {
+      observed_at: string;
+      controller_id: string;
+      deltas: ObservationDelta[];
+      complete_snapshots: string[];
+    };
+    expect(body.controller_id).toBe('00000000-0000-0000-0000-0000000000aa');
+    expect(body.deltas).toHaveLength(1);
+    expect(body.deltas[0]).toMatchObject({ kind: 'Disk', id: 'nvme0n1', op: 'upsert' });
+    expect(body.complete_snapshots).toEqual([]);
+    expect(typeof body.observed_at).toBe('string');
+  });
+
+  it('flush with no enqueued deltas sends nothing', async () => {
+    const pub = new Publisher({
+      apiSocketPath: socketPath,
+      agentToken: 'test-agent-token',
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+    });
+    await pub.flush();
+    expect(receivedBodies).toHaveLength(0);
+  });
+
+  it('passes complete_snapshots when flushWithSnapshot is called', async () => {
+    const pub = new Publisher({
+      apiSocketPath: socketPath,
+      agentToken: 'test-agent-token',
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+    });
+
+    const delta: ObservationDelta = {
+      kind: 'Disk',
+      id: 'nvme0n1',
+      op: 'upsert',
+      value: { name: 'nvme0n1' },
+    };
+
+    pub.enqueue(delta);
+    await pub.flushWithSnapshot(['Disk']);
+
+    const body = receivedBodies[0] as { complete_snapshots: string[] };
+    expect(body.complete_snapshots).toEqual(['Disk']);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/publisher.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/publisher.test.ts
@@ -99,4 +99,30 @@ describe('Publisher — core enqueue + flush', () => {
     const body = receivedBodies[0] as { complete_snapshots: string[] };
     expect(body.complete_snapshots).toEqual(['Disk']);
   });
+
+  it('early-flushes when the batch byte ceiling is crossed (not just the count)', async () => {
+    const pub = new Publisher({
+      apiSocketPath: socketPath,
+      agentToken: 'test-agent-token',
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+      maxBatchSize: 10_000, // high, so the entry-count ceiling never fires
+      maxBatchBytes: 300, // low, so the byte ceiling fires first
+    });
+
+    // Each delta serializes to well over 100 bytes; a few cross 300 and
+    // trigger the fire-and-forget early flush inside enqueue().
+    for (let i = 0; i < 4; i++) {
+      pub.enqueue({
+        kind: 'Disk',
+        id: `nvme${i}n1`,
+        op: 'upsert',
+        value: { padding: 'x'.repeat(80) },
+      });
+    }
+
+    // Let the fire-and-forget early flush land on the UDS server.
+    await new Promise((r) => setTimeout(r, 100));
+    expect(receivedBodies.length).toBeGreaterThanOrEqual(1);
+    expect((receivedBodies[0] as { deltas: unknown[] }).deltas.length).toBeGreaterThan(0);
+  });
 });

--- a/xiNAS-MCP/src/agent/boot.ts
+++ b/xiNAS-MCP/src/agent/boot.ts
@@ -1,0 +1,53 @@
+import type { CollectorRegistry, Kind, ObservationDelta } from './collectors/base.js';
+import type { Publisher } from './publisher.js';
+
+export interface BootSequenceOptions {
+  publisher: Publisher;
+  registry: CollectorRegistry;
+  controllerId: string;
+}
+
+/**
+ * runBootSequence implements the spec's Flow C startup:
+ *   1. For each collector, call initialSweep() (best-effort; a throw is
+ *      logged and treated as an empty sweep so one bad collector doesn't
+ *      abort boot).
+ *   2. Enqueue its deltas and flushWithSnapshot(kinds) where kinds is the
+ *      union of the collector's primary kind plus every kind present in
+ *      its deltas — so a dual-kind collector (Users -> User+Group, NFS ->
+ *      NfsSession+ExportRule) marks ALL its kinds complete, and an empty
+ *      collector still reconciles its primary kind to empty.
+ *   3. After all sweeps, POST /internal/v1/agent_started once so the api
+ *      clears its heartbeat startup grace timer.
+ * The caller starts steady-state event updates separately via
+ * registry.start(emit).
+ */
+export async function runBootSequence(opts: BootSequenceOptions): Promise<void> {
+  const { publisher, registry, controllerId } = opts;
+
+  for (const collector of registry.list()) {
+    let deltas: ObservationDelta[] = [];
+    try {
+      deltas = await collector.initialSweep();
+    } catch (err) {
+      process.stderr.write(
+        `${JSON.stringify({
+          time: new Date().toISOString(),
+          level: 'error',
+          subsystem: 'boot',
+          event: 'initial_sweep_failed',
+          kind: collector.kind,
+          error: err instanceof Error ? err.message : String(err),
+        })}\n`,
+      );
+      deltas = [];
+    }
+    for (const delta of deltas) {
+      publisher.enqueue(delta);
+    }
+    const kinds = new Set<Kind>([collector.kind, ...deltas.map((d) => d.kind)]);
+    await publisher.flushWithSnapshot([...kinds]);
+  }
+
+  await publisher.postOnce('/internal/v1/agent_started', { controller_id: controllerId });
+}

--- a/xiNAS-MCP/src/agent/collectors/base.ts
+++ b/xiNAS-MCP/src/agent/collectors/base.ts
@@ -85,6 +85,11 @@ export class CollectorRegistry {
     this.collectors.push(collector);
   }
 
+  /** Read-only view of registered collectors, for the boot sequence's per-collector sweep. */
+  list(): readonly Collector[] {
+    return this.collectors;
+  }
+
   /**
    * Returns deltas from every registered collector's initialSweep().
    * Uses allSettled so one failing collector (e.g. nfs-helper down) cannot

--- a/xiNAS-MCP/src/agent/publisher.ts
+++ b/xiNAS-MCP/src/agent/publisher.ts
@@ -76,7 +76,7 @@ export class Publisher {
   }
 
   async #doFlush(completeSnapshots: Kind[]): Promise<void> {
-    if (this.#queue.length === 0) return;
+    if (this.#queue.length === 0 && completeSnapshots.length === 0) return;
 
     const batch = this.#queue.splice(0);
     const kindsInBatch = new Set(batch.map((d) => d.kind));

--- a/xiNAS-MCP/src/agent/publisher.ts
+++ b/xiNAS-MCP/src/agent/publisher.ts
@@ -1,0 +1,103 @@
+import http from 'node:http';
+import type { Kind, ObservationDelta } from './collectors/base.js';
+
+export interface PublisherOptions {
+  apiSocketPath: string;
+  agentToken: string;
+  controllerId: string;
+  /** Max deltas per batch before an early flush. Default: 256. */
+  maxBatchSize?: number;
+  /** Max body size in bytes before an early flush. Default: 1_048_576 (1 MB). */
+  maxBatchBytes?: number;
+}
+
+/**
+ * Publisher batches ObservationDelta emissions from collectors and
+ * POSTs them to /internal/v1/observed over the api's Unix-domain
+ * socket. Each flush clears the queue.
+ *
+ * For retry and pendingReconcile, see F2.
+ */
+export class Publisher {
+  readonly #opts: Required<PublisherOptions>;
+  #queue: ObservationDelta[] = [];
+
+  constructor(opts: PublisherOptions) {
+    this.#opts = {
+      maxBatchSize: 256,
+      maxBatchBytes: 1_048_576,
+      ...opts,
+    };
+  }
+
+  /** Add a delta to the pending batch. */
+  enqueue(delta: ObservationDelta): void {
+    this.#queue.push(delta);
+  }
+
+  /**
+   * POST the current batch to /internal/v1/observed with no
+   * complete_snapshots. Clears the queue on success.
+   */
+  async flush(): Promise<void> {
+    return this.#doFlush([]);
+  }
+
+  /**
+   * POST the current batch marking the given kinds as complete
+   * snapshots so the api can reconcile stale keys.
+   */
+  async flushWithSnapshot(completeSnapshots: Kind[]): Promise<void> {
+    return this.#doFlush(completeSnapshots);
+  }
+
+  async #doFlush(completeSnapshots: Kind[]): Promise<void> {
+    if (this.#queue.length === 0) return;
+
+    const batch = this.#queue.splice(0);
+    const body = JSON.stringify({
+      observed_at: new Date().toISOString(),
+      controller_id: this.#opts.controllerId,
+      deltas: batch,
+      complete_snapshots: completeSnapshots,
+    });
+
+    await this.#postJson('/internal/v1/observed', body);
+  }
+
+  #postJson(path: string, body: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const req = http.request(
+        {
+          socketPath: this.#opts.apiSocketPath,
+          path,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(body),
+            Authorization: `Bearer ${this.#opts.agentToken}`,
+          },
+        },
+        (res) => {
+          // Drain the response body so the socket stays healthy.
+          res.resume();
+          res.on('end', () => {
+            if (res.statusCode !== undefined && res.statusCode >= 200 && res.statusCode < 300) {
+              resolve();
+            } else {
+              reject(new Error(`POST ${path} returned HTTP ${res.statusCode ?? 'unknown'}`));
+            }
+          });
+        },
+      );
+      req.on('error', reject);
+      req.write(body);
+      req.end();
+    });
+  }
+
+  /** Post a one-shot JSON body to an arbitrary path (used for agent_started). */
+  async postOnce(path: string, payload: Record<string, unknown>): Promise<void> {
+    await this.#postJson(path, JSON.stringify(payload));
+  }
+}

--- a/xiNAS-MCP/src/agent/publisher.ts
+++ b/xiNAS-MCP/src/agent/publisher.ts
@@ -36,6 +36,8 @@ interface PostResult {
 export class Publisher {
   readonly #opts: Required<PublisherOptions>;
   #queue: ObservationDelta[] = [];
+  /** Running serialized-byte estimate of #queue, for the maxBatchBytes cap. */
+  #queueBytes = 0;
 
   /** Public so collectors can read and tests can inspect. */
   readonly pendingReconcile: Set<Kind> = new Set();
@@ -52,9 +54,17 @@ export class Publisher {
 
   enqueue(delta: ObservationDelta): void {
     this.#queue.push(delta);
-    // Early flush if we've hit the batch ceiling.
-    if (this.#queue.length >= this.#opts.maxBatchSize) {
-      void this.flush();
+    this.#queueBytes += Buffer.byteLength(JSON.stringify(delta));
+    // Early flush at EITHER ceiling (spec: 256 entries or 1 MB). The
+    // .catch keeps this fire-and-forget flush from ever surfacing an
+    // unhandled rejection — #doFlush is written to resolve on every
+    // error path (5xx/network → pendingReconcile), but this guards a
+    // future change that could let it throw (e.g. a circular value).
+    if (
+      this.#queue.length >= this.#opts.maxBatchSize ||
+      this.#queueBytes >= this.#opts.maxBatchBytes
+    ) {
+      void this.flush().catch(() => {});
     }
   }
 
@@ -79,6 +89,7 @@ export class Publisher {
     if (this.#queue.length === 0 && completeSnapshots.length === 0) return;
 
     const batch = this.#queue.splice(0);
+    this.#queueBytes = 0;
     const kindsInBatch = new Set(batch.map((d) => d.kind));
 
     const body = JSON.stringify({

--- a/xiNAS-MCP/src/agent/publisher.ts
+++ b/xiNAS-MCP/src/agent/publisher.ts
@@ -9,52 +9,78 @@ export interface PublisherOptions {
   maxBatchSize?: number;
   /** Max body size in bytes before an early flush. Default: 1_048_576 (1 MB). */
   maxBatchBytes?: number;
+  /**
+   * Base backoff in ms for the first retry. Subsequent attempts double,
+   * capped at 30_000 ms. Default: 250. Set to 0 in tests to skip waits.
+   */
+  retryBaseMs?: number;
+  /** Maximum retry attempts. Default: 5. */
+  maxRetries?: number;
+}
+
+interface PostResult {
+  status: number;
 }
 
 /**
  * Publisher batches ObservationDelta emissions from collectors and
  * POSTs them to /internal/v1/observed over the api's Unix-domain
- * socket. Each flush clears the queue.
+ * socket.
  *
- * For retry and pendingReconcile, see F2.
+ * Retry policy (F2): 5 attempts, exponential backoff starting at
+ * retryBaseMs (default 250ms), capped at 30s. 4xx → no retry.
+ * 5xx retry exhaustion → affected kinds are added to pendingReconcile.
+ * Collectors check needsReconcile(kind) before their next tick; if
+ * true they run initialSweep instead of incremental delta.
  */
 export class Publisher {
   readonly #opts: Required<PublisherOptions>;
   #queue: ObservationDelta[] = [];
 
+  /** Public so collectors can read and tests can inspect. */
+  readonly pendingReconcile: Set<Kind> = new Set();
+
   constructor(opts: PublisherOptions) {
     this.#opts = {
       maxBatchSize: 256,
       maxBatchBytes: 1_048_576,
+      retryBaseMs: 250,
+      maxRetries: 5,
       ...opts,
     };
   }
 
-  /** Add a delta to the pending batch. */
   enqueue(delta: ObservationDelta): void {
     this.#queue.push(delta);
+    // Early flush if we've hit the batch ceiling.
+    if (this.#queue.length >= this.#opts.maxBatchSize) {
+      void this.flush();
+    }
   }
 
-  /**
-   * POST the current batch to /internal/v1/observed with no
-   * complete_snapshots. Clears the queue on success.
-   */
+  needsReconcile(kind: Kind): boolean {
+    return this.pendingReconcile.has(kind);
+  }
+
   async flush(): Promise<void> {
     return this.#doFlush([]);
   }
 
-  /**
-   * POST the current batch marking the given kinds as complete
-   * snapshots so the api can reconcile stale keys.
-   */
   async flushWithSnapshot(completeSnapshots: Kind[]): Promise<void> {
     return this.#doFlush(completeSnapshots);
+  }
+
+  /** Post a one-shot JSON body (used for /internal/v1/agent_started). */
+  async postOnce(path: string, payload: Record<string, unknown>): Promise<void> {
+    await this.#postJsonRaw(path, JSON.stringify(payload));
   }
 
   async #doFlush(completeSnapshots: Kind[]): Promise<void> {
     if (this.#queue.length === 0) return;
 
     const batch = this.#queue.splice(0);
+    const kindsInBatch = new Set(batch.map((d) => d.kind));
+
     const body = JSON.stringify({
       observed_at: new Date().toISOString(),
       controller_id: this.#opts.controllerId,
@@ -62,10 +88,52 @@ export class Publisher {
       complete_snapshots: completeSnapshots,
     });
 
-    await this.#postJson('/internal/v1/observed', body);
+    const { maxRetries, retryBaseMs } = this.#opts;
+    let lastStatus = 0;
+
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        const result = await this.#postJsonRaw('/internal/v1/observed', body);
+        lastStatus = result.status;
+
+        if (result.status >= 200 && result.status < 300) {
+          // Success: clear pending for these kinds.
+          for (const k of kindsInBatch) {
+            this.pendingReconcile.delete(k);
+          }
+          // Also clear kinds requested for reconcile that succeeded.
+          for (const k of completeSnapshots) {
+            this.pendingReconcile.delete(k as Kind);
+          }
+          return;
+        }
+
+        // 4xx: don't retry — payload is structurally wrong.
+        if (result.status >= 400 && result.status < 500) {
+          return;
+        }
+
+        // 5xx: back off and retry.
+      } catch (_err) {
+        // Network error — treat same as 5xx, will retry.
+        lastStatus = 0;
+      }
+
+      if (attempt < maxRetries - 1) {
+        const backoffMs = Math.min(retryBaseMs * Math.pow(2, attempt), 30_000);
+        await sleep(backoffMs);
+      }
+    }
+
+    // Retry exhaustion: mark kinds for reconcile.
+    // Surface lastStatus in health (future: last_publish_error field).
+    void lastStatus; // used for structured log in production; omitted here for test simplicity
+    for (const k of kindsInBatch) {
+      this.pendingReconcile.add(k);
+    }
   }
 
-  #postJson(path: string, body: string): Promise<void> {
+  #postJsonRaw(path: string, body: string): Promise<PostResult> {
     return new Promise((resolve, reject) => {
       const req = http.request(
         {
@@ -79,14 +147,9 @@ export class Publisher {
           },
         },
         (res) => {
-          // Drain the response body so the socket stays healthy.
           res.resume();
           res.on('end', () => {
-            if (res.statusCode !== undefined && res.statusCode >= 200 && res.statusCode < 300) {
-              resolve();
-            } else {
-              reject(new Error(`POST ${path} returned HTTP ${res.statusCode ?? 'unknown'}`));
-            }
+            resolve({ status: res.statusCode ?? 0 });
           });
         },
       );
@@ -95,9 +158,8 @@ export class Publisher {
       req.end();
     });
   }
+}
 
-  /** Post a one-shot JSON body to an arbitrary path (used for agent_started). */
-  async postOnce(path: string, payload: Record<string, unknown>): Promise<void> {
-    await this.#postJson(path, JSON.stringify(payload));
-  }
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
## Phase F — publisher (stacked on #209)

Sixth execution slice of the xinas-agent S0+S1 plan. **Base is #209's branch** (Phase E collectors), so this PR's diff is the 4 Phase F commits.

The Publisher is the **agent→api boundary**: it batches `ObservationDelta`s and POSTs them to the api's `/internal/v1/observed` over the api's Unix-domain socket, authenticated with the agent bearer. Plus the boot sequence that drives the initial full sweep.

### What's here
| Commit | Task | What |
|--------|------|------|
| `468a0ea` | F1 | Publisher core — batch queue, `flush()`/`flushWithSnapshot(kinds)`, HTTP POST over UDS via `node:http`, `Authorization: Bearer` |
| `e29e348` | F2 | Retry (5 attempts, exp backoff 250ms×2ⁿ cap 30s), 4xx→no-retry, 5xx-exhaustion→`pendingReconcile: Set<Kind>`, `needsReconcile()` |
| `83c49c8` | F3 | `runBootSequence` — per-collector initialSweep → enqueue → `flushWithSnapshot(kinds)` → `POST /agent_started` |
| `5bd…` | review | enforce the 1 MB batch-byte cap |

### Cross-phase reconciliations (F3)
The plan's F3 conflicted with the actual Phase E implementations — resolved:
- **Unified on the E1 `CollectorRegistry`** (added a `list()` accessor) instead of creating a second one.
- **Empty-collector reconcile**: `Publisher.#doFlush` no longer early-returns on an empty queue when `complete_snapshots` is non-empty, so an empty collector still POSTs a reconcile-to-empty batch.
- **Dual-kind `complete_snapshots`**: boot flushes the union of the collector's primary kind + every kind in its deltas, so Users (User+Group) and NFS (NfsSession+ExportRule) mark *all* their kinds complete.

### Review → fix
Verdict **SHIP**, no P0s, security clean (the agent bearer is never logged; `Content-Length` uses `byteLength`). One P1 fixed: **the 1 MB `maxBatchBytes` cap was declared but never enforced** (only the 256-entry count was checked) — `enqueue()` now early-flushes at either ceiling. Deferred per review: the `pendingReconcile` *reader* (collector re-sweep on `needsReconcile`) and flush serialization land with the real probe→collector→agent-server boot wiring.

### Known deferral (intentional)
`agent-server.ts` is **not** modified — the agent does not yet push observations at runtime. Wiring real probes → collectors → `runBootSequence` into the entry point (in the background, so an unavailable api can't block the RPC server from coming up) is a deliberate follow-up.

### Verification
- `tsc --noEmit` exit 0 · **391 tests / 74 files pass** (+1 / +3 over Phase E) · `biome lint` warnings-only
- Pure agent code; no `Requires-Rebuild` trailer.

### Not in this PR
Phases G–L (api-v1.yaml contract, api internal routes + heartbeat, public routes, tests, Ansible role, sanity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)