### PR TITLE
feat(phase0): xinas-agent S0+S1 — Phase I public read routes (DRAFT, stacked on #212)

### DIFF
--- a/xiNAS-MCP/src/__tests__/api/_helpers.ts
+++ b/xiNAS-MCP/src/__tests__/api/_helpers.ts
@@ -1,10 +1,11 @@
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { openStateStore, type OpenedStateStore } from '../../state/index.js';
 import { createApp } from '../../api/app.js';
 import type { ApiConfig } from '../../api/config.js';
 import type { ApiContext } from '../../api/context.js';
+import { HeartbeatTracker } from '../../api/heartbeat.js';
+import { type OpenedStateStore, openStateStore } from '../../state/index.js';
 
 export interface TestSetup {
   dir: string;
@@ -36,7 +37,16 @@ export async function buildTestApp(): Promise<TestSetup & { cleanup(): Promise<v
     auditJsonlPath: config.state.auditJsonlPath,
     nodeId: NODE_ID,
   });
-  const ctx: ApiContext = { config, state };
+  // Wire an (unstarted, so always-offline) HeartbeatTracker so routes that
+  // surface agent state — e.g. /api/v1/system → node.status.agent — have a
+  // deterministic tracker. It never start()s, so no tick timer/probe runs.
+  const tracker = new HeartbeatTracker({
+    intervalMs: 5_000,
+    controllerId: NODE_ID,
+    state,
+    agentSocketPath: '/tmp/nonexistent.sock',
+  });
+  const ctx: ApiContext = { config, state, tracker };
   const app = createApp(ctx);
   return {
     dir,

--- a/xiNAS-MCP/src/__tests__/api/routes-groups.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/routes-groups.test.ts
@@ -1,0 +1,71 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ADMIN_TOKEN, buildTestApp } from './_helpers.js';
+
+describe('GET /api/v1/groups', () => {
+  let setup: Awaited<ReturnType<typeof buildTestApp>>;
+
+  beforeEach(async () => {
+    setup = await buildTestApp();
+    setup.state.kv.put('/xinas/v1/observed/Group/1000', {
+      kind: 'Group',
+      id: '1000',
+      spec: { name: 'alice', gid: 1000, members: [] },
+      status: { resolvable: true, source: 'local', observed_at: new Date().toISOString() },
+    });
+    setup.state.kv.put('/xinas/v1/observed/Group/2000', {
+      kind: 'Group',
+      id: '2000',
+      spec: { name: 'domain_users', gid: 2000, members: ['alice', 'bob'] },
+      status: { resolvable: true, source: 'nss', observed_at: new Date().toISOString() },
+    });
+  });
+
+  afterEach(async () => {
+    await setup.cleanup();
+  });
+
+  it('lists all groups when source=all (default)', async () => {
+    const res = await request(setup.app).get('/api/v1/groups').set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result).toHaveLength(2);
+    expect(res.body.result.map((g: { id: string }) => g.id)).toContain('1000');
+    expect(res.body.result.map((g: { id: string }) => g.id)).toContain('2000');
+  });
+
+  it('filters to source=local only', async () => {
+    const res = await request(setup.app)
+      .get('/api/v1/groups?source=local')
+      .set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result).toHaveLength(1);
+    expect(res.body.result[0].spec.name).toBe('alice');
+    expect(res.body.result[0].status.source).toBe('local');
+  });
+
+  it('filters to source=nss only', async () => {
+    const res = await request(setup.app)
+      .get('/api/v1/groups?source=nss')
+      .set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result).toHaveLength(1);
+    expect(res.body.result[0].spec.members).toContain('alice');
+  });
+
+  it('returns 404 when gid not found', async () => {
+    const res = await request(setup.app)
+      .get('/api/v1/groups/9999')
+      .set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(404);
+    expect(res.body.errors[0].code).toBe('NOT_FOUND');
+  });
+
+  it('returns a single group by gid', async () => {
+    const res = await request(setup.app)
+      .get('/api/v1/groups/2000')
+      .set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result.spec.name).toBe('domain_users');
+    expect(res.body.result.spec.members).toHaveLength(2);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/api/routes-nfs-exports-join.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/routes-nfs-exports-join.test.ts
@@ -1,0 +1,87 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ADMIN_TOKEN, buildTestApp } from './_helpers.js';
+
+describe('Share read-join: status.exports[] populated from observed ExportRule', () => {
+  let setup: Awaited<ReturnType<typeof buildTestApp>>;
+
+  const SHARE_ID = 'share01';
+  const EXPORT_PATH = '/srv/nfs/share01';
+
+  beforeEach(async () => {
+    setup = await buildTestApp();
+    setup.state.kv.put(`/xinas/v1/desired/Share/${SHARE_ID}`, {
+      kind: 'Share',
+      id: SHARE_ID,
+      spec: {
+        path: '/data/share01',
+        export_path: EXPORT_PATH,
+        clients: [{ pattern: '10.0.0.0/8', options: ['rw', 'sync'] }],
+        fsid: 42,
+      },
+      status: { exports: [] },
+    });
+  });
+
+  afterEach(async () => {
+    await setup.cleanup();
+  });
+
+  it('GET /shares list: status.exports is [] when no ExportRule observed', async () => {
+    const res = await request(setup.app).get('/api/v1/shares').set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result).toHaveLength(1);
+    expect(res.body.result[0].status.exports).toEqual([]);
+  });
+
+  it('GET /shares list: status.exports populated when a matching ExportRule exists', async () => {
+    setup.state.kv.put('/xinas/v1/observed/ExportRule/share01', {
+      kind: 'ExportRule',
+      id: 'share01',
+      spec: { export_path: EXPORT_PATH },
+      status: {
+        rules: [
+          { client: '10.0.0.0/8', options: ['rw', 'sync', 'no_root_squash'] },
+          { client: '192.168.1.0/24', options: ['ro'] },
+        ],
+        observed_at: new Date().toISOString(),
+      },
+    });
+    const res = await request(setup.app).get('/api/v1/shares').set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result[0].status.exports).toHaveLength(2);
+    expect(res.body.result[0].status.exports[0].client).toBe('10.0.0.0/8');
+  });
+
+  it('GET /shares/{id}: status.exports populated for a matching ExportRule', async () => {
+    setup.state.kv.put('/xinas/v1/observed/ExportRule/share01', {
+      kind: 'ExportRule',
+      id: 'share01',
+      spec: { export_path: EXPORT_PATH },
+      status: {
+        rules: [{ client: '10.0.0.0/8', options: ['rw', 'sync'] }],
+        observed_at: new Date().toISOString(),
+      },
+    });
+    const res = await request(setup.app)
+      .get(`/api/v1/shares/${SHARE_ID}`)
+      .set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result.status.exports).toHaveLength(1);
+    expect(res.body.result.status.exports[0].client).toBe('10.0.0.0/8');
+  });
+
+  it('GET /shares/{id}: status.exports is [] when the only ExportRule is for a different path', async () => {
+    setup.state.kv.put('/xinas/v1/observed/ExportRule/other', {
+      kind: 'ExportRule',
+      id: 'other',
+      spec: { export_path: '/srv/nfs/other' },
+      status: { rules: [{ client: '*', options: ['ro'] }], observed_at: new Date().toISOString() },
+    });
+    const res = await request(setup.app)
+      .get(`/api/v1/shares/${SHARE_ID}`)
+      .set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result.status.exports).toEqual([]);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/api/routes-nfs-idmap.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/routes-nfs-idmap.test.ts
@@ -1,0 +1,47 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ADMIN_TOKEN, buildTestApp } from './_helpers.js';
+
+describe('GET /api/v1/nfs-idmap', () => {
+  let setup: Awaited<ReturnType<typeof buildTestApp>>;
+
+  beforeEach(async () => {
+    setup = await buildTestApp();
+  });
+
+  afterEach(async () => {
+    await setup.cleanup();
+  });
+
+  it('returns 404 when no snapshot has been observed yet', async () => {
+    const res = await request(setup.app).get('/api/v1/nfs-idmap').set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(404);
+    expect(res.body.errors[0].code).toBe('NOT_FOUND');
+  });
+
+  it('returns the singleton when a snapshot exists', async () => {
+    setup.state.kv.put('/xinas/v1/observed/nfs_idmap/snapshot', {
+      kind: 'NfsIdmap',
+      status: {
+        conf_present: true,
+        domain: 'example.com',
+        local_realms: ['EXAMPLE.COM'],
+        method: 'nsswitch',
+        idmapd_active: true,
+        idmapd_unit_state: 'active',
+        observed_at: new Date().toISOString(),
+      },
+    });
+    const res = await request(setup.app).get('/api/v1/nfs-idmap').set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result.kind).toBe('NfsIdmap');
+    expect(res.body.result.status.domain).toBe('example.com');
+    expect(res.body.result.status.method).toBe('nsswitch');
+    expect(res.body.result.status.idmapd_active).toBe(true);
+  });
+
+  it('requires authentication (no anonymous access)', async () => {
+    const res = await request(setup.app).get('/api/v1/nfs-idmap');
+    expect(res.status).toBe(401);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/api/routes-nfs-sessions.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/routes-nfs-sessions.test.ts
@@ -1,0 +1,93 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ADMIN_TOKEN, buildTestApp } from './_helpers.js';
+
+describe('GET /api/v1/shares/{id}/sessions — populated from observed state', () => {
+  let setup: Awaited<ReturnType<typeof buildTestApp>>;
+
+  const SHARE_ID = 'share01';
+  const EXPORT_PATH = '/srv/nfs/share01';
+
+  beforeEach(async () => {
+    setup = await buildTestApp();
+
+    setup.state.kv.put(`/xinas/v1/desired/Share/${SHARE_ID}`, {
+      kind: 'Share',
+      id: SHARE_ID,
+      spec: {
+        path: '/data/share01',
+        export_path: EXPORT_PATH,
+        clients: [{ pattern: '10.0.0.0/8', options: ['rw', 'sync'] }],
+        fsid: 42,
+      },
+    });
+
+    setup.state.kv.put('/xinas/v1/observed/NfsSession/10.1.2.3:share01', {
+      kind: 'NfsSession',
+      id: '10.1.2.3:/srv/nfs/share01',
+      spec: { client_addr: '10.1.2.3', export_path: EXPORT_PATH },
+      status: { proto_version: 'v4.2', locked_files: 0, observed_at: new Date().toISOString() },
+    });
+    setup.state.kv.put('/xinas/v1/observed/NfsSession/10.1.2.4:share01', {
+      kind: 'NfsSession',
+      id: '10.1.2.4:/srv/nfs/share01',
+      spec: { client_addr: '10.1.2.4', export_path: EXPORT_PATH },
+      status: { proto_version: 'v4.1', locked_files: 2, observed_at: new Date().toISOString() },
+    });
+
+    // A session for a DIFFERENT share — must NOT appear in results.
+    setup.state.kv.put('/xinas/v1/observed/NfsSession/10.1.2.5:other', {
+      kind: 'NfsSession',
+      id: '10.1.2.5:/srv/nfs/other',
+      spec: { client_addr: '10.1.2.5', export_path: '/srv/nfs/other' },
+      status: { proto_version: 'v4', locked_files: 0, observed_at: new Date().toISOString() },
+    });
+  });
+
+  afterEach(async () => {
+    await setup.cleanup();
+  });
+
+  it('returns only NfsSession entries whose export_path matches the share', async () => {
+    const res = await request(setup.app)
+      .get(`/api/v1/shares/${SHARE_ID}/sessions`)
+      .set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result).toHaveLength(2);
+    const clientAddrs = res.body.result.map(
+      (s: { spec: { client_addr: string } }) => s.spec.client_addr,
+    );
+    expect(clientAddrs).toContain('10.1.2.3');
+    expect(clientAddrs).toContain('10.1.2.4');
+    expect(clientAddrs).not.toContain('10.1.2.5');
+  });
+
+  it('returns an empty array when no sessions exist for the share', async () => {
+    setup.state.kv.delete('/xinas/v1/observed/NfsSession/10.1.2.3:share01');
+    setup.state.kv.delete('/xinas/v1/observed/NfsSession/10.1.2.4:share01');
+    const res = await request(setup.app)
+      .get(`/api/v1/shares/${SHARE_ID}/sessions`)
+      .set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result).toHaveLength(0);
+  });
+
+  it('returns 404 when the share does not exist', async () => {
+    const res = await request(setup.app)
+      .get('/api/v1/shares/nonexistent/sessions')
+      .set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(404);
+    expect(res.body.errors[0].code).toBe('NOT_FOUND');
+  });
+
+  it('cross-share isolation: every returned session belongs to this share', async () => {
+    const res = await request(setup.app)
+      .get(`/api/v1/shares/${SHARE_ID}/sessions`)
+      .set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    const exportPaths = res.body.result.map(
+      (s: { spec: { export_path: string } }) => s.spec.export_path,
+    );
+    expect(exportPaths.every((p: string) => p === EXPORT_PATH)).toBe(true);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/api/routes-system-agent.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/routes-system-agent.test.ts
@@ -1,0 +1,55 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ADMIN_TOKEN, buildTestApp, seedCluster, seedNode } from './_helpers.js';
+
+describe('GET /api/v1/system — agent sub-object', () => {
+  let setup: Awaited<ReturnType<typeof buildTestApp>>;
+
+  beforeEach(async () => {
+    setup = await buildTestApp();
+    seedCluster(setup.state);
+    seedNode(setup.state);
+  });
+
+  afterEach(async () => {
+    await setup.cleanup();
+  });
+
+  it('includes result.node.status.agent with required fields', async () => {
+    const res = await request(setup.app).get('/api/v1/system').set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    const agent = res.body.result?.node?.status?.agent;
+    expect(agent).toBeDefined();
+    expect(agent).toHaveProperty('state');
+    expect(['healthy', 'degraded', 'offline']).toContain(agent.state);
+    // On a fresh test app whose tracker never start()s, state is offline.
+    expect(agent.state).toBe('offline');
+  });
+
+  it('preserves the pre-existing node.status.agent_state alongside the new agent sub-object', async () => {
+    const res = await request(setup.app).get('/api/v1/system').set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    const status = res.body.result?.node?.status;
+    // agent_state (the older flat field) and agent (the new sub-object) coexist.
+    expect(status.agent_state).toBe('offline');
+    expect(status.agent).toBeDefined();
+  });
+
+  it('agent.collectors is an object (may be empty on startup)', async () => {
+    const res = await request(setup.app).get('/api/v1/system').set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    const agent = res.body.result?.node?.status?.agent;
+    expect(typeof agent.collectors).toBe('object');
+    expect(Array.isArray(agent.collectors)).toBe(false);
+  });
+
+  it('last_heartbeat_at is null when no heartbeat has succeeded', async () => {
+    const res = await request(setup.app).get('/api/v1/system').set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    const agent = res.body.result?.node?.status?.agent;
+    // null is valid per api-v1.yaml (type: [string, "null"], format: date-time)
+    expect(agent.last_heartbeat_at === null || typeof agent.last_heartbeat_at === 'string').toBe(
+      true,
+    );
+  });
+});

--- a/xiNAS-MCP/src/__tests__/api/routes-users.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/routes-users.test.ts
@@ -1,0 +1,72 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ADMIN_TOKEN, buildTestApp } from './_helpers.js';
+
+describe('GET /api/v1/users', () => {
+  let setup: Awaited<ReturnType<typeof buildTestApp>>;
+
+  beforeEach(async () => {
+    setup = await buildTestApp();
+    // Seed observed Users
+    setup.state.kv.put('/xinas/v1/observed/User/1000', {
+      kind: 'User',
+      id: '1000',
+      spec: { name: 'alice', uid: 1000, gid: 1000, home: '/home/alice', shell: '/bin/bash' },
+      status: { resolvable: true, source: 'local', observed_at: new Date().toISOString() },
+    });
+    setup.state.kv.put('/xinas/v1/observed/User/1001', {
+      kind: 'User',
+      id: '1001',
+      spec: { name: 'bob', uid: 1001, gid: 1001, home: '/home/bob', shell: '/bin/sh' },
+      status: { resolvable: true, source: 'nss', observed_at: new Date().toISOString() },
+    });
+  });
+
+  afterEach(async () => {
+    await setup.cleanup();
+  });
+
+  it('lists all users when source=all (default)', async () => {
+    const res = await request(setup.app).get('/api/v1/users').set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result).toHaveLength(2);
+    expect(res.body.result.map((u: { id: string }) => u.id)).toContain('1000');
+    expect(res.body.result.map((u: { id: string }) => u.id)).toContain('1001');
+  });
+
+  it('filters to source=local only', async () => {
+    const res = await request(setup.app)
+      .get('/api/v1/users?source=local')
+      .set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result).toHaveLength(1);
+    expect(res.body.result[0].id).toBe('1000');
+    expect(res.body.result[0].status.source).toBe('local');
+  });
+
+  it('filters to source=nss only', async () => {
+    const res = await request(setup.app)
+      .get('/api/v1/users?source=nss')
+      .set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result).toHaveLength(1);
+    expect(res.body.result[0].status.source).toBe('nss');
+  });
+
+  it('returns 404 when uid not found', async () => {
+    const res = await request(setup.app)
+      .get('/api/v1/users/9999')
+      .set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(404);
+    expect(res.body.errors[0].code).toBe('NOT_FOUND');
+  });
+
+  it('returns a single user by uid', async () => {
+    const res = await request(setup.app)
+      .get('/api/v1/users/1000')
+      .set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result.spec.name).toBe('alice');
+    expect(res.body.result.spec.uid).toBe(1000);
+  });
+});

--- a/xiNAS-MCP/src/api/app.ts
+++ b/xiNAS-MCP/src/api/app.ts
@@ -16,6 +16,7 @@ import { groupsRouter } from './routes/groups.js';
 import { healthRouter } from './routes/health.js';
 import { inventoryRouter } from './routes/inventory.js';
 import { networkRouter } from './routes/network.js';
+import { nfsIdmapRouter } from './routes/nfs-idmap.js';
 import { nfsRouter } from './routes/nfs.js';
 import { storageRouter } from './routes/storage.js';
 import { supportRouter } from './routes/support.js';
@@ -70,6 +71,7 @@ export function createApp(ctx: ApiContext): Express {
   v1.use(inventoryRouter(ctx));
   v1.use(usersRouter(ctx));
   v1.use(groupsRouter(ctx));
+  v1.use(nfsIdmapRouter(ctx));
 
   // Mutating verbs all route to the executor-unavailable stub until
   // xinas-agent ships. Per ADR-0002 §Agent heartbeat, plan and apply

--- a/xiNAS-MCP/src/api/app.ts
+++ b/xiNAS-MCP/src/api/app.ts
@@ -12,6 +12,7 @@ import { systemWarningsMiddleware } from './middleware/system-warnings.js';
 import { auditRouter } from './routes/audit-query.js';
 import { configHistoryRouter } from './routes/config-history.js';
 import { eventsRouter } from './routes/events.js';
+import { groupsRouter } from './routes/groups.js';
 import { healthRouter } from './routes/health.js';
 import { inventoryRouter } from './routes/inventory.js';
 import { networkRouter } from './routes/network.js';
@@ -68,6 +69,7 @@ export function createApp(ctx: ApiContext): Express {
   v1.use(supportRouter(ctx));
   v1.use(inventoryRouter(ctx));
   v1.use(usersRouter(ctx));
+  v1.use(groupsRouter(ctx));
 
   // Mutating verbs all route to the executor-unavailable stub until
   // xinas-agent ships. Per ADR-0002 §Agent heartbeat, plan and apply

--- a/xiNAS-MCP/src/api/app.ts
+++ b/xiNAS-MCP/src/api/app.ts
@@ -20,6 +20,7 @@ import { storageRouter } from './routes/storage.js';
 import { supportRouter } from './routes/support.js';
 import { systemRouter } from './routes/system.js';
 import { tasksRouter } from './routes/tasks.js';
+import { usersRouter } from './routes/users.js';
 
 export function createApp(ctx: ApiContext): Express {
   const app = express();
@@ -66,6 +67,7 @@ export function createApp(ctx: ApiContext): Express {
   v1.use(configHistoryRouter(ctx));
   v1.use(supportRouter(ctx));
   v1.use(inventoryRouter(ctx));
+  v1.use(usersRouter(ctx));
 
   // Mutating verbs all route to the executor-unavailable stub until
   // xinas-agent ships. Per ADR-0002 §Agent heartbeat, plan and apply

--- a/xiNAS-MCP/src/api/routes/groups.ts
+++ b/xiNAS-MCP/src/api/routes/groups.ts
@@ -1,0 +1,51 @@
+/**
+ * /api/v1/groups — list and get observed Group resources.
+ *
+ * Observed at: /xinas/v1/observed/Group/<gid-as-string>
+ * Source filter: ?source=local|nss|all (default: all)
+ *
+ * Follows the live route shape (see the Phase-I route-handler contract):
+ * factory takes ApiContext, sendOk(req, res, result, revisions), 404 via
+ * ApiException, helpers from reads.js.
+ */
+import { Router } from 'express';
+import type { ApiContext } from '../context.js';
+import { ApiException } from '../errors.js';
+import { getOrNull, listByPrefix, sendOk, unwrapValues } from '../handlers/reads.js';
+
+export function groupsRouter(ctx: ApiContext): Router {
+  const r = Router();
+
+  // GET /api/v1/groups[?source=local|nss|all]
+  r.get('/groups', (req, res) => {
+    const source = (req.query.source as string | undefined) ?? 'all';
+    if (source !== 'all' && source !== 'local' && source !== 'nss') {
+      throw new ApiException('INVALID_ARGUMENT', `source must be local|nss|all, got '${source}'`);
+    }
+    const rows = listByPrefix<Record<string, unknown>>(ctx.state, '/xinas/v1/observed/Group/');
+    let values = unwrapValues(rows);
+    if (source !== 'all') {
+      values = values.filter(
+        (g) => (g.status as { source?: string } | undefined)?.source === source,
+      );
+    }
+    sendOk(
+      req,
+      res,
+      values,
+      rows.map((x) => x.revision),
+    );
+  });
+
+  // GET /api/v1/groups/:gid
+  r.get('/groups/:gid', (req, res) => {
+    const row = getOrNull<Record<string, unknown>>(
+      ctx.state,
+      `/xinas/v1/observed/Group/${req.params.gid}`,
+    );
+    if (!row) throw new ApiException('NOT_FOUND', `group gid=${req.params.gid} not found`);
+    sendOk(req, res, row.value, [row.revision]);
+  });
+
+  return r;
+}

--- a/xiNAS-MCP/src/api/routes/nfs-idmap.ts
+++ b/xiNAS-MCP/src/api/routes/nfs-idmap.ts
@@ -1,0 +1,38 @@
+/**
+ * /api/v1/nfs-idmap — singleton NfsIdmap resource.
+ *
+ * Observed at: /xinas/v1/observed/nfs_idmap/snapshot (snake_case
+ * singleton per ADR-0003 locked layout — the agent uses observedSegment(Kind)
+ * which maps NfsIdmap → nfs_idmap, so the key is nfs_idmap/snapshot,
+ * NOT NfsIdmap/snapshot).
+ *
+ * Returns NOT_FOUND when the agent has not yet posted the snapshot.
+ *
+ * Follows the live route shape (see the Phase-I route-handler contract):
+ * factory takes ApiContext, sendOk(req, res, result, revisions), 404 via
+ * ApiException, helpers from reads.js.
+ */
+import { Router } from 'express';
+import type { ApiContext } from '../context.js';
+import { ApiException } from '../errors.js';
+import { getOrNull, sendOk } from '../handlers/reads.js';
+
+const SNAPSHOT_KEY = '/xinas/v1/observed/nfs_idmap/snapshot';
+
+export function nfsIdmapRouter(ctx: ApiContext): Router {
+  const r = Router();
+
+  // GET /api/v1/nfs-idmap
+  r.get('/nfs-idmap', (req, res) => {
+    const row = getOrNull<Record<string, unknown>>(ctx.state, SNAPSHOT_KEY);
+    if (!row) {
+      throw new ApiException(
+        'NOT_FOUND',
+        'NfsIdmap snapshot not yet observed; agent may not be running',
+      );
+    }
+    sendOk(req, res, row.value, [row.revision]);
+  });
+
+  return r;
+}

--- a/xiNAS-MCP/src/api/routes/nfs.ts
+++ b/xiNAS-MCP/src/api/routes/nfs.ts
@@ -3,6 +3,40 @@ import type { ApiContext } from '../context.js';
 import { ApiException } from '../errors.js';
 import { getOrNull, listByPrefix, sendOk, unwrapValues } from '../handlers/reads.js';
 
+/**
+ * Read-time join: for a desired Share, look up the observed ExportRule
+ * whose spec.export_path matches the share's spec.export_path and set
+ * status.exports to that rule's status.rules[] (or [] if none). ExportRule
+ * is an internal observed kind (no public endpoint of its own); this is the
+ * only place it surfaces. Returns a new object — does not mutate the row,
+ * and is safe when the desired Share has no status field.
+ */
+function joinExports(
+  state: ApiContext['state'],
+  share: Record<string, unknown>,
+): Record<string, unknown> {
+  const shareSpec = share.spec as Record<string, unknown> | undefined;
+  const exportPath = shareSpec?.export_path as string | undefined;
+
+  let exports: unknown[] = [];
+  if (exportPath) {
+    const match = listByPrefix<Record<string, unknown>>(
+      state,
+      '/xinas/v1/observed/ExportRule/',
+    ).find((row) => {
+      const spec = row.value.spec as Record<string, unknown> | undefined;
+      return spec?.export_path === exportPath;
+    });
+    if (match) {
+      const ruleStatus = match.value.status as Record<string, unknown> | undefined;
+      exports = (ruleStatus?.rules as unknown[]) ?? [];
+    }
+  }
+
+  const existingStatus = (share.status ?? {}) as Record<string, unknown>;
+  return { ...share, status: { ...existingStatus, exports } };
+}
+
 export function nfsRouter(ctx: ApiContext): Router {
   const r = Router();
 
@@ -11,7 +45,7 @@ export function nfsRouter(ctx: ApiContext): Router {
     sendOk(
       req,
       res,
-      unwrapValues(rows),
+      unwrapValues(rows).map((s) => joinExports(ctx.state, s)),
       rows.map((x) => x.revision),
     );
   });
@@ -22,7 +56,7 @@ export function nfsRouter(ctx: ApiContext): Router {
       `/xinas/v1/desired/Share/${req.params.id}`,
     );
     if (!row) throw new ApiException('NOT_FOUND', `share ${req.params.id} not found`);
-    sendOk(req, res, row.value, [row.revision]);
+    sendOk(req, res, joinExports(ctx.state, row.value), [row.revision]);
   });
 
   r.get('/shares/:id/sessions', (req, res) => {

--- a/xiNAS-MCP/src/api/routes/nfs.ts
+++ b/xiNAS-MCP/src/api/routes/nfs.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
-import { ApiException } from '../errors.js';
-import { sendOk, getOrNull, listByPrefix, unwrapValues } from '../handlers/reads.js';
 import type { ApiContext } from '../context.js';
+import { ApiException } from '../errors.js';
+import { getOrNull, listByPrefix, sendOk, unwrapValues } from '../handlers/reads.js';
 
 export function nfsRouter(ctx: ApiContext): Router {
   const r = Router();
@@ -26,12 +26,34 @@ export function nfsRouter(ctx: ApiContext): Router {
   });
 
   r.get('/shares/:id/sessions', (req, res) => {
-    // Sessions are runtime observation state; not in the store yet.
-    // The agent will populate /xinas/v1/observed/Share/<id>/sessions
-    // when it ships. Until then, return an empty array.
-    const exists = getOrNull(ctx.state, `/xinas/v1/desired/Share/${req.params.id}`);
-    if (!exists) throw new ApiException('NOT_FOUND', `share ${req.params.id} not found`);
-    sendOk(req, res, []);
+    // The Share itself lives in desired state (same prefix the list/get
+    // handlers read). 404 if it doesn't exist.
+    const shareRow = getOrNull<Record<string, unknown>>(
+      ctx.state,
+      `/xinas/v1/desired/Share/${req.params.id}`,
+    );
+    if (!shareRow) throw new ApiException('NOT_FOUND', `share ${req.params.id} not found`);
+
+    // Sessions are observed NfsSession entries (pushed by the agent). Filter
+    // the full observed set to those whose spec.export_path matches this
+    // share's spec.export_path. A defensive client_addr type guard skips any
+    // malformed observed row.
+    const shareSpec = shareRow.value.spec as Record<string, unknown> | undefined;
+    const exportPath = shareSpec?.export_path as string | undefined;
+    const sessions = listByPrefix<Record<string, unknown>>(
+      ctx.state,
+      '/xinas/v1/observed/NfsSession/',
+    ).filter((row) => {
+      const spec = row.value.spec as Record<string, unknown> | undefined;
+      return typeof spec?.client_addr === 'string' && spec?.export_path === exportPath;
+    });
+
+    sendOk(
+      req,
+      res,
+      unwrapValues(sessions),
+      sessions.map((row) => row.revision),
+    );
   });
 
   r.get('/nfs-profiles', (req, res) => {

--- a/xiNAS-MCP/src/api/routes/system.ts
+++ b/xiNAS-MCP/src/api/routes/system.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
-import { ApiException } from '../errors.js';
-import { sendOk, getOrNull, listByPrefix, unwrapValues } from '../handlers/reads.js';
 import type { ApiContext } from '../context.js';
+import { ApiException } from '../errors.js';
+import { getOrNull, listByPrefix, sendOk, unwrapValues } from '../handlers/reads.js';
 
 export function systemRouter(ctx: ApiContext): Router {
   const r = Router();
@@ -11,7 +11,23 @@ export function systemRouter(ctx: ApiContext): Router {
     if (!cluster) throw new ApiException('NOT_FOUND', 'cluster not initialized');
     const nodes = listByPrefix<Record<string, unknown>>(ctx.state, '/xinas/v1/nodes/');
     if (nodes.length === 0) throw new ApiException('NOT_FOUND', 'no node registered');
-    sendOk(req, res, { cluster: cluster.value, node: nodes[0]!.value }, [
+
+    // Merge the live agent state into node.status.agent. currentSnapshot()
+    // (H1) bundles state/version/last_heartbeat_at/last_observed_push_at/
+    // collectors, so the agent version + per-collector health surface here
+    // without a fresh RPC. Omitted when no tracker is wired (the optional
+    // agent sub-object in api-v1.yaml). The pre-existing node.status.agent_state
+    // field is preserved alongside it.
+    const nodeValue = nodes[0]!.value as Record<string, unknown>;
+    const agent = ctx.tracker?.currentSnapshot();
+    const node = agent
+      ? {
+          ...nodeValue,
+          status: { ...((nodeValue.status as Record<string, unknown>) ?? {}), agent },
+        }
+      : nodeValue;
+
+    sendOk(req, res, { cluster: cluster.value, node }, [
       cluster.revision,
       ...nodes.map((n) => n.revision),
     ]);

--- a/xiNAS-MCP/src/api/routes/users.ts
+++ b/xiNAS-MCP/src/api/routes/users.ts
@@ -1,0 +1,51 @@
+/**
+ * /api/v1/users — list and get observed User resources.
+ *
+ * Observed at: /xinas/v1/observed/User/<uid-as-string>
+ * Source filter: ?source=local|nss|all (default: all)
+ *
+ * Follows the live route shape (see the Phase-I route-handler contract):
+ * factory takes ApiContext, sendOk(req, res, result, revisions), 404 via
+ * ApiException, helpers from reads.js.
+ */
+import { Router } from 'express';
+import type { ApiContext } from '../context.js';
+import { ApiException } from '../errors.js';
+import { getOrNull, listByPrefix, sendOk, unwrapValues } from '../handlers/reads.js';
+
+export function usersRouter(ctx: ApiContext): Router {
+  const r = Router();
+
+  // GET /api/v1/users[?source=local|nss|all]
+  r.get('/users', (req, res) => {
+    const source = (req.query.source as string | undefined) ?? 'all';
+    if (source !== 'all' && source !== 'local' && source !== 'nss') {
+      throw new ApiException('INVALID_ARGUMENT', `source must be local|nss|all, got '${source}'`);
+    }
+    const rows = listByPrefix<Record<string, unknown>>(ctx.state, '/xinas/v1/observed/User/');
+    let values = unwrapValues(rows);
+    if (source !== 'all') {
+      values = values.filter(
+        (u) => (u.status as { source?: string } | undefined)?.source === source,
+      );
+    }
+    sendOk(
+      req,
+      res,
+      values,
+      rows.map((x) => x.revision),
+    );
+  });
+
+  // GET /api/v1/users/:uid
+  r.get('/users/:uid', (req, res) => {
+    const row = getOrNull<Record<string, unknown>>(
+      ctx.state,
+      `/xinas/v1/observed/User/${req.params.uid}`,
+    );
+    if (!row) throw new ApiException('NOT_FOUND', `user uid=${req.params.uid} not found`);
+    sendOk(req, res, row.value, [row.revision]);
+  });
+
+  return r;
+}


### PR DESCRIPTION
## Phase I — API public route additions (stacked on #212)

Ninth execution slice. **Base is #212's branch** (Phase H internal routes); diff is the 6 Phase I commits. This is the **read side** — it makes all the observed state the agent pushes (Phase H) visible through `/api/v1/*`.

### What's here
| Commit | Task | What |
|--------|------|------|
| `a895767` | I1 | `GET /api/v1/users[/{uid}]` — reads observed User from the state store |
| `44bcc10` | I2 | `GET /api/v1/groups[/{gid}]` |
| `94a014d` | I3 | `GET /api/v1/nfs-idmap` singleton (route kebab `/nfs-idmap`, KV segment snake `nfs_idmap`) |
| `21d4a0c` | I4 | `/api/v1/system` → `node.status.agent` from `HeartbeatTracker.currentSnapshot()` |
| `8180854` | I5 | `/api/v1/shares/{id}/sessions` populated from observed NfsSession, filtered by `export_path` |
| `e3e7924` | I6 | read-time join: observed `ExportRule` → `Share.status.exports[]` |

### Reconciliations / notes
- I3 reads `/xinas/v1/observed/nfs_idmap/snapshot` (the `observedSegment('NfsIdmap')` mapping H3 writes through), documented inline.
- I4 keeps `ctx.tracker` **optional** (Phase H made it so) — `agent` is omitted via conditional spread when no tracker. `buildTestApp()` now wires an unstarted (always-offline) tracker so every route test is deterministic; behavior-neutral for existing tests (offline → mutating routes still 500, GETs no warnings). The pre-existing `node.status.agent_state` flat field is preserved alongside the new `agent` sub-object.
- I5/I6 read the Share from **desired** state (`/xinas/v1/desired/Share/<id>`) and join **observed** NfsSession/ExportRule by `spec.export_path`. Defensive `typeof client_addr === 'string'` guard on sessions.

I built these directly (subagent dispatch was hitting transient 529s) with the same live-code reconciliation discipline.

### Deferred / for review
- **I6 join cost**: the list handler calls `joinExports` per share, each scanning all observed ExportRules — O(shares×rules). Fine at Phase-0 scale (a handful of shares); a list-once-into-a-map optimization is a clean follow-up if share counts grow.
- Deep end-to-end validation of the full observe→push→read path is **Phase J** (comprehensive testing, next) rather than a separate Phase I review — Phase I is read-only routes mirroring the existing API patterns.

### Verification
- `tsc --noEmit` exit 0 · **444 tests / 85 files pass** (+25 over Phase H) · `biome lint` warnings-only · format clean
- Code-only api/TS; no `Requires-Rebuild` trailer.

### Not in this PR
Phases J–L (comprehensive testing incl. the J3 schema-validation wiring, Ansible role, sanity + PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)