### PR TITLE
feat(phase0): xinas-agent S0+S1 — Phase G api-v1.yaml contract (DRAFT, stacked on #210)

### DIFF
--- a/docs/control-path/api-v1.yaml
+++ b/docs/control-path/api-v1.yaml
@@ -465,6 +465,59 @@ components:
               type: object
               additionalProperties:
                 type: string
+            agent:
+              type: object
+              required: [state, version]
+              description: "Agent-health surface populated by the HeartbeatTracker."
+              properties:
+                state:
+                  type: string
+                  enum: [healthy, degraded, offline]
+                last_heartbeat_at:
+                  type: [string, "null"]
+                  format: date-time
+                last_observed_push_at:
+                  type: [string, "null"]
+                  format: date-time
+                version:
+                  type: string
+                collectors:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: "Per-collector state: running | stubbed | error: <reason>"
+
+    SystemdUnit:
+      type: object
+      required: [kind, id, metadata, status]
+      description: "Observed systemd unit state collected by the E7 collector. Stored in the state-store only; no public REST path in this release."
+      properties:
+        kind:
+          type: string
+          const: SystemdUnit
+        id:
+          type: string
+          description: "Unit name including suffix, e.g. nfs-server.service or srv-share01.mount."
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        status:
+          type: object
+          required: [load_state, active_state, sub_state, observed_at]
+          properties:
+            load_state:
+              type: string
+              description: "loaded | not-found | error | masked"
+            active_state:
+              type: string
+              description: "active | reloading | inactive | failed | activating | deactivating"
+            sub_state:
+              type: string
+            unit_file_state:
+              type: string
+              description: "enabled | disabled | static | masked | ..."
+            observed_at:
+              type: string
+              format: date-time
 
     Disk:
       type: object

--- a/docs/control-path/api-v1.yaml
+++ b/docs/control-path/api-v1.yaml
@@ -59,6 +59,10 @@ tags:
     description: Support bundle generation.
   - name: health
     description: Health profiles and check results.
+  - name: users
+    description: Observed local and NSS-resolved user accounts.
+  - name: groups
+    description: Observed local and NSS-resolved groups.
 
 # ---------------------------------------------------------------------------
 # Security
@@ -979,6 +983,78 @@ components:
           type: array
           items: { type: string }
 
+    User:
+      type: object
+      required: [kind, id, metadata, spec, status]
+      properties:
+        kind:
+          type: string
+          const: User
+        id:
+          type: string
+          description: "Decimal uid as string."
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        spec:
+          type: object
+          required: [name, uid, gid]
+          properties:
+            name:
+              type: string
+            uid:
+              type: integer
+            gid:
+              type: integer
+            gecos:
+              type: string
+            home:
+              type: string
+            shell:
+              type: string
+        status:
+          type: object
+          required: [resolvable, source]
+          properties:
+            resolvable:
+              type: boolean
+            source:
+              type: string
+              enum: [local, nss]
+
+    Group:
+      type: object
+      required: [kind, id, metadata, spec, status]
+      properties:
+        kind:
+          type: string
+          const: Group
+        id:
+          type: string
+          description: "Decimal gid as string."
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        spec:
+          type: object
+          required: [name, gid]
+          properties:
+            name:
+              type: string
+            gid:
+              type: integer
+            members:
+              type: array
+              items:
+                type: string
+        status:
+          type: object
+          required: [resolvable, source]
+          properties:
+            resolvable:
+              type: boolean
+            source:
+              type: string
+              enum: [local, nss]
+
   # -------------------------------------------------------------------------
   # Reusable responses
   # -------------------------------------------------------------------------
@@ -1025,6 +1101,11 @@ components:
           schema: { $ref: '#/components/schemas/Envelope' }
     Internal:
       description: '`INTERNAL` — server-side failure (incl. `EXECUTOR_UNAVAILABLE`, `AUDIT_WRITE_FAILED`).'
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/Envelope' }
+    Unauthorized:
+      description: '`UNAUTHENTICATED` — missing or invalid bearer token or peer credentials.'
       content:
         application/json:
           schema: { $ref: '#/components/schemas/Envelope' }
@@ -1921,3 +2002,126 @@ paths:
               schema: { type: string, format: binary }
         '404': { $ref: '#/components/responses/NotFound' }
         '500': { $ref: '#/components/responses/Internal' }
+
+  # =========================================================================
+  # Users / Groups (observed state from E8 collector)
+  # =========================================================================
+  /users:
+    get:
+      tags: [users]
+      operationId: listUsers
+      summary: List all observed local and NSS-resolved users.
+      description: >
+        Returns all User objects observed by the E8 users collector.
+        Filter by source to narrow to local (/etc/passwd) or NSS-resolved entries.
+      parameters:
+        - name: source
+          in: query
+          schema:
+            type: string
+            enum: [local, nss, all]
+            default: all
+        - $ref: '#/components/parameters/QueryLimit'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Envelope'
+                  - type: object
+                    properties:
+                      result:
+                        type: array
+                        items: { $ref: '#/components/schemas/User' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /users/{uid}:
+    get:
+      tags: [users]
+      operationId: getUser
+      summary: Get a single user by numeric uid.
+      description: Returns the User object for the given numeric uid, or 404 if not found.
+      parameters:
+        - name: uid
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Envelope'
+                  - type: object
+                    properties:
+                      result: { $ref: '#/components/schemas/User' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /groups:
+    get:
+      tags: [groups]
+      operationId: listGroups
+      summary: List all observed local and NSS-resolved groups.
+      description: >
+        Returns all Group objects observed by the E8 users collector.
+        Filter by source to narrow to local (/etc/group) or NSS-resolved entries.
+      parameters:
+        - name: source
+          in: query
+          schema:
+            type: string
+            enum: [local, nss, all]
+            default: all
+        - $ref: '#/components/parameters/QueryLimit'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Envelope'
+                  - type: object
+                    properties:
+                      result:
+                        type: array
+                        items: { $ref: '#/components/schemas/Group' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /groups/{gid}:
+    get:
+      tags: [groups]
+      operationId: getGroup
+      summary: Get a single group by numeric gid.
+      description: Returns the Group object for the given numeric gid, or 404 if not found.
+      parameters:
+        - name: gid
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Envelope'
+                  - type: object
+                    properties:
+                      result: { $ref: '#/components/schemas/Group' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'

--- a/docs/control-path/api-v1.yaml
+++ b/docs/control-path/api-v1.yaml
@@ -575,6 +575,30 @@ components:
             effective_mount_options:
               type: array
               items: { type: string }
+            currently_mounted:
+              type: boolean
+            mount_options:
+              type: array
+              items:
+                type: string
+            mount_unit_name:
+              type: string
+              description: "Name of the .mount unit, e.g. srv-share01.mount"
+            mount_unit_enabled:
+              type: boolean
+              description: "From `systemctl is-enabled` (B4). Whether the .mount unit is enabled (WantedBy=local-fs.target)."
+            mount_unit_state:
+              type: string
+              enum: [active, inactive, failed, activating, deactivating]
+              description: "systemd ActiveState of the .mount unit, from the dbus cross-reference in the Filesystem collector (E4). Distinct from mount_unit_enabled (enablement)."
+            owner_uid:
+              type: integer
+            owner_gid:
+              type: integer
+            owner_user_name:
+              type: [string, "null"]
+            owner_group_name:
+              type: [string, "null"]
 
     Share:
       type: object
@@ -627,6 +651,11 @@ components:
                 $ref: '#/components/schemas/NfsSession'
             effective_options:
               type: string
+            exports:
+              type: array
+              items:
+                $ref: '#/components/schemas/ExportRule'
+              description: "Per-host export entries observed from /etc/exports.d/ or helper output."
 
     ShareClient:
       type: object
@@ -711,6 +740,25 @@ components:
               type: boolean
             idmapd_unit_state:
               type: string
+
+    ExportRule:
+      type: object
+      required: [host_pattern, options]
+      properties:
+        host_pattern:
+          type: string
+          description: "Matches /etc/exports host field (CIDR, hostname, wildcard, netgroup)."
+        options:
+          type: array
+          items:
+            type: string
+        squash_mode:
+          type: string
+          enum: [root_squash, no_root_squash, all_squash]
+        anon_uid:
+          type: integer
+        anon_gid:
+          type: integer
 
     NfsProfile:
       description: Per ADR-0005. Singleton `default` in Phase 0.

--- a/docs/control-path/api-v1.yaml
+++ b/docs/control-path/api-v1.yaml
@@ -533,7 +533,7 @@ components:
               type: string
         status:
           type: object
-          required: [device_path, serial, model, capacity_bytes, safe_for_use]
+          required: [device_path, serial, model, capacity_bytes, safe_for_use, observed_at]
           properties:
             device_path: { type: string }
             serial: { type: string }
@@ -554,6 +554,10 @@ components:
                 array_id: { type: string }
                 role: { type: string, enum: [data, parity, spare] }
             safe_for_use: { type: boolean }
+            observed_at:
+              type: string
+              format: date-time
+              description: "When the agent's collector observed this entity. Agents stamp this at probe-time; api computes observation_age_seconds = now - observed_at on read."
 
     XiraidArray:
       type: object
@@ -580,7 +584,7 @@ components:
               items: { type: string }
         status:
           type: object
-          required: [state, volume_path]
+          required: [state, volume_path, observed_at]
           properties:
             state:
               type: string
@@ -589,6 +593,10 @@ components:
             rebuild_progress_pct: { type: [integer, "null"] }
             check_progress_pct: { type: [integer, "null"] }
             usable_capacity_bytes: { type: integer, format: int64 }
+            observed_at:
+              type: string
+              format: date-time
+              description: "When the agent's collector observed this entity. Agents stamp this at probe-time; api computes observation_age_seconds = now - observed_at on read."
 
     Filesystem:
       type: object
@@ -618,7 +626,7 @@ components:
                 mode: { type: string }
         status:
           type: object
-          required: [mounted, uuid, size_bytes, free_bytes]
+          required: [mounted, uuid, size_bytes, free_bytes, observed_at]
           properties:
             mounted: { type: boolean }
             uuid: { type: string }
@@ -652,6 +660,10 @@ components:
               type: [string, "null"]
             owner_group_name:
               type: [string, "null"]
+            observed_at:
+              type: string
+              format: date-time
+              description: "When the agent's collector observed this entity. Agents stamp this at probe-time; api computes observation_age_seconds = now - observed_at on read."
 
     Share:
       type: object
@@ -694,6 +706,7 @@ components:
                 hard_bytes: { type: integer, format: int64 }
         status:
           type: object
+          required: [observed_at]
           properties:
             exported: { type: boolean }
             client_mount_profile:
@@ -709,6 +722,10 @@ components:
               items:
                 $ref: '#/components/schemas/ExportRule'
               description: "Per-host export entries observed from /etc/exports.d/ or helper output."
+            observed_at:
+              type: string
+              format: date-time
+              description: "When the agent's collector observed this entity. Agents stamp this at probe-time; api computes observation_age_seconds = now - observed_at on read."
 
     ShareClient:
       type: object
@@ -776,7 +793,7 @@ components:
           $ref: '#/components/schemas/Metadata'
         status:
           type: object
-          required: [conf_present, idmapd_active, method]
+          required: [conf_present, idmapd_active, method, observed_at]
           properties:
             conf_present:
               type: boolean
@@ -793,6 +810,10 @@ components:
               type: boolean
             idmapd_unit_state:
               type: string
+            observed_at:
+              type: string
+              format: date-time
+              description: "When the agent's collector observed this entity. Agents stamp this at probe-time; api computes observation_age_seconds = now - observed_at on read."
 
     ExportRule:
       type: object
@@ -884,6 +905,7 @@ components:
                 on_v3_settings_change:  { type: string, enum: [reload, restart, none] }
         status:
           type: object
+          required: [observed_at]
           properties:
             effective_files:
               type: object
@@ -902,6 +924,10 @@ components:
             warnings:
               type: array
               items: { $ref: '#/components/schemas/Warning' }
+            observed_at:
+              type: string
+              format: date-time
+              description: "When the agent's collector observed this entity. Agents stamp this at probe-time; api computes observation_age_seconds = now - observed_at on read."
 
     NetworkInterface:
       type: object
@@ -924,6 +950,7 @@ components:
             enabled: { type: boolean }
         status:
           type: object
+          required: [observed_at]
           properties:
             driver: { type: string }
             rdma_capable: { type: boolean }
@@ -935,6 +962,10 @@ components:
             duplicates_detected_in:
               type: array
               items: { type: string }
+            observed_at:
+              type: string
+              format: date-time
+              description: "When the agent's collector observed this entity. Agents stamp this at probe-time; api computes observation_age_seconds = now - observed_at on read."
 
     ServiceIP:
       type: object
@@ -1170,13 +1201,17 @@ components:
               type: string
         status:
           type: object
-          required: [resolvable, source]
+          required: [resolvable, source, observed_at]
           properties:
             resolvable:
               type: boolean
             source:
               type: string
               enum: [local, nss]
+            observed_at:
+              type: string
+              format: date-time
+              description: "When the agent's collector observed this entity. Agents stamp this at probe-time; api computes observation_age_seconds = now - observed_at on read."
 
     Group:
       type: object
@@ -1204,13 +1239,17 @@ components:
                 type: string
         status:
           type: object
-          required: [resolvable, source]
+          required: [resolvable, source, observed_at]
           properties:
             resolvable:
               type: boolean
             source:
               type: string
               enum: [local, nss]
+            observed_at:
+              type: string
+              format: date-time
+              description: "When the agent's collector observed this entity. Agents stamp this at probe-time; api computes observation_age_seconds = now - observed_at on read."
 
   # -------------------------------------------------------------------------
   # Reusable responses

--- a/docs/control-path/api-v1.yaml
+++ b/docs/control-path/api-v1.yaml
@@ -650,11 +650,67 @@ components:
 
     NfsSession:
       type: object
+      required: [kind, id, metadata, spec, status]
       properties:
-        client_ip: { type: string }
-        nfs_version: { type: string }
-        export_path: { type: string }
-        active_locks: { type: integer }
+        kind:
+          type: string
+          const: NfsSession
+        id:
+          type: string
+          description: "Composite: <client_addr>:<export_path>."
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        spec:
+          type: object
+          required: [client_addr, export_path]
+          properties:
+            client_addr:
+              type: string
+            client_hostname:
+              type: string
+            export_path:
+              type: string
+        status:
+          type: object
+          required: [proto_version, locked_files, observed_at]
+          properties:
+            proto_version:
+              type: string
+              enum: [v3, v4, v4.1, v4.2]
+            locked_files:
+              type: integer
+            observed_at:
+              type: string
+              format: date-time
+
+    NfsIdmap:
+      type: object
+      required: [kind, metadata, status]
+      properties:
+        kind:
+          type: string
+          const: NfsIdmap
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        status:
+          type: object
+          required: [conf_present, idmapd_active, method]
+          properties:
+            conf_present:
+              type: boolean
+            domain:
+              type: string
+            local_realms:
+              type: array
+              items:
+                type: string
+            method:
+              type: string
+              enum: [nsswitch, static, umich_ldap, unknown]
+            idmapd_active:
+              type: boolean
+            idmapd_unit_state:
+              type: string
 
     NfsProfile:
       description: Per ADR-0005. Singleton `default` in Phase 0.
@@ -2121,6 +2177,31 @@ paths:
                   - type: object
                     properties:
                       result: { $ref: '#/components/schemas/Group' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /nfs-idmap:
+    get:
+      tags: [nfs]
+      operationId: getNfsIdmap
+      summary: Get the observed NFS idmap daemon configuration (singleton).
+      description: >
+        Returns the singleton NfsIdmap object reflecting the current rpc.idmapd
+        configuration and daemon state. Observed-state segment is `nfs_idmap`;
+        public route is `/nfs-idmap` per ADR-0003.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Envelope'
+                  - type: object
+                    properties:
+                      result: { $ref: '#/components/schemas/NfsIdmap' }
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':

--- a/xiNAS-MCP/src/__tests__/contracts/fixtures/NfsProfile.json
+++ b/xiNAS-MCP/src/__tests__/contracts/fixtures/NfsProfile.json
@@ -49,6 +49,7 @@
       "rdma_port": 20049,
       "active_versions": ["4.1", "4.2"]
     },
-    "warnings": []
+    "warnings": [],
+    "observed_at": "2026-05-26T16:00:00Z"
   }
 }


### PR DESCRIPTION
## Phase G — API contract additions (stacked on #210)

Seventh execution slice. **Base is #210's branch** (Phase F publisher); diff is the 5 Phase G commits. All edits land in `docs/control-path/api-v1.yaml` — the OpenAPI contract the api side (Phase H/I) implements and the agent publisher already targets. This shifts back to the **api** side.

### What's here
| Commit | Task | What |
|--------|------|------|
| `32633aa` | G1 | `User` + `Group` schemas + `/users`, `/groups` GET paths (+ `Unauthorized` reusable response) |
| `89c2092` | G2 | **replace** PR #201's flat `NfsSession` with the kind-shaped one; add `NfsIdmap` + `/nfs-idmap` (segment `nfs_idmap`, route `/nfs-idmap`) |
| `78036ee` | G3 | `ExportRule` schema + `Share.status.exports[]` ($ref) + additive optional `Filesystem.status` fields |
| `4b491a9` | G4 | `SystemdUnit` schema + optional `Node.status.agent` sub-object (heartbeat surface) |
| `0a9abda` | G5 | required `status.observed_at` on every observed kind |

Run sequentially (one file → no parallel). Each commit kept the **openapi** gate at 0 spectral errors and the **typescript-contracts** gate at 5/5.

### Reconciliation handled
- G2 replaced the stale flat `NfsSession` and repointed `Share.status.sessions[]` + `/shares/{id}/sessions` at the new shape (no dangling refs) — the gap the Phase D review flagged.
- G4 kept `Node.status.agent` optional so the existing `Node.json` contract fixture stays valid.

### Two items flagged for your review
1. **`observed_at` requiredness on non-agent kinds** (G5): the plan lists `Share`/`NfsProfile`/`XiraidArray` under "every observed kind," so `observed_at` is now `required` there and `NfsProfile.json` was updated to match. But those are desired-state/stub kinds with **no agent collector** in S0+S1 — the read path can only satisfy that `required` once they're actually observed. Followed the plan as written; worth a spec decision (relax to optional on those three vs. wire observation later).
2. **`SystemdUnit` `oas3-unused-component` warning** (G4): SystemdUnit is state-store-only with no public path in S0+S1, so spectral warns it's unused (warning, not error — gate passes). Clears if/when Phase I adds a read route.

### Verification
- `spectral lint` **0 errors** (41 warnings — 40 pre-existing + the SystemdUnit unused note) · `npm run test:contracts` **5/5** (Node + NfsProfile fixtures pass)
- Spec/contract only; no `Requires-Rebuild` trailer.

### Not in this PR
Phases H–L (api internal routes `/internal/v1/observed` + `/agent_started` + heartbeat, public route additions, tests, Ansible role, sanity). Phase H implements *against* this contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)