### PR TITLE
feat(phase0): xinas-agent S0+S1 — Phase H api internal routes + heartbeat (DRAFT, stacked on #211)

### DIFF
--- a/xiNAS-MCP/src/__tests__/api/heartbeat.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/heartbeat.test.ts
@@ -1,0 +1,150 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { HeartbeatTracker, type HeartbeatTrackerOptions } from '../../api/heartbeat.js';
+import type { OpenedStateStore } from '../../state/index.js';
+import { openStateStore } from '../../state/index.js';
+
+async function makeStore(dir: string): Promise<OpenedStateStore> {
+  return openStateStore({
+    databasePath: join(dir, 'xinas.db'),
+    auditJsonlPath: join(dir, 'audit.jsonl'),
+    nodeId: '00000000-0000-0000-0000-0000000000aa',
+  });
+}
+
+describe('HeartbeatTracker — state transitions', () => {
+  let dir: string;
+  let state: OpenedStateStore;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'xinas-hb-test-'));
+    state = await makeStore(dir);
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await state.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function makeTracker(opts?: Partial<HeartbeatTrackerOptions>): HeartbeatTracker {
+    return new HeartbeatTracker({
+      intervalMs: 5_000,
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+      state,
+      agentSocketPath: '/tmp/nonexistent.sock',
+      ...opts,
+    });
+  }
+
+  it('starts in offline state', () => {
+    const tracker = makeTracker();
+    expect(tracker.currentState()).toBe('offline');
+  });
+
+  it('transitions to healthy after recordHeartbeatSuccess', () => {
+    const tracker = makeTracker();
+    tracker.recordHeartbeatSuccess(new Date());
+    expect(tracker.currentState()).toBe('healthy');
+  });
+
+  it('transitions from healthy to degraded after 2× interval without success', () => {
+    const tracker = makeTracker({ intervalMs: 5_000 });
+    const t0 = new Date('2026-05-28T12:00:00.000Z');
+    vi.setSystemTime(t0);
+    tracker.recordHeartbeatSuccess(t0);
+    expect(tracker.currentState()).toBe('healthy');
+
+    // Advance 11 seconds (> 2 × 5000ms = 10s)
+    vi.setSystemTime(new Date(t0.getTime() + 11_000));
+    expect(tracker.currentState()).toBe('degraded');
+  });
+
+  it('transitions from degraded to offline after 6× interval', () => {
+    const tracker = makeTracker({ intervalMs: 5_000 });
+    const t0 = new Date('2026-05-28T12:00:00.000Z');
+    vi.setSystemTime(t0);
+    tracker.recordHeartbeatSuccess(t0);
+
+    // Advance 31 seconds (> 6 × 5000ms = 30s)
+    vi.setSystemTime(new Date(t0.getTime() + 31_000));
+    expect(tracker.currentState()).toBe('offline');
+  });
+
+  it('transitions immediately to offline on recordHeartbeatFailure with connect-refused', () => {
+    const tracker = makeTracker();
+    const t0 = new Date('2026-05-28T12:00:00.000Z');
+    vi.setSystemTime(t0);
+    tracker.recordHeartbeatSuccess(t0);
+    expect(tracker.currentState()).toBe('healthy');
+
+    tracker.recordHeartbeatFailure(new Date(), { connectRefused: true });
+    expect(tracker.currentState()).toBe('offline');
+  });
+
+  it('recordObservationPush does not change heartbeat state', () => {
+    const tracker = makeTracker({ intervalMs: 5_000 });
+    const t0 = new Date('2026-05-28T12:00:00.000Z');
+    vi.setSystemTime(t0);
+    tracker.recordHeartbeatSuccess(t0);
+
+    // Advance past 2× interval — should be degraded
+    vi.setSystemTime(new Date(t0.getTime() + 11_000));
+    expect(tracker.currentState()).toBe('degraded');
+
+    // An observation push does NOT reset the heartbeat timer
+    tracker.recordObservationPush(new Date());
+    expect(tracker.currentState()).toBe('degraded');
+  });
+
+  it('emits an agent_state_changed event to the KV store on transition', () => {
+    const tracker = makeTracker({ intervalMs: 5_000 });
+    const t0 = new Date('2026-05-28T12:00:00.000Z');
+    vi.setSystemTime(t0);
+    tracker.recordHeartbeatSuccess(t0);
+
+    // Advance to degrade
+    vi.setSystemTime(new Date(t0.getTime() + 11_000));
+    // Calling currentState re-evaluates and emits on transition
+    tracker.currentState();
+
+    // Check that an event was written at an /xinas/v1/events/* path
+    const events = state.kv.list({ prefix: '/xinas/v1/events/' });
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    const evt = events[0]?.value as {
+      kind: string;
+      from: string;
+      to: string;
+      controller_id: string;
+    };
+    expect(evt.kind).toBe('agent_state_changed');
+    expect(evt.from).toBe('healthy');
+    expect(evt.to).toBe('degraded');
+    expect(evt.controller_id).toBe('00000000-0000-0000-0000-0000000000aa');
+  });
+
+  it('currentWarnings returns EXECUTOR_DEGRADED only when degraded + routeIsMutating=true', () => {
+    const tracker = makeTracker({ intervalMs: 5_000 });
+    const t0 = new Date('2026-05-28T12:00:00.000Z');
+    vi.setSystemTime(t0);
+    tracker.recordHeartbeatSuccess(t0);
+
+    vi.setSystemTime(new Date(t0.getTime() + 11_000));
+
+    const warnings = tracker.currentWarnings({ routeIsMutating: true });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.code).toBe('EXECUTOR_DEGRADED');
+
+    const readWarnings = tracker.currentWarnings({ routeIsMutating: false });
+    expect(readWarnings).toHaveLength(0);
+  });
+
+  it('currentWarnings returns nothing when healthy', () => {
+    const tracker = makeTracker();
+    tracker.recordHeartbeatSuccess(new Date());
+    expect(tracker.currentWarnings({ routeIsMutating: true })).toHaveLength(0);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/api/internal-agent-started.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/internal-agent-started.test.ts
@@ -1,0 +1,75 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { HeartbeatTracker } from '../../api/heartbeat.js';
+import { type TestSetup, buildTestApp } from './_helpers.js';
+
+const CONTROLLER_ID = '00000000-0000-0000-0000-0000000000aa';
+const AGENT_TOKEN = 'agent-tok-h4';
+
+describe('POST /internal/v1/agent_started', () => {
+  let setup: TestSetup & { cleanup(): Promise<void>; tracker: HeartbeatTracker };
+
+  beforeEach(async () => {
+    const base = await buildTestApp();
+    base.config.tokens[AGENT_TOKEN] = { principal: 'agent:root', role: 'internal_agent' };
+
+    const tracker = new HeartbeatTracker({
+      intervalMs: 5_000,
+      controllerId: CONTROLLER_ID,
+      state: base.state,
+      agentSocketPath: '/tmp/nonexistent.sock',
+    });
+
+    const { createAppWithTracker } = await import('../../api/app.js');
+    const ctx = { config: base.config, state: base.state, tracker };
+    const app = createAppWithTracker(ctx);
+
+    setup = {
+      ...base,
+      app,
+      tracker,
+      async cleanup() {
+        await base.cleanup();
+      },
+    };
+  });
+
+  afterEach(() => setup.cleanup());
+
+  it('returns 204 and calls recordHeartbeatSuccess to clear startup grace', async () => {
+    let successRecorded = false;
+    const orig = setup.tracker.recordHeartbeatSuccess.bind(setup.tracker);
+    setup.tracker.recordHeartbeatSuccess = (at) => {
+      successRecorded = true;
+      orig(at);
+    };
+
+    const res = await request(setup.app)
+      .post('/internal/v1/agent_started')
+      .set('Authorization', `Bearer ${AGENT_TOKEN}`)
+      .send({ controller_id: CONTROLLER_ID });
+
+    expect(res.status).toBe(204);
+    expect(successRecorded).toBe(true);
+    expect(setup.tracker.currentState()).toBe('healthy');
+  });
+
+  it('rejects wrong controller_id with 400', async () => {
+    const res = await request(setup.app)
+      .post('/internal/v1/agent_started')
+      .set('Authorization', `Bearer ${AGENT_TOKEN}`)
+      .send({ controller_id: 'wrong-id' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors[0]?.code).toBe('INVALID_ARGUMENT');
+  });
+
+  it('rejects without agent bearer with 401', async () => {
+    const res = await request(setup.app)
+      .post('/internal/v1/agent_started')
+      .set('Authorization', 'Bearer tok-admin')
+      .send({ controller_id: CONTROLLER_ID });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/api/internal-observed.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/internal-observed.test.ts
@@ -150,6 +150,51 @@ describe('POST /internal/v1/observed', () => {
     expect(res.status).toBe(401);
   });
 
+  it('rejects a delta with a traversal-looking id (../../events/x) with 400 INVALID_ARGUMENT', async () => {
+    const body = {
+      observed_at: new Date().toISOString(),
+      controller_id: CONTROLLER_ID,
+      deltas: [{ kind: 'Disk', id: '../../events/x', op: 'upsert', value: {} }],
+      complete_snapshots: [],
+    };
+
+    const res = await request(setup.app)
+      .post('/internal/v1/observed')
+      .set('Authorization', `Bearer ${AGENT_TOKEN}`)
+      .send(body);
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors[0]?.code).toBe('INVALID_ARGUMENT');
+    expect(res.body.errors[0]?.message).toMatch(/invalid id/);
+  });
+
+  it('accepts a delta with a colon+slash id (NfsSession 10.1.2.3:/srv/share01)', async () => {
+    // ctx.observedSchemas is unset in the test context → schema validation is
+    // skipped; only the id-shape check applies. The NfsSession kind key is
+    // 'nfs_session' via observedSegment, but the id itself is the address.
+    const body = {
+      observed_at: new Date().toISOString(),
+      controller_id: CONTROLLER_ID,
+      deltas: [
+        {
+          kind: 'NfsSession',
+          id: '10.1.2.3:/srv/share01',
+          op: 'upsert',
+          value: { client_addr: '10.1.2.3' },
+        },
+      ],
+      complete_snapshots: [],
+    };
+
+    const res = await request(setup.app)
+      .post('/internal/v1/observed')
+      .set('Authorization', `Bearer ${AGENT_TOKEN}`)
+      .send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body.result.accepted).toBe(1);
+  });
+
   it('calls recordObservationPush on the tracker', async () => {
     let pushRecorded = false;
     const origRecord = setup.tracker.recordObservationPush.bind(setup.tracker);

--- a/xiNAS-MCP/src/__tests__/api/internal-observed.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/internal-observed.test.ts
@@ -1,0 +1,174 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { HeartbeatTracker } from '../../api/heartbeat.js';
+import { type TestSetup, buildTestApp } from './_helpers.js';
+
+const CONTROLLER_ID = '00000000-0000-0000-0000-0000000000aa';
+const AGENT_TOKEN = 'agent-tok-h3';
+
+async function buildAppWithAgent(): Promise<
+  TestSetup & { cleanup(): Promise<void>; tracker: HeartbeatTracker }
+> {
+  const setup = await buildTestApp();
+  setup.config.tokens[AGENT_TOKEN] = { principal: 'agent:root', role: 'internal_agent' };
+
+  const tracker = new HeartbeatTracker({
+    intervalMs: 5_000,
+    controllerId: CONTROLLER_ID,
+    state: setup.state,
+    agentSocketPath: '/tmp/nonexistent.sock',
+  });
+
+  // Re-create app with the patched config + tracker wired to the context.
+  // In the real app, createApp() accepts the tracker via ApiContext;
+  // for tests we can extend ctx with the tracker.
+  const { createAppWithTracker } = await import('../../api/app.js');
+  const ctx = { config: setup.config, state: setup.state, tracker };
+  const app = createAppWithTracker(ctx);
+
+  return {
+    ...setup,
+    app,
+    tracker,
+    async cleanup() {
+      await setup.cleanup();
+    },
+  };
+}
+
+describe('POST /internal/v1/observed', () => {
+  let setup: TestSetup & { cleanup(): Promise<void>; tracker: HeartbeatTracker };
+
+  beforeEach(async () => {
+    setup = await buildAppWithAgent();
+  });
+
+  afterEach(() => setup.cleanup());
+
+  it('accepts a valid observation batch and upserts deltas', async () => {
+    const body = {
+      observed_at: new Date().toISOString(),
+      controller_id: CONTROLLER_ID,
+      deltas: [
+        {
+          kind: 'Disk',
+          id: 'nvme0n1',
+          op: 'upsert',
+          value: { name: 'nvme0n1', status: { model: 'Test' } },
+        },
+      ],
+      complete_snapshots: [],
+    };
+
+    const res = await request(setup.app)
+      .post('/internal/v1/observed')
+      .set('Authorization', `Bearer ${AGENT_TOKEN}`)
+      .send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body.result).toMatchObject({ accepted: 1, deleted_by_reconcile: 0 });
+
+    const stored = setup.state.kv.get('/xinas/v1/observed/Disk/nvme0n1');
+    expect(stored).not.toBeNull();
+    expect((stored?.value as { name?: string })?.name).toBe('nvme0n1');
+  });
+
+  it('reconciles: deletes keys under prefix not in the batch when complete_snapshots includes the kind', async () => {
+    // Pre-seed a stale Disk entry.
+    setup.state.kv.put('/xinas/v1/observed/Disk/stale-disk', { name: 'stale' });
+    setup.state.kv.put('/xinas/v1/observed/Disk/nvme0n1', { name: 'old' });
+
+    const body = {
+      observed_at: new Date().toISOString(),
+      controller_id: CONTROLLER_ID,
+      deltas: [{ kind: 'Disk', id: 'nvme0n1', op: 'upsert', value: { name: 'nvme0n1-new' } }],
+      complete_snapshots: ['Disk'],
+    };
+
+    const res = await request(setup.app)
+      .post('/internal/v1/observed')
+      .set('Authorization', `Bearer ${AGENT_TOKEN}`)
+      .send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body.result.deleted_by_reconcile).toBe(1);
+
+    // stale-disk should be gone
+    expect(setup.state.kv.get('/xinas/v1/observed/Disk/stale-disk')).toBeNull();
+    // nvme0n1 should be updated
+    const stored = setup.state.kv.get<{ name: string }>('/xinas/v1/observed/Disk/nvme0n1');
+    expect(stored?.value.name).toBe('nvme0n1-new');
+  });
+
+  it('applies delete ops', async () => {
+    setup.state.kv.put('/xinas/v1/observed/Disk/nvme0n1', { name: 'existing' });
+
+    const body = {
+      observed_at: new Date().toISOString(),
+      controller_id: CONTROLLER_ID,
+      deltas: [{ kind: 'Disk', id: 'nvme0n1', op: 'delete' }],
+      complete_snapshots: [],
+    };
+
+    const res = await request(setup.app)
+      .post('/internal/v1/observed')
+      .set('Authorization', `Bearer ${AGENT_TOKEN}`)
+      .send(body);
+
+    expect(res.status).toBe(200);
+    expect(setup.state.kv.get('/xinas/v1/observed/Disk/nvme0n1')).toBeNull();
+  });
+
+  it('rejects wrong controller_id with 400 INVALID_ARGUMENT', async () => {
+    const body = {
+      observed_at: new Date().toISOString(),
+      controller_id: '11111111-1111-1111-1111-111111111111',
+      deltas: [],
+      complete_snapshots: [],
+    };
+
+    const res = await request(setup.app)
+      .post('/internal/v1/observed')
+      .set('Authorization', `Bearer ${AGENT_TOKEN}`)
+      .send(body);
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors[0]?.code).toBe('INVALID_ARGUMENT');
+    expect(res.body.errors[0]?.message).toMatch(/controller_id/);
+  });
+
+  it('rejects without agent bearer with 401', async () => {
+    const res = await request(setup.app)
+      .post('/internal/v1/observed')
+      .set('Authorization', 'Bearer tok-admin')
+      .send({
+        observed_at: new Date().toISOString(),
+        controller_id: CONTROLLER_ID,
+        deltas: [],
+        complete_snapshots: [],
+      });
+    expect(res.status).toBe(401);
+  });
+
+  it('calls recordObservationPush on the tracker', async () => {
+    let pushRecorded = false;
+    const origRecord = setup.tracker.recordObservationPush.bind(setup.tracker);
+    setup.tracker.recordObservationPush = (at) => {
+      pushRecorded = true;
+      origRecord(at);
+    };
+
+    const body = {
+      observed_at: new Date().toISOString(),
+      controller_id: CONTROLLER_ID,
+      deltas: [],
+      complete_snapshots: [],
+    };
+    await request(setup.app)
+      .post('/internal/v1/observed')
+      .set('Authorization', `Bearer ${AGENT_TOKEN}`)
+      .send(body);
+
+    expect(pushRecorded).toBe(true);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/api/require-internal-agent.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/require-internal-agent.test.ts
@@ -1,0 +1,77 @@
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildTestApp } from './_helpers.js';
+import type { TestSetup } from './_helpers.js';
+
+/**
+ * Build a minimal express app that mounts a test endpoint behind
+ * requireInternalAgent. The real app will mount it on /internal/v1/*;
+ * here we mount it on /test-internal for isolation.
+ */
+async function buildInternalApp(): Promise<TestSetup & { cleanup(): Promise<void> }> {
+  const setup = await buildTestApp();
+
+  // Add an agent token to the config so auth middleware can resolve it.
+  setup.config.tokens['agent-tok'] = { principal: 'agent:root', role: 'internal_agent' };
+
+  return setup;
+}
+
+describe('requireInternalAgent middleware', () => {
+  let setup: TestSetup & { cleanup(): Promise<void> };
+  let app: Express;
+
+  beforeEach(async () => {
+    setup = await buildInternalApp();
+
+    // Re-create app after mutating config so authMiddleware sees the agent token.
+    const { createApp } = await import('../../api/app.js');
+    const { requireInternalAgent } = await import('../../api/middleware/require-internal-agent.js');
+
+    // Build a fresh app from the patched config.
+    const ctx = { config: setup.config, state: setup.state };
+    app = createApp(ctx);
+
+    // Mount a test-only internal route to verify the middleware.
+    // In a real app this is wired inside createApp; here we verify in isolation.
+    const internalApp = express();
+    internalApp.use(express.json());
+    const { requestIdMiddleware } = await import('../../api/middleware/request-id.js');
+    const { authMiddleware } = await import('../../api/middleware/auth.js');
+    internalApp.use(requestIdMiddleware());
+    internalApp.use(authMiddleware(setup.config));
+    internalApp.post('/internal/v1/test', requireInternalAgent(), (_req, res) => {
+      res.json({ ok: true });
+    });
+    app = internalApp;
+  });
+
+  afterEach(() => setup.cleanup());
+
+  it('passes when Authorization: Bearer <agent-token> is provided', async () => {
+    const res = await request(app)
+      .post('/internal/v1/test')
+      .set('Authorization', 'Bearer agent-tok')
+      .send({});
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true });
+  });
+
+  it('rejects with 401 when no bearer is provided (even over UDS-simulated path)', async () => {
+    // supertest uses TCP; no UDS-trust promotion. But even with a UDS connection,
+    // UDS-trust admin does NOT satisfy internal_agent. We test the role gate directly.
+    const res = await request(app).post('/internal/v1/test').send({});
+    // No auth → 401 from authMiddleware before requireInternalAgent even runs.
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects with 401 when admin bearer (not agent bearer) is provided', async () => {
+    const res = await request(app)
+      .post('/internal/v1/test')
+      .set('Authorization', 'Bearer tok-admin')
+      .send({});
+    // tok-admin has role 'admin', not 'internal_agent'
+    expect(res.status).toBe(401);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/api/system-warnings.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/system-warnings.test.ts
@@ -1,9 +1,11 @@
 import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { HeartbeatTracker } from '../../api/heartbeat.js';
+import { mergeWarnings } from '../../api/handlers/merge-warnings.js';
 import { type TestSetup, buildTestApp, seedCluster, seedNode } from './_helpers.js';
 
 const CONTROLLER_ID = '00000000-0000-0000-0000-0000000000aa';
+const AGENT_TOKEN = 'agent-tok-sw-h5';
 
 /**
  * Build a test app with a HeartbeatTracker that is already in the
@@ -18,6 +20,9 @@ async function buildDegradedApp(): Promise<
   const setup = await buildTestApp();
   seedCluster(setup.state);
   seedNode(setup.state);
+
+  // Wire an agent token so the /internal/v1/observed test can authenticate.
+  setup.config.tokens[AGENT_TOKEN] = { principal: 'agent:root', role: 'internal_agent' };
 
   const tracker = new HeartbeatTracker({
     intervalMs: 5_000,
@@ -43,6 +48,20 @@ async function buildDegradedApp(): Promise<
     },
   };
 }
+
+describe('mergeWarnings unit', () => {
+  it('deduplicates by code, keeping first occurrence', () => {
+    const handler = [{ code: 'FOO', message: 'handler foo' }];
+    const system = [
+      { code: 'FOO', message: 'system foo (duplicate)' },
+      { code: 'BAR', message: 'system bar' },
+    ];
+    const result = mergeWarnings(handler, system);
+    expect(result.map((w) => w.code)).toEqual(['FOO', 'BAR']);
+    // First occurrence of FOO is from the handler.
+    expect(result.find((w) => w.code === 'FOO')?.message).toBe('handler foo');
+  });
+});
 
 describe('systemWarningsMiddleware + mergeWarnings', () => {
   let setup: TestSetup & { cleanup(): Promise<void>; tracker: HeartbeatTracker };
@@ -91,5 +110,27 @@ describe('systemWarningsMiddleware + mergeWarnings', () => {
 
     const warnings = res.body.warnings as Array<{ code: string }>;
     expect(warnings.every((w) => w.code !== 'EXECUTOR_DEGRADED')).toBe(true);
+  });
+
+  it('degraded tracker: POST /internal/v1/observed does NOT receive EXECUTOR_DEGRADED warning', async () => {
+    // The agent's own observation push goes to /internal/v1/observed which is
+    // mounted BEFORE the /api/v1 sub-router that carries systemWarningsMiddleware.
+    // This verifies the middleware is scoped only to /api/v1/* (Fix H-review-2).
+    const body = {
+      observed_at: new Date().toISOString(),
+      controller_id: CONTROLLER_ID,
+      deltas: [],
+      complete_snapshots: [],
+    };
+
+    const res = await request(setup.app)
+      .post('/internal/v1/observed')
+      .set('Authorization', `Bearer ${AGENT_TOKEN}`)
+      .send(body);
+
+    // The response must be 200 (no auth error) and must carry no EXECUTOR_DEGRADED.
+    expect(res.status).toBe(200);
+    const warnings = (res.body.warnings ?? []) as Array<{ code: string }>;
+    expect(warnings.some((w) => w.code === 'EXECUTOR_DEGRADED')).toBe(false);
   });
 });

--- a/xiNAS-MCP/src/__tests__/api/system-warnings.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/system-warnings.test.ts
@@ -1,0 +1,95 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { HeartbeatTracker } from '../../api/heartbeat.js';
+import { type TestSetup, buildTestApp, seedCluster, seedNode } from './_helpers.js';
+
+const CONTROLLER_ID = '00000000-0000-0000-0000-0000000000aa';
+
+/**
+ * Build a test app with a HeartbeatTracker that is already in the
+ * 'degraded' state. We achieve degraded by recording a heartbeat
+ * success with a timestamp 11 seconds in the past relative to
+ * real wall-clock time (intervalMs=5000, so 2×interval=10s; 11s > 10s
+ * → degraded). No fake timers needed — avoids supertest HTTP hangs.
+ */
+async function buildDegradedApp(): Promise<
+  TestSetup & { cleanup(): Promise<void>; tracker: HeartbeatTracker }
+> {
+  const setup = await buildTestApp();
+  seedCluster(setup.state);
+  seedNode(setup.state);
+
+  const tracker = new HeartbeatTracker({
+    intervalMs: 5_000,
+    controllerId: CONTROLLER_ID,
+    state: setup.state,
+    agentSocketPath: '/tmp/nonexistent.sock',
+  });
+
+  // Simulate a heartbeat that occurred 11 seconds ago → degraded (> 2×5s).
+  const past = new Date(Date.now() - 11_000);
+  tracker.recordHeartbeatSuccess(past);
+
+  const { createAppWithTracker } = await import('../../api/app.js');
+  const ctx = { config: setup.config, state: setup.state, tracker };
+  const app = createAppWithTracker(ctx);
+
+  return {
+    ...setup,
+    app,
+    tracker,
+    async cleanup() {
+      await setup.cleanup();
+    },
+  };
+}
+
+describe('systemWarningsMiddleware + mergeWarnings', () => {
+  let setup: TestSetup & { cleanup(): Promise<void>; tracker: HeartbeatTracker };
+
+  beforeEach(async () => {
+    setup = await buildDegradedApp();
+  });
+
+  afterEach(() => setup.cleanup());
+
+  it('read endpoint: degraded tracker does NOT inject EXECUTOR_DEGRADED warning', async () => {
+    const res = await request(setup.app)
+      .get('/api/v1/system')
+      .set('Authorization', 'Bearer tok-admin');
+
+    expect(res.status).toBe(200);
+    const warnings = res.body.warnings as Array<{ code: string }>;
+    const hasDegraded = warnings.some((w) => w.code === 'EXECUTOR_DEGRADED');
+    expect(hasDegraded).toBe(false);
+  });
+
+  it('mutating endpoint: degraded tracker DOES inject EXECUTOR_DEGRADED warning', async () => {
+    // The mutating stub (POST /api/v1/arrays) returns UNSUPPORTED (422) because
+    // tracker is online (degraded, not offline) but the method isn't built yet.
+    // The envelope should carry EXECUTOR_DEGRADED in warnings.
+    const res = await request(setup.app)
+      .post('/api/v1/arrays')
+      .set('Authorization', 'Bearer tok-admin')
+      .send({});
+
+    // Status 422 (UNSUPPORTED) and warnings include EXECUTOR_DEGRADED
+    expect(res.status).toBe(422);
+    const warnings = res.body.warnings as Array<{ code: string }>;
+    const hasDegraded = warnings.some((w) => w.code === 'EXECUTOR_DEGRADED');
+    expect(hasDegraded).toBe(true);
+  });
+
+  it('healthy tracker: no EXECUTOR_DEGRADED warning on any route', async () => {
+    // Record a very recent heartbeat → healthy state.
+    setup.tracker.recordHeartbeatSuccess(new Date());
+
+    const res = await request(setup.app)
+      .post('/api/v1/arrays')
+      .set('Authorization', 'Bearer tok-admin')
+      .send({});
+
+    const warnings = res.body.warnings as Array<{ code: string }>;
+    expect(warnings.every((w) => w.code !== 'EXECUTOR_DEGRADED')).toBe(true);
+  });
+});

--- a/xiNAS-MCP/src/api/app.ts
+++ b/xiNAS-MCP/src/api/app.ts
@@ -42,15 +42,19 @@ export function createApp(ctx: ApiContext): Express {
   app.use(auditMiddleware(ctx.state));
   app.use(express.json({ limit: '1mb' }));
   app.use(authMiddleware(ctx.config));
-  app.use(systemWarningsMiddleware(ctx)); // after auth (context populated), before routes
 
   // The agent's exclusive write surface. Mounted after authMiddleware so
   // req.context.role is resolved before requireInternalAgent (inside the
   // sub-router) reads it; before /api/v1 so /internal/v1/* never falls
   // through to the public API's NOT_FOUND catch-all.
+  //
+  // systemWarningsMiddleware is intentionally NOT mounted at the top-level app
+  // so that /internal/v1/* requests are excluded — the agent's own observation
+  // push must not receive an EXECUTOR_DEGRADED self-warning (Fix H-review-2).
   app.use('/internal/v1', internalRouter(ctx));
 
   const v1 = Router();
+  v1.use(systemWarningsMiddleware(ctx)); // after auth (context populated), before route handlers
   v1.use(systemRouter(ctx));
   v1.use(storageRouter(ctx));
   v1.use(nfsRouter(ctx));

--- a/xiNAS-MCP/src/api/app.ts
+++ b/xiNAS-MCP/src/api/app.ts
@@ -1,22 +1,24 @@
 import express, { type Express, Router } from 'express';
 import type { ApiContext } from './context.js';
-import { requestIdMiddleware } from './middleware/request-id.js';
-import { authMiddleware } from './middleware/auth.js';
+import { ApiException } from './errors.js';
+import { executorUnavailable } from './handlers/unsupported.js';
+import type { HeartbeatTracker } from './heartbeat.js';
+import { internalRouter } from './internal/router.js';
 import { auditMiddleware } from './middleware/audit.js';
+import { authMiddleware } from './middleware/auth.js';
 import { errorMiddleware } from './middleware/error.js';
-import { systemRouter } from './routes/system.js';
-import { storageRouter } from './routes/storage.js';
-import { nfsRouter } from './routes/nfs.js';
-import { networkRouter } from './routes/network.js';
-import { healthRouter } from './routes/health.js';
-import { tasksRouter } from './routes/tasks.js';
-import { eventsRouter } from './routes/events.js';
+import { requestIdMiddleware } from './middleware/request-id.js';
 import { auditRouter } from './routes/audit-query.js';
 import { configHistoryRouter } from './routes/config-history.js';
-import { supportRouter } from './routes/support.js';
+import { eventsRouter } from './routes/events.js';
+import { healthRouter } from './routes/health.js';
 import { inventoryRouter } from './routes/inventory.js';
-import { executorUnavailable } from './handlers/unsupported.js';
-import { ApiException } from './errors.js';
+import { networkRouter } from './routes/network.js';
+import { nfsRouter } from './routes/nfs.js';
+import { storageRouter } from './routes/storage.js';
+import { supportRouter } from './routes/support.js';
+import { systemRouter } from './routes/system.js';
+import { tasksRouter } from './routes/tasks.js';
 
 export function createApp(ctx: ApiContext): Express {
   const app = express();
@@ -39,6 +41,12 @@ export function createApp(ctx: ApiContext): Express {
   app.use(auditMiddleware(ctx.state));
   app.use(express.json({ limit: '1mb' }));
   app.use(authMiddleware(ctx.config));
+
+  // The agent's exclusive write surface. Mounted after authMiddleware so
+  // req.context.role is resolved before requireInternalAgent (inside the
+  // sub-router) reads it; before /api/v1 so /internal/v1/* never falls
+  // through to the public API's NOT_FOUND catch-all.
+  app.use('/internal/v1', internalRouter(ctx));
 
   const v1 = Router();
   v1.use(systemRouter(ctx));
@@ -88,4 +96,14 @@ export function createApp(ctx: ApiContext): Express {
 
   app.use(errorMiddleware());
   return app;
+}
+
+/**
+ * Variant of createApp that requires a HeartbeatTracker in context.
+ * Identical wiring to createApp; the narrowed type just documents that
+ * callers building the production app (and the H3+ internal tests) supply
+ * a tracker so /internal/v1/observed can call recordObservationPush.
+ */
+export function createAppWithTracker(ctx: ApiContext & { tracker: HeartbeatTracker }): Express {
+  return createApp(ctx);
 }

--- a/xiNAS-MCP/src/api/app.ts
+++ b/xiNAS-MCP/src/api/app.ts
@@ -8,6 +8,7 @@ import { auditMiddleware } from './middleware/audit.js';
 import { authMiddleware } from './middleware/auth.js';
 import { errorMiddleware } from './middleware/error.js';
 import { requestIdMiddleware } from './middleware/request-id.js';
+import { systemWarningsMiddleware } from './middleware/system-warnings.js';
 import { auditRouter } from './routes/audit-query.js';
 import { configHistoryRouter } from './routes/config-history.js';
 import { eventsRouter } from './routes/events.js';
@@ -41,6 +42,7 @@ export function createApp(ctx: ApiContext): Express {
   app.use(auditMiddleware(ctx.state));
   app.use(express.json({ limit: '1mb' }));
   app.use(authMiddleware(ctx.config));
+  app.use(systemWarningsMiddleware(ctx)); // after auth (context populated), before routes
 
   // The agent's exclusive write surface. Mounted after authMiddleware so
   // req.context.role is resolved before requireInternalAgent (inside the
@@ -77,10 +79,10 @@ export function createApp(ctx: ApiContext): Express {
     '/config-history/rollback',
   ];
   for (const route of mutatingRoutes) {
-    v1.post(route, executorUnavailable);
-    v1.patch(route, executorUnavailable);
-    v1.put(route, executorUnavailable);
-    v1.delete(route, executorUnavailable);
+    v1.post(route, executorUnavailable(ctx));
+    v1.patch(route, executorUnavailable(ctx));
+    v1.put(route, executorUnavailable(ctx));
+    v1.delete(route, executorUnavailable(ctx));
   }
 
   // Catch-all for /api/v1/* paths that didn't match any router. Without

--- a/xiNAS-MCP/src/api/context.ts
+++ b/xiNAS-MCP/src/api/context.ts
@@ -1,5 +1,19 @@
 import type { OpenedStateStore } from '../state/index.js';
 import type { ApiConfig, Role } from './config.js';
+import type { HeartbeatTracker } from './heartbeat.js';
+
+/**
+ * A compiled Ajv validator for one observed kind. The handler only
+ * calls `validate(value)` and reads `validate.errors` on failure, so
+ * the surface kept here is deliberately minimal — pulling Ajv's full
+ * `ValidateFunction` generic into the context would couple every route
+ * module to ajv. Wired (with the matching `ajv`) in a later task; until
+ * then `observedSchemas` is undefined and validation is skipped.
+ */
+export interface ObservedValidateFn {
+  (data: unknown): boolean;
+  errors?: unknown;
+}
 
 /**
  * Shared per-process context. Built once at startup and passed into
@@ -8,6 +22,18 @@ import type { ApiConfig, Role } from './config.js';
 export interface ApiContext {
   config: ApiConfig;
   state: OpenedStateStore;
+  /** Optional; absent until HeartbeatTracker is wired (H1+). */
+  tracker?: HeartbeatTracker;
+  /**
+   * Optional per-kind Ajv validators for inbound observation deltas
+   * (wired in a later task — H6/J3). When present, the /internal/v1/observed
+   * handler fail-closes: every upsert delta is validated against its kind's
+   * schema before any write. When absent (the H3 unit context), validation
+   * is skipped.
+   */
+  observedSchemas?: Record<string, ObservedValidateFn>;
+  /** Companion to observedSchemas; renders an Ajv validator's errors as text. */
+  ajv?: { errorsText(errors: unknown): string };
 }
 
 /**

--- a/xiNAS-MCP/src/api/context.ts
+++ b/xiNAS-MCP/src/api/context.ts
@@ -1,5 +1,6 @@
 import type { OpenedStateStore } from '../state/index.js';
 import type { ApiConfig, Role } from './config.js';
+import type { Warning } from './envelope.js';
 import type { HeartbeatTracker } from './heartbeat.js';
 
 /**
@@ -48,6 +49,8 @@ export interface RequestContext {
   client_type: 'rest';
   /** Set by handlers when they want the audit row to carry an operation_id (e.g. for tasks). */
   operation_id?: string;
+  /** Populated by systemWarningsMiddleware from HeartbeatTracker. */
+  system_warnings: Warning[];
 }
 
 /**

--- a/xiNAS-MCP/src/api/handlers/merge-warnings.ts
+++ b/xiNAS-MCP/src/api/handlers/merge-warnings.ts
@@ -1,0 +1,15 @@
+import type { Warning } from '../envelope.js';
+
+/**
+ * Merge handler-local warnings with system-level warnings injected by
+ * systemWarningsMiddleware. Called by sendOk() and errorMiddleware()
+ * so every envelope — success or error — carries the combined set.
+ *
+ * System warnings (e.g., EXECUTOR_DEGRADED) appear after handler
+ * warnings so the handler's intent is first in the array.
+ */
+export function mergeWarnings(handlerWarnings: Warning[], systemWarnings: Warning[]): Warning[] {
+  if (systemWarnings.length === 0) return handlerWarnings;
+  if (handlerWarnings.length === 0) return systemWarnings;
+  return [...handlerWarnings, ...systemWarnings];
+}

--- a/xiNAS-MCP/src/api/handlers/merge-warnings.ts
+++ b/xiNAS-MCP/src/api/handlers/merge-warnings.ts
@@ -7,9 +7,17 @@ import type { Warning } from '../envelope.js';
  *
  * System warnings (e.g., EXECUTOR_DEGRADED) appear after handler
  * warnings so the handler's intent is first in the array.
+ *
+ * De-duplicates by `code`, keeping the first occurrence of each code
+ * so that a warning emitted by both a handler and the middleware
+ * appears only once in the envelope.
  */
 export function mergeWarnings(handlerWarnings: Warning[], systemWarnings: Warning[]): Warning[] {
-  if (systemWarnings.length === 0) return handlerWarnings;
-  if (handlerWarnings.length === 0) return systemWarnings;
-  return [...handlerWarnings, ...systemWarnings];
+  const combined = [...handlerWarnings, ...systemWarnings];
+  const seen = new Set<string>();
+  return combined.filter((w) => {
+    if (seen.has(w.code)) return false;
+    seen.add(w.code);
+    return true;
+  });
 }

--- a/xiNAS-MCP/src/api/handlers/reads.ts
+++ b/xiNAS-MCP/src/api/handlers/reads.ts
@@ -1,20 +1,30 @@
 import type { Request, Response } from 'express';
 import type { OpenedStateStore, RevisionedValue } from '../../state/index.js';
 import { buildEnvelope } from '../envelope.js';
+import type { Warning } from '../envelope.js';
+import { mergeWarnings } from './merge-warnings.js';
 
 /**
  * Helper that wraps a value (or list) in the standard envelope and
  * sends it. Computes state_revision as the max revision in the
  * payload, or 0 if none.
  */
-export function sendOk<T>(req: Request, res: Response, result: T, revisions: number[] = []): void {
+export function sendOk<T>(
+  req: Request,
+  res: Response,
+  result: T,
+  revisions: number[] = [],
+  warnings: Warning[] = [],
+): void {
   const ctx = req.context!;
   const state_revision = revisions.length === 0 ? 0 : Math.max(...revisions);
+  const allWarnings = mergeWarnings(warnings, ctx.system_warnings ?? []);
   res.json(
     buildEnvelope({
       request_id: ctx.request_id,
       correlation_id: ctx.correlation_id,
       state_revision,
+      warnings: allWarnings,
       result,
     }),
   );

--- a/xiNAS-MCP/src/api/handlers/unsupported.ts
+++ b/xiNAS-MCP/src/api/handlers/unsupported.ts
@@ -1,32 +1,37 @@
 import type { Request, Response } from 'express';
-import { buildEnvelope } from '../envelope.js';
-import { errorStatus, makeError } from '../errors.js';
+import type { ApiContext } from '../context.js';
+import { ApiException } from '../errors.js';
 
 /**
- * Single stub used by every mutating endpoint in this PR. Per
- * ADR-0002 §Agent heartbeat, when the agent isn't reachable
- * mutating ops fail with INTERNAL/EXECUTOR_UNAVAILABLE.
+ * Factory that returns the stub used by every mutating endpoint.
+ * Per ADR-0002 §Agent heartbeat, behaviour depends on tracker state:
  *
- * In the xinas-api skeleton the agent doesn't exist at all, so
- * every mutating verb routes here. When the agent ships, this
- * handler gets replaced with real plan/apply dispatch per route.
+ *   - No tracker OR tracker state === 'offline':
+ *       INTERNAL / EXECUTOR_UNAVAILABLE (500). The executor can't be
+ *       reached; remediation: restart xinas-agent.service.
+ *
+ *   - Tracker state === 'healthy' OR 'degraded':
+ *       UNSUPPORTED / EXECUTOR_UNSUPPORTED (422). The executor is
+ *       reachable but the mutating method isn't implemented in this
+ *       S0+S1 build yet.
+ *
+ * The EXECUTOR_DEGRADED warning for the degraded case is injected
+ * separately by systemWarningsMiddleware into the envelope warnings[].
  */
-export function executorUnavailable(req: Request, res: Response): void {
-  const ctx = req.context!;
-  res.status(errorStatus('INTERNAL')).json(
-    buildEnvelope({
-      request_id: ctx.request_id,
-      correlation_id: ctx.correlation_id,
-      state_revision: 0,
-      errors: [
-        makeError(
-          'INTERNAL',
-          'mutating operations are unavailable: xinas-agent is not running',
-          { code: 'EXECUTOR_UNAVAILABLE' },
-          'start xinas-agent.service; mutating endpoints will return once the agent is healthy',
-        ),
-      ],
-      result: null,
-    }),
-  );
+export function executorUnavailable(ctx: ApiContext) {
+  return (_req: Request, _res: Response): void => {
+    const offline = ctx.tracker ? ctx.tracker.currentState() === 'offline' : true;
+    if (offline) {
+      throw new ApiException(
+        'INTERNAL',
+        'xinas-agent is offline',
+        { code: 'EXECUTOR_UNAVAILABLE' },
+        'restart xinas-agent.service',
+      );
+    }
+    // Executor reachable but the method isn't built yet in S0+S1.
+    throw new ApiException('UNSUPPORTED', 'this operation is not implemented in this build', {
+      code: 'EXECUTOR_UNSUPPORTED',
+    });
+  };
 }

--- a/xiNAS-MCP/src/api/heartbeat.ts
+++ b/xiNAS-MCP/src/api/heartbeat.ts
@@ -1,0 +1,238 @@
+import { randomUUID } from 'node:crypto';
+import type { OpenedStateStore } from '../state/index.js';
+import type { Warning } from './envelope.js';
+
+type AgentState = 'healthy' | 'degraded' | 'offline';
+
+export interface HeartbeatTrackerOptions {
+  /** How often the api polls agent.health. Default: 5000ms. */
+  intervalMs: number;
+  controllerId: string;
+  state: OpenedStateStore;
+  /**
+   * Performs one agent.health RPC over the agent UDS and returns the
+   * version + collectors map. start() calls this every intervalMs.
+   * Injected so tests (J1 mock-agent) supply a fake and never open a
+   * real socket. Production wires this to a thin JSON-RPC-over-UDS
+   * client against agentSocketPath that sends {"method":"agent.health"}
+   * and maps the result. Rejects (ECONNREFUSED/ENOENT) → offline.
+   *
+   * Optional: only start()'s tick loop uses it. The synchronous
+   * state-transition logic (recordHeartbeat*, currentState, …) never
+   * touches it, so unit tests that exercise only the state machine
+   * construct a tracker without one.
+   */
+  healthProbe?: () => Promise<{ version?: string; collectors?: Record<string, string> }>;
+  /** Path to the agent's UDS socket (used by the production healthProbe). */
+  agentSocketPath: string;
+}
+
+interface FailureOpts {
+  connectRefused?: boolean;
+}
+
+/**
+ * HeartbeatTracker tracks the live state of the xinas-agent process
+ * from the api's perspective. The api ticks the agent every
+ * intervalMs via agent.health; the tracker transitions between
+ * healthy / degraded / offline based on the time since the last
+ * successful response.
+ *
+ * State table (per spec §"Flow B"):
+ *   ≤ 2 × interval since last success  → healthy
+ *   > 2 × interval, ≤ 6 × interval     → degraded
+ *   > 6 × interval OR connect-refused  → offline
+ *
+ * currentState() re-evaluates on every call and emits an
+ * agent_state_changed event to /xinas/v1/events/<ts>/<id> whenever
+ * the computed state differs from the last known state.
+ */
+export class HeartbeatTracker {
+  readonly #opts: HeartbeatTrackerOptions;
+  #lastHeartbeatAt: Date | null = null;
+  #lastObservationPushAt: Date | null = null;
+  #connectRefused = false;
+  #knownState: AgentState = 'offline';
+  // The constructor-default `offline` is "not yet observed", not an
+  // observed-offline event. The first transition out of it (offline →
+  // healthy on the first successful heartbeat) is the agent's initial
+  // appearance and is NOT broadcast as an agent_state_changed event —
+  // only transitions between observed live states are.
+  #bootstrapped = false;
+  // Captured from the most recent successful agent.health response so
+  // currentSnapshot() (consumed by /api/v1/system → result.node.status.agent)
+  // can surface the agent version + per-collector health without a fresh RPC.
+  #agentVersion: string | null = null;
+  #collectors: Record<string, string> = {};
+  #tickTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(opts: HeartbeatTrackerOptions) {
+    this.#opts = opts;
+  }
+
+  /**
+   * Record a successful agent.health response. `payload` carries the
+   * version + collectors map from the response so currentSnapshot() can
+   * report them. Older call sites that pass only `at` still work
+   * (version/collectors retain their previous captured values).
+   */
+  recordHeartbeatSuccess(
+    at: Date,
+    payload?: { version?: string; collectors?: Record<string, string> },
+  ): void {
+    this.#lastHeartbeatAt = at;
+    this.#connectRefused = false;
+    if (payload?.version !== undefined) this.#agentVersion = payload.version;
+    if (payload?.collectors !== undefined) this.#collectors = payload.collectors;
+    this.currentState(); // trigger transition emit if needed
+  }
+
+  recordHeartbeatFailure(at: Date, opts?: FailureOpts): void {
+    void at;
+    if (opts?.connectRefused) {
+      this.#connectRefused = true;
+    }
+    this.currentState();
+  }
+
+  recordObservationPush(at: Date): void {
+    this.#lastObservationPushAt = at;
+    // Does NOT reset heartbeat state per spec §"Flow A" step 5.
+  }
+
+  get lastObservationPushAt(): Date | null {
+    return this.#lastObservationPushAt;
+  }
+
+  get lastHeartbeatAt(): Date | null {
+    return this.#lastHeartbeatAt;
+  }
+
+  currentState(): AgentState {
+    const newState = this.#computeState();
+    if (newState !== this.#knownState) {
+      const prev = this.#knownState;
+      this.#knownState = newState;
+      // Suppress the initial offline → live transition (the agent's
+      // first appearance); emit every transition thereafter.
+      if (this.#bootstrapped) {
+        this.#emitStateChange(prev, newState);
+      } else {
+        this.#bootstrapped = true;
+      }
+    }
+    return this.#knownState;
+  }
+
+  currentWarnings(opts: { routeIsMutating: boolean }): Warning[] {
+    const state = this.currentState();
+    if (state === 'degraded' && opts.routeIsMutating) {
+      return [
+        {
+          code: 'EXECUTOR_DEGRADED',
+          message:
+            'The xinas-agent is reachable but not responding to health checks on schedule. ' +
+            'Mutating operations may be delayed or unreliable.',
+        },
+      ];
+    }
+    return [];
+  }
+
+  /**
+   * Full agent-state view for /api/v1/system → result.node.status.agent.
+   * Pure read; does not perform an RPC. `version` + `collectors` reflect
+   * the most recent successful agent.health response (null / {} until the
+   * first one lands).
+   */
+  currentSnapshot(): {
+    state: AgentState;
+    version: string | null;
+    last_heartbeat_at: string | null;
+    last_observed_push_at: string | null;
+    collectors: Record<string, string>;
+  } {
+    return {
+      state: this.currentState(),
+      version: this.#agentVersion,
+      last_heartbeat_at: this.#lastHeartbeatAt?.toISOString() ?? null,
+      last_observed_push_at: this.#lastObservationPushAt?.toISOString() ?? null,
+      collectors: this.#collectors,
+    };
+  }
+
+  /**
+   * Start the periodic heartbeat tick. Every intervalMs the tracker calls
+   * the injected `healthProbe()` (a thin agent.health RPC over the agent
+   * UDS). Success → recordHeartbeatSuccess(now, payload); connect-refused →
+   * recordHeartbeatFailure(now, { connectRefused: true }); any other error →
+   * recordHeartbeatFailure(now). Idempotent; safe to call once at api boot.
+   *
+   * `healthProbe` is provided in HeartbeatTrackerOptions so tests inject a
+   * fake (J1's mock-agent) and never open a real socket. unref() the timer
+   * so it never keeps the process (or a test runner) alive. Throws if no
+   * healthProbe was configured — the tick loop has nothing to poll.
+   */
+  start(): void {
+    if (this.#tickTimer) return;
+    const probe = this.#opts.healthProbe;
+    if (probe === undefined) {
+      throw new Error('HeartbeatTracker.start(): no healthProbe configured');
+    }
+    const tick = async (): Promise<void> => {
+      try {
+        const payload = await probe();
+        this.recordHeartbeatSuccess(new Date(), payload);
+      } catch (err) {
+        const connectRefused = err instanceof Error && /ECONNREFUSED|ENOENT/.test(err.message);
+        this.recordHeartbeatFailure(
+          new Date(),
+          connectRefused ? { connectRefused: true } : undefined,
+        );
+      }
+    };
+    this.#tickTimer = setInterval(() => void tick(), this.#opts.intervalMs);
+    if (typeof this.#tickTimer.unref === 'function') this.#tickTimer.unref();
+    // Fire one tick immediately so a freshly-started agent is detected
+    // without waiting a full interval.
+    void tick();
+  }
+
+  stop(): void {
+    if (this.#tickTimer) {
+      clearInterval(this.#tickTimer);
+      this.#tickTimer = null;
+    }
+  }
+
+  #computeState(): AgentState {
+    if (this.#connectRefused) return 'offline';
+    if (this.#lastHeartbeatAt === null) return 'offline';
+
+    const nowMs = Date.now();
+    const elapsedMs = nowMs - this.#lastHeartbeatAt.getTime();
+    const { intervalMs } = this.#opts;
+
+    if (elapsedMs <= 2 * intervalMs) return 'healthy';
+    if (elapsedMs <= 6 * intervalMs) return 'degraded';
+    return 'offline';
+  }
+
+  #emitStateChange(from: AgentState, to: AgentState): void {
+    const ts = new Date().toISOString();
+    const eventId = randomUUID();
+    const key = `/xinas/v1/events/${ts}/${eventId}`;
+    try {
+      this.#opts.state.kv.put(key, {
+        kind: 'agent_state_changed',
+        controller_id: this.#opts.controllerId,
+        from,
+        to,
+        reason: to === 'offline' && this.#connectRefused ? 'connect_refused' : 'heartbeat_timeout',
+        last_successful_heartbeat_at: this.#lastHeartbeatAt?.toISOString() ?? null,
+      });
+    } catch (_err) {
+      // Best-effort: event emission failure does not affect tracker state.
+    }
+  }
+}

--- a/xiNAS-MCP/src/api/internal/agent-started.ts
+++ b/xiNAS-MCP/src/api/internal/agent-started.ts
@@ -1,0 +1,44 @@
+import type { NextFunction, Request, Response } from 'express';
+import type { ApiContext } from '../context.js';
+import { ApiException } from '../errors.js';
+
+interface AgentStartedBody {
+  controller_id: string;
+}
+
+/**
+ * POST /internal/v1/agent_started
+ *
+ * The agent calls this once after its initial sweep batch completes.
+ * The api clears the HeartbeatTracker's startup grace by treating
+ * agent_started as a successful heartbeat signal — the api starts in
+ * 'offline' state and would sit there until the first 5s heartbeat
+ * tick if agent_started were not posted.
+ *
+ * Returns 204 No Content on success.
+ */
+export function agentStartedHandler(ctx: ApiContext) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    try {
+      const body = req.body as AgentStartedBody;
+
+      if (body.controller_id !== ctx.config.controller_id) {
+        throw new ApiException(
+          'INVALID_ARGUMENT',
+          `controller_id mismatch: request has '${body.controller_id}', ` +
+            `api is configured with '${ctx.config.controller_id}'`,
+        );
+      }
+
+      // Treat agent_started as a synthetic successful heartbeat so the
+      // tracker immediately transitions from 'offline' to 'healthy'.
+      // This clears the startup grace window without waiting for the
+      // first real heartbeat tick.
+      ctx.tracker?.recordHeartbeatSuccess(new Date());
+
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  };
+}

--- a/xiNAS-MCP/src/api/internal/observed.ts
+++ b/xiNAS-MCP/src/api/internal/observed.ts
@@ -20,6 +20,36 @@ interface ObservedBody {
 }
 
 /**
+ * Validates an observed-delta id before it is embedded in a KV key.
+ *
+ * Rejects ids that could produce path-traversal-looking or malformed keys:
+ *   - empty string or whitespace-only
+ *   - any control character (charCode < 0x20 or === 0x7f)
+ *   - a `.` or `..` path segment (split on `/`)
+ *   - leading or trailing `/`, or consecutive `//` (empty segment)
+ *
+ * Allows `/` and `:` within the id — legitimate ids contain them (e.g.
+ * NfsSession id `10.1.2.3:/srv/share01`, mount paths like `/srv/share`).
+ *
+ * Full inbound-delta schema validation (kind + value shape) is wired in
+ * Phase J (J3). Until then this id-shape check is the sole inbound key
+ * guard running on every write, schema-validation is conditional on
+ * ctx.observedSchemas being present (see loop below).
+ */
+export function isValidObservedId(id: string): boolean {
+  if (id.trim().length === 0) return false;
+  if (id.startsWith('/') || id.endsWith('/') || id.includes('//')) return false;
+  for (let i = 0; i < id.length; i++) {
+    const c = id.charCodeAt(i);
+    if (c < 0x20 || c === 0x7f) return false;
+  }
+  for (const segment of id.split('/')) {
+    if (segment === '..' || segment === '.') return false;
+  }
+  return true;
+}
+
+/**
  * POST /internal/v1/observed — the xinas-agent's exclusive write path
  * for observed state (spec §"Flow A"). Gated by requireInternalAgent
  * on the parent sub-router (H2).
@@ -76,6 +106,19 @@ export function observedHandler(ctx: ApiContext) {
                 `${ctx.ajv?.errorsText(validate.errors) ?? 'invalid'}`,
             );
           }
+        }
+      }
+
+      // Id-shape check BEFORE the transaction — reject any delta whose id could
+      // produce a path-traversal-looking or malformed KV key. This applies to
+      // both upsert and delete deltas since both construct a key from the id.
+      for (let i = 0; i < deltas.length; i++) {
+        const delta = deltas[i]!;
+        if (!isValidObservedId(delta.id)) {
+          throw new ApiException(
+            'INVALID_ARGUMENT',
+            `delta[${i}]: invalid id '${delta.id}'`,
+          );
         }
       }
 

--- a/xiNAS-MCP/src/api/internal/observed.ts
+++ b/xiNAS-MCP/src/api/internal/observed.ts
@@ -1,0 +1,136 @@
+import type { NextFunction, Request, Response } from 'express';
+import type { Kind } from '../../agent/collectors/base.js';
+import { observedSegment } from '../../agent/collectors/base.js';
+import type { ApiContext } from '../context.js';
+import { ApiException } from '../errors.js';
+import { sendOk } from '../handlers/reads.js';
+
+interface ObservationDeltaBody {
+  kind: Kind;
+  id: string;
+  op: 'upsert' | 'delete';
+  value?: Record<string, unknown>;
+}
+
+interface ObservedBody {
+  observed_at: string;
+  controller_id: string;
+  deltas: ObservationDeltaBody[];
+  complete_snapshots: Kind[];
+}
+
+/**
+ * POST /internal/v1/observed — the xinas-agent's exclusive write path
+ * for observed state (spec §"Flow A"). Gated by requireInternalAgent
+ * on the parent sub-router (H2).
+ *
+ * Validates the request's controller_id matches the api's. Then opens a
+ * single KvTransaction that (1) applies every delta (upsert → tx.put,
+ * delete → tx.delete) and (2) for each kind in complete_snapshots,
+ * enumerates the current keys under that kind's prefix and deletes any
+ * not present in the batch's upserts (reconcile). Applies and reconcile
+ * deletes commit atomically. Finally notifies the heartbeat tracker that
+ * an observation push happened (does NOT update heartbeat state).
+ */
+export function observedHandler(ctx: ApiContext) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    try {
+      const body = req.body as ObservedBody;
+
+      // Validate controller_id match.
+      if (body.controller_id !== ctx.config.controller_id) {
+        throw new ApiException(
+          'INVALID_ARGUMENT',
+          `controller_id mismatch: request has '${body.controller_id}', ` +
+            `api is configured with '${ctx.config.controller_id}'`,
+        );
+      }
+
+      const deltas = body.deltas ?? [];
+      const completeSnapshots: Kind[] = body.complete_snapshots ?? [];
+
+      // Per-delta schema validation BEFORE the transaction (fail-closed),
+      // but only when validators are wired into the context. Each upsert
+      // delta's `value` is validated against its kind's JSON Schema (the
+      // api-v1.yaml component schemas Phase G adds, compiled once at startup
+      // and keyed by kind). On the first failure, reject the WHOLE batch —
+      // nothing is written — with INVALID_ARGUMENT naming the failing delta's
+      // index + the Ajv error, so a malformed agent push can never poison
+      // observed state. Delete deltas carry no value and skip schema
+      // validation (only their key shape matters). This is the safety net
+      // that also catches a delta with an unknown/mis-cased kind (no schema →
+      // reject). When ctx.observedSchemas is absent (the H3 unit context, and
+      // until H6/J3 wire it), the loop is skipped entirely.
+      if (ctx.observedSchemas) {
+        for (let i = 0; i < deltas.length; i++) {
+          const delta = deltas[i]!;
+          if (delta.op !== 'upsert') continue;
+          const validate = ctx.observedSchemas[delta.kind];
+          if (!validate) {
+            throw new ApiException('INVALID_ARGUMENT', `delta[${i}]: unknown kind '${delta.kind}'`);
+          }
+          if (!validate(delta.value)) {
+            throw new ApiException(
+              'INVALID_ARGUMENT',
+              `delta[${i}] (kind=${delta.kind}, id=${delta.id}) failed schema: ` +
+                `${ctx.ajv?.errorsText(validate.errors) ?? 'invalid'}`,
+            );
+          }
+        }
+      }
+
+      let accepted = 0;
+      let deletedByReconcile = 0;
+      const revisions: number[] = [];
+
+      // Derive the KV path segment through observedSegment(kind) (base.ts) so
+      // writer and reader never disagree on singletons (NfsIdmap → nfs_idmap,
+      // inventory/managed_files stay lowercase). H3 stays kind-agnostic; no
+      // per-kind special-casing (the ExportRule→Share fold-in is a read-time
+      // join in I6, not a write-time merge here).
+      ctx.state.kv.transaction((tx) => {
+        // 1. Apply all deltas.
+        for (const delta of deltas) {
+          const key = `/xinas/v1/observed/${observedSegment(delta.kind)}/${delta.id}`;
+          if (delta.op === 'upsert') {
+            const result = tx.put(key, delta.value ?? {});
+            // No expected_revision → put always commits (ok: true). Guard
+            // anyway so a future CAS variant can't silently push undefined.
+            if (result.ok) revisions.push(result.value.revision);
+            accepted++;
+          } else if (delta.op === 'delete') {
+            tx.delete(key);
+            accepted++;
+          }
+        }
+
+        // 2. Reconcile complete snapshots: delete keys under the prefix
+        //    that were NOT in the batch.
+        const upsertedKeys = new Set(
+          deltas
+            .filter((d) => d.op === 'upsert')
+            .map((d) => `/xinas/v1/observed/${observedSegment(d.kind)}/${d.id}`),
+        );
+
+        for (const kind of completeSnapshots) {
+          const prefix = `/xinas/v1/observed/${observedSegment(kind)}/`;
+          const current = tx.list({ prefix });
+          for (const row of current) {
+            if (!upsertedKeys.has(row.key)) {
+              tx.delete(row.key);
+              deletedByReconcile++;
+            }
+          }
+        }
+      });
+
+      // 3. Notify the tracker that an observation push happened.
+      ctx.tracker?.recordObservationPush(new Date());
+
+      const stateRevision = revisions.length > 0 ? Math.max(...revisions) : 0;
+      sendOk(req, res, { accepted, deleted_by_reconcile: deletedByReconcile }, [stateRevision]);
+    } catch (err) {
+      next(err);
+    }
+  };
+}

--- a/xiNAS-MCP/src/api/internal/observed.ts
+++ b/xiNAS-MCP/src/api/internal/observed.ts
@@ -115,10 +115,7 @@ export function observedHandler(ctx: ApiContext) {
       for (let i = 0; i < deltas.length; i++) {
         const delta = deltas[i]!;
         if (!isValidObservedId(delta.id)) {
-          throw new ApiException(
-            'INVALID_ARGUMENT',
-            `delta[${i}]: invalid id '${delta.id}'`,
-          );
+          throw new ApiException('INVALID_ARGUMENT', `delta[${i}]: invalid id '${delta.id}'`);
         }
       }
 

--- a/xiNAS-MCP/src/api/internal/router.ts
+++ b/xiNAS-MCP/src/api/internal/router.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import type { ApiContext } from '../context.js';
 import { requireInternalAgent } from '../middleware/require-internal-agent.js';
+import { agentStartedHandler } from './agent-started.js';
 import { observedHandler } from './observed.js';
 
 /**
@@ -11,11 +12,12 @@ import { observedHandler } from './observed.js';
  * /internal/v1, after request-id + auth so req.context.role is resolved
  * before the gate reads it.
  *
- * H3 wires /observed only. H4 adds /agent_started.
+ * H3 wires /observed. H4 adds /agent_started.
  */
 export function internalRouter(ctx: ApiContext): Router {
   const router = Router();
   router.use(requireInternalAgent());
   router.post('/observed', observedHandler(ctx));
+  router.post('/agent_started', agentStartedHandler(ctx));
   return router;
 }

--- a/xiNAS-MCP/src/api/internal/router.ts
+++ b/xiNAS-MCP/src/api/internal/router.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import type { ApiContext } from '../context.js';
+import { requireInternalAgent } from '../middleware/require-internal-agent.js';
+import { observedHandler } from './observed.js';
+
+/**
+ * /internal/v1 sub-router — the xinas-agent's exclusive write surface.
+ *
+ * requireInternalAgent() gates every route here: only a bearer token
+ * whose role is 'internal_agent' passes (H2). Mounted by createApp under
+ * /internal/v1, after request-id + auth so req.context.role is resolved
+ * before the gate reads it.
+ *
+ * H3 wires /observed only. H4 adds /agent_started.
+ */
+export function internalRouter(ctx: ApiContext): Router {
+  const router = Router();
+  router.use(requireInternalAgent());
+  router.post('/observed', observedHandler(ctx));
+  return router;
+}

--- a/xiNAS-MCP/src/api/middleware/error.ts
+++ b/xiNAS-MCP/src/api/middleware/error.ts
@@ -1,6 +1,7 @@
-import type { ErrorRequestHandler, Request, Response, NextFunction } from 'express';
-import { ApiException, errorStatus, makeError } from '../errors.js';
+import type { ErrorRequestHandler, NextFunction, Request, Response } from 'express';
 import { buildEnvelope } from '../envelope.js';
+import { ApiException, errorStatus, makeError } from '../errors.js';
+import { mergeWarnings } from '../handlers/merge-warnings.js';
 
 /**
  * Express body-parser (express.json) signals malformed JSON by
@@ -29,6 +30,7 @@ export function errorMiddleware(): ErrorRequestHandler {
           request_id: ctx?.request_id ?? 'unknown',
           correlation_id: ctx?.correlation_id ?? 'unknown',
           state_revision: 0,
+          warnings: mergeWarnings([], ctx?.system_warnings ?? []),
           errors: [makeError(err.code, err.message, err.details, err.remediation)],
           result: null,
         }),
@@ -42,6 +44,7 @@ export function errorMiddleware(): ErrorRequestHandler {
           request_id: ctx?.request_id ?? 'unknown',
           correlation_id: ctx?.correlation_id ?? 'unknown',
           state_revision: 0,
+          warnings: mergeWarnings([], ctx?.system_warnings ?? []),
           errors: [makeError('INVALID_ARGUMENT', `malformed JSON body: ${msg}`)],
           result: null,
         }),
@@ -54,6 +57,7 @@ export function errorMiddleware(): ErrorRequestHandler {
         request_id: ctx?.request_id ?? 'unknown',
         correlation_id: ctx?.correlation_id ?? 'unknown',
         state_revision: 0,
+        warnings: mergeWarnings([], ctx?.system_warnings ?? []),
         errors: [makeError('INTERNAL', msg)],
         result: null,
       }),

--- a/xiNAS-MCP/src/api/middleware/request-id.ts
+++ b/xiNAS-MCP/src/api/middleware/request-id.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import type { Request, Response, NextFunction } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 
 /**
  * Middleware that ensures every request has a request_id (server-
@@ -21,6 +21,7 @@ export function requestIdMiddleware() {
       principal: 'anonymous',
       role: 'viewer',
       client_type: 'rest',
+      system_warnings: [],
     };
     res.setHeader('X-Request-ID', request_id);
     res.setHeader('X-Correlation-ID', correlation_id);

--- a/xiNAS-MCP/src/api/middleware/require-internal-agent.ts
+++ b/xiNAS-MCP/src/api/middleware/require-internal-agent.ts
@@ -1,0 +1,51 @@
+import type { NextFunction, Request, Response } from 'express';
+import { buildEnvelope } from '../envelope.js';
+import { errorStatus, makeError } from '../errors.js';
+
+/**
+ * requireInternalAgent — role gate for /internal/v1/* routes.
+ *
+ * Rejects unless req.context.role === 'internal_agent'. This is
+ * explicitly stricter than the normal auth middleware:
+ *
+ *   - UDS-trust admin promotion (role='admin') is NOT sufficient.
+ *     Even a root-level local connection gets 401 here.
+ *   - A bearer token with role='admin' or 'operator' is NOT sufficient.
+ *   - Only a bearer token whose TokenPrincipal.role is 'internal_agent'
+ *     passes.
+ *
+ * Rationale (ADR-0002 line 221, spec §"API processing" step 1):
+ * The /internal/v1/ family is the agent's exclusive write path.
+ * Allowing operators or admin tokens would let a local admin push
+ * arbitrary state bypassing the privilege boundary.
+ *
+ * Must run AFTER authMiddleware (which populates req.context).
+ */
+export function requireInternalAgent() {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const ctx = req.context;
+    if (!ctx) {
+      next(new Error('requireInternalAgent requires authMiddleware to run first'));
+      return;
+    }
+    if (ctx.role === 'internal_agent') {
+      next();
+      return;
+    }
+    res.status(errorStatus('PERMISSION_DENIED')).json(
+      buildEnvelope({
+        request_id: ctx.request_id,
+        correlation_id: ctx.correlation_id,
+        state_revision: 0,
+        errors: [
+          makeError(
+            'PERMISSION_DENIED',
+            'this route requires the internal_agent role; ' +
+              'UDS admin trust and operator/admin bearer tokens are not accepted',
+          ),
+        ],
+        result: null,
+      }),
+    );
+  };
+}

--- a/xiNAS-MCP/src/api/middleware/system-warnings.ts
+++ b/xiNAS-MCP/src/api/middleware/system-warnings.ts
@@ -1,0 +1,38 @@
+import type { NextFunction, Request, Response } from 'express';
+import type { ApiContext } from '../context.js';
+
+/** HTTP methods that represent mutating operations. */
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+/**
+ * systemWarningsMiddleware — populates req.context.system_warnings
+ * from HeartbeatTracker.currentWarnings() on every request.
+ *
+ * Must run after authMiddleware (req.context must be populated).
+ * Must run before route handlers so system_warnings is available when
+ * sendOk() or errorMiddleware() builds the response envelope.
+ *
+ * Semantics per spec §Observability:
+ *   EXECUTOR_DEGRADED is injected only on mutating-route requests
+ *   (POST/PUT/PATCH/DELETE) when the tracker is in 'degraded' state.
+ *   Read endpoints (GET) do NOT carry the warning.
+ */
+export function systemWarningsMiddleware(ctx: ApiContext) {
+  return (req: Request, _res: Response, next: NextFunction): void => {
+    const context = req.context;
+    if (!context) {
+      next();
+      return;
+    }
+    // Ensure system_warnings is initialized even when no tracker exists.
+    context.system_warnings = [];
+
+    const tracker = ctx.tracker;
+    if (tracker) {
+      const routeIsMutating = MUTATING_METHODS.has(req.method);
+      context.system_warnings = tracker.currentWarnings({ routeIsMutating });
+    }
+
+    next();
+  };
+}

--- a/xiNAS-MCP/src/api/routes/support.ts
+++ b/xiNAS-MCP/src/api/routes/support.ts
@@ -1,11 +1,11 @@
 import { Router } from 'express';
+import type { ApiContext } from '../context.js';
 import { ApiException } from '../errors.js';
 import { executorUnavailable } from '../handlers/unsupported.js';
-import type { ApiContext } from '../context.js';
 
-export function supportRouter(_ctx: ApiContext): Router {
+export function supportRouter(ctx: ApiContext): Router {
   const r = Router();
-  r.post('/support-bundle', executorUnavailable);
+  r.post('/support-bundle', executorUnavailable(ctx));
   r.get('/support-bundle/:task_id', (_req, _res) => {
     throw new ApiException('NOT_FOUND', 'no bundle for that task');
   });

--- a/xiNAS-MCP/src/api/routes/tasks.ts
+++ b/xiNAS-MCP/src/api/routes/tasks.ts
@@ -66,7 +66,7 @@ export function tasksRouter(ctx: ApiContext): Router {
     sendOk(req, res, row.value, [row.revision]);
   });
 
-  r.post('/tasks/:id/cancel', executorUnavailable);
+  r.post('/tasks/:id/cancel', executorUnavailable(ctx));
 
   r.get('/tasks/:id/watch', (req, res) => {
     // Single-shot SSE: emit one snapshot event with the current state,


### PR DESCRIPTION
## Phase H — API internal routes + heartbeat (stacked on #211)

Eighth execution slice. **Base is #211's branch** (Phase G contract); diff is the 6 Phase H commits. **This is the api side of the agent↔api convergence** — the api now receives and processes the agent's observation pushes.

### What's here
| Commit | Task | What |
|--------|------|------|
| `0403902` | H1 | `HeartbeatTracker` — agent-health state machine (healthy/degraded/offline via time-since-last-success; emits `agent_state_changed` events; `currentWarnings`/`currentSnapshot`) |
| `adb8173` | H2 | `requireInternalAgent` — gates `/internal/v1/*` to the `internal_agent` role (admin bearer / UDS-trust do NOT pass) |
| `6e923a3` | H3 | `POST /internal/v1/observed` — validate controller_id, single-transaction apply-deltas + reconcile complete_snapshots, `observedSegment` path mapping, `recordObservationPush` |
| `46410e2` | H4 | `POST /internal/v1/agent_started` — clears the heartbeat startup grace |
| `6592808` | H5 | `systemWarningsMiddleware` + `mergeWarnings`; `executorUnavailable` refactor (offline→EXECUTOR_UNAVAILABLE/500, online-degraded→EXECUTOR_UNSUPPORTED/422) |
| `0b96cf7` | review | id sanitization + /internal self-warning exclusion + mergeWarnings dedup |

### Reconciliations handled (plan vs live code)
- H1: made `healthProbe` optional (tests don't exercise the tick loop); caught two plan-test bugs (fake-timer clock anchor, event-ordering bootstrap).
- H3: per-delta schema validation made **conditional** on `ctx.observedSchemas` (the test doesn't wire schemas, and a minimal Disk value can't satisfy G5's required fields); `tx.put` returns `CasResult` (read `result.value.revision`, not the plan's `result.revision`); router wires `/observed` only (H4 adds `/agent_started`).

### Security/correctness review → fixes (`0b96cf7`)
Verdict **FIX-FIRST** (no P0 — the flat KV can't escape the `/observed/` prefix). Applied:
- **`id` sanitization** — agent-supplied delta `id` went verbatim into the KV key; now rejects empty/control-char/`..`-segment/leading-trailing-slash ids before any write (a leaked agent token can't write traversal-looking keys). Slashes/colons within ids still allowed (legit NfsSession ids).
- **/internal self-warning** — excluded `/internal/*` from `systemWarnings` (scoped it to the `/api/v1` router) so the agent's own observation push doesn't get an `EXECUTOR_DEGRADED` warning about itself.
- **mergeWarnings dedup** by code.

### Two items flagged for your review
1. **Inbound-delta schema validation is inert in production** — the conditional `if (ctx.observedSchemas)` block is never wired (the compile-api-v1.yaml-schemas-into-Ajv step + its enforcement test are **Phase J / J3** per PCR-5). Until then, the id-shape check is the only inbound key guard. Enforcing it now would break the H3 test. Confirm J3 is the right home, or pull the wiring forward.
2. **Heartbeat bootstrap event** — the first `offline→healthy` transition (agent first appears) emits no `agent_state_changed` event (suppressed to avoid a spurious event on every clean boot). Defensible, matches the test; confirm operators don't need an explicit "agent connected" signal.

### Verification
- `tsc --noEmit` exit 0 · **419 tests / 80 files pass** (+28 over Phase G) · `biome lint` warnings-only
- Code-only api/TS; no `Requires-Rebuild` trailer.

### Not in this PR
Phases I–L (public route additions, comprehensive tests incl. J3 schema-validation wiring, Ansible role, sanity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)