### PR TITLE
fix(control-path): FIX-FIRST pass — independent-review P0 + 12 P1 (operator-gated)

### DIFF
--- a/collection/roles/xinas_agent/README.md
+++ b/collection/roles/xinas_agent/README.md
@@ -48,6 +48,7 @@ The `meta/main.yml` dependency declaration enforces step 2 before step 3.
 | `xinas_agent_repo_path` | `/opt/xiNAS/xiNAS-MCP` | Path to the MCP repo checkout containing `dist/agent-server.js`. |
 | `xinas_agent_config_dir` | `/etc/xinas-agent` | Directory for the agent config file. |
 | `xinas_agent_socket` | `/run/xinas/agent.sock` | UDS socket the agent binds. Must match the api's `agent.socket` config. |
+| `xinas_agent_socket_group` | `xinas-api` | Group the agent socket is chowned to so the unprivileged api can connect. MUST be a group the api process belongs to (the `xinas_api` role creates `xinas-api` and adds the api user). If wrong/undefined the socket ends up `root:root` and the api gets EACCES → agent pinned `offline`. Rendered into config.json's `socket_group`. |
 | `xinas_api_socket` | `/run/xinas/api.sock` | UDS socket the agent uses to POST observations to the api. |
 | `xinas_agent_controller_id_path` | `/var/lib/xinas/controller-id` | Shared identity file (read-only; written by `xinas_api`). |
 | `xinas_agent_token_path` | `/etc/xinas-agent/agent-token` | Token file (read-only; written by `xinas_api`). Mode `0400 root:root`. |

--- a/collection/roles/xinas_agent/defaults/main.yml
+++ b/collection/roles/xinas_agent/defaults/main.yml
@@ -16,6 +16,15 @@ xinas_agent_config_dir: /etc/xinas-agent
 # can connect.
 xinas_agent_socket: /run/xinas/agent.sock
 
+# Group the agent socket is chowned to so the (unprivileged) xinas-api
+# process can connect to it. MUST be a group the api process is a member
+# of — the xinas_api role creates `xinas-api` and adds the api user to it.
+# If this is wrong/undefined, agent-server.ts's getent lookup fails and
+# falls back to the process gid (0 under User=root), leaving the socket
+# root:root 0660 → the api gets EACCES on connect → the heartbeat never
+# succeeds and the agent is pinned `offline`.
+xinas_agent_socket_group: xinas-api
+
 # Path to the api's UDS socket. The agent POSTs observation batches
 # to the api over this socket.
 xinas_api_socket: /run/xinas/api.sock

--- a/collection/roles/xinas_agent/templates/xinas-agent-config.json.j2
+++ b/collection/roles/xinas_agent/templates/xinas-agent-config.json.j2
@@ -3,5 +3,6 @@
   "agent_socket": "{{ xinas_agent_socket }}",
   "controller_id_path": "{{ xinas_agent_controller_id_path }}",
   "agent_token_path": "{{ xinas_agent_token_path }}",
+  "socket_group": "{{ xinas_agent_socket_group }}",
   "heartbeat_interval_ms": {{ xinas_agent_heartbeat_interval_ms }}
 }

--- a/collection/roles/xinas_api/templates/xinas-api-config.json.j2
+++ b/collection/roles/xinas_api/templates/xinas-api-config.json.j2
@@ -15,6 +15,7 @@
     "socket": "{{ xinas_api_agent_socket }}",
     "heartbeat_interval_ms": {{ xinas_api_agent_heartbeat_interval_ms }}
   },
+  "internalTokensPath": "{{ xinas_api_config_dir }}/internal-tokens.json",
   "state": {
     "databasePath": "{{ xinas_api_state_dir }}/xinas.db",
     "auditJsonlPath": "{{ xinas_api_log_dir }}/audit.jsonl",

--- a/collection/roles/xinas_api/templates/xinas-api-tmpfiles.conf.j2
+++ b/collection/roles/xinas_api/templates/xinas-api-tmpfiles.conf.j2
@@ -9,8 +9,23 @@
 # /run/xinas is on tmpfs and MUST be recreated each boot. The
 # persistent state + log dirs use the same mechanism for owner/mode
 # consistency.
+#
+# /run/xinas holds the api.sock and agent.sock UDS files, which ARE the
+# auth boundary (api.sock: operator/admin access; agent.sock: internal-agent
+# /root trust). The socket FILES are chmod 0660 + chowned after bind, but the
+# DIRECTORY's write permission governs who can unlink/replace those inodes.
+# It must therefore NOT be writable by the operator group (xinas-admin): a
+# group member could swap the agent socket for their own listener and
+# escalate to internal-agent trust. Mode 1731 root:xinas-api:
+#   - owner root (rwx): the agent (root) creates agent.sock.
+#   - group xinas-api (-wx): the api user (supplementary xinas-api) creates
+#     api.sock and traverses; operators are NOT in xinas-api.
+#   - other (--x): everyone can traverse to connect to a socket they have
+#     FILE permission on, but cannot create/unlink/replace anything.
+#   - sticky (1): a process may only unlink files it owns, so the api user
+#     cannot replace the root-owned agent.sock either.
 
-d /run/xinas             0770 root {{ xinas_api_socket_group }} -
+d /run/xinas             1731 root xinas-api -
 d /var/lib/xinas         0755 root root          -
 d {{ xinas_api_state_dir }}   0750 {{ xinas_api_user }} {{ xinas_api_socket_group }} -
 d {{ xinas_api_log_dir }}     0750 {{ xinas_api_user }} {{ xinas_api_socket_group }} -

--- a/docs/Installer/xinas-api-role-spec.md
+++ b/docs/Installer/xinas-api-role-spec.md
@@ -229,7 +229,13 @@ corresponding feature ships.
         - Template config.json from xinas-api-config.json.j2 with that
           token, the looked-up _xinas_admin_gid, and the
           controller_id. force: true (first write only because of the
-          enclosing condition). no_log: true.
+          enclosing condition). no_log: true. The template MUST emit
+          `internalTokensPath: {{ xinas_api_config_dir }}/internal-tokens.json`
+          — without it `loadConfig()` never merges the internal-tokens
+          file (there is no default/env fallback), so the agent's bearer
+          is unknown to the api and every `POST /internal/v1/observed`
+          401s. (Regression-guarded by the rendered-template contract
+          test `src/__tests__/agent/config-template.test.ts`.)
         - Write the token to /etc/xinas-api/admin-token, mode 0640,
           owner root, group {{ xinas_api_socket_group }}.
           no_log: true.

--- a/docs/Installer/xinas-api-role-spec.md
+++ b/docs/Installer/xinas-api-role-spec.md
@@ -90,10 +90,12 @@ xinas_api_state_dir: /var/lib/xinas/state
 xinas_api_log_dir:   /var/log/xinas
 
 # Unix-domain socket path. The parent directory /run/xinas is created
-# by the role's tmpfiles.d entry as root:xinas-admin 0770 so the api
-# process (primary group xinas-admin) can create the socket and
-# operators in xinas-admin can traverse + connect; the socket file
-# itself is chmod 0660
+# by the role's tmpfiles.d entry as root:xinas-api 1731 (sticky). The api
+# process creates api.sock via its xinas-api SUPPLEMENTARY membership, and
+# the agent (root) creates agent.sock; operators (xinas-admin, NOT in
+# xinas-api) can only traverse + connect — they cannot replace a socket
+# inode (the dir is not group-writable to them, and the sticky bit blocks
+# cross-owner unlink). The socket file itself is chmod 0660
 # + chown :{{ xinas_api_socket_group }} by server.ts after binding.
 xinas_api_socket: /run/xinas/api.sock
 
@@ -157,7 +159,7 @@ corresponding feature ships.
 5.  Install tmpfiles.d snippet at /usr/lib/tmpfiles.d/xinas-api.conf
     (mode 0644 root:root) with these lines:
 
-        d /run/xinas             0770 root {{ xinas_api_socket_group }} -
+        d /run/xinas             1731 root xinas-api -
         d /var/lib/xinas         0755 root root          -
         d /var/lib/xinas/state   0750 {{ xinas_api_user }} {{ xinas_api_socket_group }} -
         d /var/log/xinas         0750 {{ xinas_api_user }} {{ xinas_api_socket_group }} -

--- a/docs/control-path/xinas-agent-s0s1-spec.md
+++ b/docs/control-path/xinas-agent-s0s1-spec.md
@@ -230,7 +230,7 @@ Architecture rules:
 |---|---|---|
 | `agent.health` | Real | `{ status, version, uptime_seconds, controller_id, in_flight_tasks: 0, collectors: { <name>: 'running' \| 'stubbed' \| 'error: <reason>' } }` |
 | `agent.version` | Real | `{ version, git_sha, build_date }` |
-| `inventory.collect`, `disks.list`, `filesystems.list`, `mounts.list`, `network.snapshot`, `systemd.units_status`, `exports.list`, `nfs.sessions.list` | Real (callable on demand; same data the collectors push asynchronously) | Whatever the collector last computed; `INTERNAL` if the collector is in an error state |
+| `inventory.collect`, `disks.list`, `filesystems.list`, `mounts.list`, `network.snapshot`, `systemd.units_status`, `exports.list`, `nfs.sessions.list` | Stub (deferred to WS12 convergence) | JSON-RPC error -32000 with `data.code: 'EXECUTOR_UNSUPPORTED'`. **The LIVE data path in S0/S1 is the push model (Flow A)** — collectors push the same data asynchronously to `/internal/v1/observed`, which the api serves from its KV store; no S0/S1 caller uses the on-demand pull. These on-demand read methods are enumerated-but-stubbed now (so they return `EXECUTOR_UNSUPPORTED`, not an unknown `-32601`) and are wired to the collectors' last-computed snapshots in WS12. |
 | `arrays.list`, `managed_files.checksums` | Stub | JSON-RPC error -32000 with `data.code: 'EXECUTOR_UNSUPPORTED'` |
 | `arrays.create`, `arrays.delete`, `arrays.import`, `spare.set` | Stub | JSON-RPC error -32000 with `data.code: 'EXECUTOR_UNSUPPORTED'` |
 | `fs.create`, `fs.mount`, `fs.unmount`, `fs.grow`, `fs.set_quota_mode` | Stub | JSON-RPC error -32000 with `data.code: 'EXECUTOR_UNSUPPORTED'` |

--- a/docs/control-path/xinas-agent-s0s1-spec.md
+++ b/docs/control-path/xinas-agent-s0s1-spec.md
@@ -580,6 +580,8 @@ ExportRule:
 
 The existing `/api/v1/export-groups` endpoint stays as-is (still returns `[]` in S0+S1); ExportRule entries surface inside `Share.status.exports[]` where they naturally belong. No new public GET endpoint for ExportRule.
 
+**Join key (read time):** the fold-in matches `desired Share.spec.path` against the observed `ExportRule.spec.export_path` (and, for `/shares/{id}/sessions`, against `NfsSession.spec.export_path`). The Share has **no** `export_path` field — its `spec.path` IS the exported directory the agent stamps onto the observed rows. Keying the Share side off a non-existent `export_path` silently returns `[]` for every real Share.
+
 ### `SystemdUnit` resource (new public kind)
 
 ```yaml

--- a/docs/plans/2026-06-02-xinas-agent-s0s1-independent-review.md
+++ b/docs/plans/2026-06-02-xinas-agent-s0s1-independent-review.md
@@ -1,0 +1,152 @@
+# xinas-agent S0+S1 — Independent multi-agent review
+
+_24-agent separated review of PRs #205-#215 vs the plan + spec + ADRs + api-v1.yaml._
+
+I'll synthesize the per-phase review data into a decisive final report. The data is already verified, so my job is to weight confirmed findings and present a clear cross-check. Let me produce the report directly.
+
+# xiNAS xinas-agent S0+S1 — Lead Review Report
+
+**Scope:** Phases A–K/L, PRs #205–#215 (~90 commits), reviewed against `docs/plans/2026-05-28-xinas-agent-s0s1-plan.md`, `docs/control-path/xinas-agent-s0s1-spec.md`, the ADRs, and `api-v1.yaml`. All findings below carry an adversarial verification verdict; refuted findings are dropped.
+
+---
+
+## 1. Overall verdict
+
+**FIX-FIRST.**
+
+The architecture is sound and the per-phase craftsmanship is genuinely high — clean layering (pure parsers → probes → collectors → publisher → api receiver), correct security model on the file/socket boundary, and disciplined error-code semantics. But the end-to-end observation path is broken in production by a confirmed P0 plus a cluster of P1s that all share one root cause: **the wiring that connects deliberately-built mechanisms was never closed, and the test suite was shaped to pass around the gaps rather than through them.** Concretely, on a real Ansible-deployed root node today: the agent socket is mis-chowned so the api↔agent heartbeat never connects (agent stuck `offline`), and even if it did, steady-state observations never flush, three emitted kinds are rejected 400, and two read-path joins always return empty. None of this is caught by the 459 unit + 5 e2e tests because the gaps live precisely in the rendered-template / real-Share-shape / quiet-node paths the tests don't exercise. This is not shippable as-is, but every confirmed defect is narrowly scoped with a clear fix — this is a focused fix pass, not a redesign.
+
+---
+
+## 2. Per-phase conformance
+
+| Phase | PR | Conformance | Confirmed findings (real=true) |
+|-------|-----|-------------|-------------------------------|
+| A — Foundation (groups, controller-id, split-secret tokens) | 205 | partial | 1 (P1) |
+| B — Shared parse library (10 pure parsers) | 206 | full | 0 |
+| C — Agent process skeleton | 207 | full | 0 |
+| D — Probe layer (supervisor + 9 probes) | 208 | full | 0 |
+| E — Collectors (base + registry + 9 + stubs) | 209 | full | 1 (P1) |
+| F — Publisher (batch, retry, reconcile, boot) | 210 | partial | 4 (P1×4) |
+| G — API contract additions to api-v1.yaml | 211 | deviation-justified | 0 |
+| H — API internal routes + HeartbeatTracker | 212 | full | 0 |
+| I — API public read routes | 213 | deviation-concern | 1 (P1) |
+| J — Convergence wiring + integration + e2e | 214 | partial | 2 (P1×2) |
+| K/L — xinas_agent role + hardened unit | 215 | partial | 3 (P0×1, P1×2) |
+
+**Totals:** 1 P0, 12 P1 confirmed real. **0 findings were refuted** — every P0/P1 raised survived adversarial verification (several were found to *understate* the blast radius). All P2s stand as minor/defensive.
+
+---
+
+## 3. Confirmed findings
+
+### P0
+
+**[KL] Deployed agent config template omits `socket_group` → socket chowned `root:root`, api heartbeat gets EACCES, agent stuck `offline` forever**
+- **Location:** `collection/roles/xinas_agent/templates/xinas-agent-config.json.j2:1-7`; no `xinas_agent_socket_group` var in `defaults/main.yml`
+- **What's wrong:** The rendered config emits `api_socket`/`agent_socket`/`controller_id_path`/`agent_token_path`/`heartbeat_interval_ms` but **not** `socket_group`, which `src/agent/config.ts:16,39` requires and `agent-server.ts:49` feeds to `getent group`. Undefined → `getent` throws → caught at `:54` → falls back to `process.getgid()` = 0 (unit runs `User=root`). Socket ends up `root:root 0660`. The api runs `Group=xinas-admin` + `SupplementaryGroups=xinas-api` (not in root group) → EACCES on connect → `agent.health` never succeeds → state pinned `offline`. This defeats the entire purpose of Phase KL. No override path exists. The correct gid *does* exist (`xinas_api` role creates the group and adds the api user) — the agent config just never names it.
+- **Fix:** Add `"socket_group": "{{ xinas_agent_socket_group }}"` to the template and a `xinas_agent_socket_group: xinas-api` default. Add a rendered-template key-set assertion so this can't regress.
+
+### P1
+
+**[A] Rendered `config.json` never sets `internalTokensPath` → agent token never loaded by the api in a real deployment**
+- **Location:** `collection/roles/xinas_api/templates/xinas-api-config.json.j2` (no key); consumer `xiNAS-MCP/src/api/config.ts:74`
+- **What's wrong:** `loadConfig()` reads `internal-tokens.json` only when `config.internalTokensPath` is truthy; there is no default/env fallback. The A7 task writes the token files, but A8 wired only the consumer code, never the config field that activates it. Net on a real install: api loads only the admin token → the agent's `Bearer <agent-token>` on `POST /internal/v1/observed` is unrecognized → every push 401s. Tests mask it (e2e inlines the agent token into `config.json`'s `tokens` map; the A8 unit test hand-writes `internalTokensPath`). Directly contradicts spec lines 162/321 and the role-spec doc the same PR added.
+- **Fix:** Emit `"internalTokensPath": "/etc/xinas-api/internal-tokens.json"` in the api config template; add an e2e fixture built the way the role builds config.json (path set, agent token absent from inline map).
+
+**[E + J] Type-only validator rejects 3+ kinds the agent's own collectors emit (XiraidArray, managed_files, inventory — and ExportRule) → 400, batch fail-closed, observations silently dropped**
+- **Location:** `xiNAS-MCP/src/api/observed-schemas.ts:32-43` (OBSERVED_KINDS); `xiNAS-MCP/src/api/internal/observed.ts:94-110`
+- **What's wrong:** `OBSERVED_KINDS` omits `XiraidArray` and `managed_files`, and lists `inventory` which has no api-v1.yaml schema (skipped at compile → undefined validator). The convergence registers and boot-sweeps all three collectors. Each upsert whose kind is absent throws `INVALID_ARGUMENT 'unknown kind'` and **fail-closes the entire batch**; `publisher.ts:122-124` treats 4xx as non-retryable and drops silently. Verification found this **understated**: `ExportRule` is *also* absent from OBSERVED_KINDS despite having a schema and being emitted in the *same NFS batch as NfsSession* — so on any node with NFS exports, live session state is dropped too. This is a Phase-J-introduced regression (pre-J, `ctx.observedSchemas` was undefined so all kinds were accepted). The stub collectors' documented purpose (return a deferral `_stub` row instead of 404) is defeated.
+- **Fix:** Add `XiraidArray`, `managed_files`, `inventory`, `ExportRule` to `OBSERVED_KINDS`; provide type-only validators (or an explicit "kind-without-schema accepted" path) for the two schema-less kinds. Note the E10 finding and the J3 finding are the same defect surfacing at two phases — fix once.
+
+**[F] No debounce / timed flush — steady-state deltas never flush on a quiet node**
+- **Location:** `xiNAS-MCP/src/agent/publisher.ts:55-69`; `xiNAS-MCP/src/agent/convergence.ts:344`
+- **What's wrong:** `enqueue()` auto-flushes only at the 256-entry / 1 MB ceiling. There is no timer-driven flush anywhere in `src/agent/`. The sole steady-state driver just enqueues. A single hot-plug/NIC event enqueues 1 delta that sits in `#queue` forever. On a low-event node, observed state in the api KV store freezes after the boot sweep. Spec line 217/249 explicitly require a ~50–100ms debounce. (The plan's F1 sketch omitted it; the impl faithfully reproduced an under-specified sketch but diverged from the durable spec.)
+- **Fix:** Add a debounced flush timer (50–100ms) armed on every `enqueue`, cleared on flush.
+
+**[F] Poll-fallback / 5-minute backstop reconcile unwired — `pollIntervalMs` has no consumer**
+- **Location:** `xiNAS-MCP/src/agent/publisher.ts` (no poll driver); collectors `nfs.ts:69`, `inventory.ts:56`, `users.ts:55`
+- **What's wrong:** Every collector declares `pollIntervalMs` and comments say "the publisher drives polling via pollIntervalMs," but **no non-test code reads it**. Collectors with no event source (NFS, NfsIdmap, Inventory, Users) and the 5-min backstops for event-only kinds (ExportRule, Mount) are swept exactly once at boot and never again. Spec §Flow C/D (lines 346–350, 374–389) mandate this and it is in *neither* the "Out of scope" nor the "deferred" lists. The F2 commit's "backstop hook" is only the `pendingReconcile` set, which nothing fires.
+- **Fix:** Add a per-collector poll loop (`setInterval(pollIntervalMs)` calling the collector's snapshot/flush) plus a 5-min full-reconcile backstop tick.
+
+**[F] `pendingReconcile` populated on retry-exhaustion but never consumed — recovery path dead-ended**
+- **Location:** `xiNAS-MCP/src/agent/publisher.ts:71-73,142-143` (`needsReconcile` defined, zero callers)
+- **What's wrong:** On 5xx exhaustion the publisher adds the kind to `pendingReconcile` and exposes `needsReconcile(kind)`, but nothing ever calls it. Spec line 391/674 require that the next collector tick of an affected kind re-runs `initialSweep()`. After a sustained api outage drops a batch, the set is marked but no collector ever re-sweeps — recovery tracks state nothing acts on. Strictly worse given the poll backstop is also unwired (no "next tick" ever fires for event-only kinds).
+- **Fix:** Make the (newly added) poll/backstop loop consult `needsReconcile(kind)` and escalate to a full `initialSweep()` + `flushWithSnapshot([kind])`; clear on success.
+
+**[F] Boot sweep > 256 deltas (or > 1 MB) for one kind loses data to the api reconcile**
+- **Location:** `xiNAS-MCP/src/agent/publisher.ts:63-68`; `boot.ts:45-49`; `xiNAS-MCP/src/api/internal/observed.ts:149-164`
+- **What's wrong:** `runBootSequence` enqueues all of one kind's deltas synchronously then calls `flushWithSnapshot([kind])`. If the kind exceeds the ceiling, the early `void this.flush()` POSTs the first 256 with `complete_snapshots:[]` (no reconcile); the trailing `flushWithSnapshot` POSTs the remainder *with* `complete_snapshots:[kind]`. The api reconcile builds `upsertedKeys` from the current request only, so it **deletes every key the first batch wrote** → only the last <256 entries survive. Violates the per-kind-complete invariant (spec 340–341). **Bounded today** (S0/S1 cardinalities are far below 256), latent for any future high-cardinality kind (un-stubbed XiraidArray/ManagedFile).
+- **Fix:** Suppress the early ceiling-flush during the boot sweep (boot-mode flag), or serialize: never emit a `complete_snapshots:[]` partial for a kind that will be reconciled in the same sweep.
+
+**[I] Share join keys off non-existent `share.spec.export_path` → `/sessions` and `status.exports[]` always empty against real data**
+- **Location:** `xiNAS-MCP/src/api/routes/nfs.ts:19,76`
+- **What's wrong:** Both join handlers read `share.spec.export_path`, but the Share schema has no `export_path` (it requires `[path, clients, fsid]`; `seedShare()` writes `spec.path`). For a real Share, `exportPath` resolves `undefined`, so `/shares/{id}/sessions` and `Share.status.exports[]` always return `[]`. The agent's `export_path` (the `/etc/exports` dir) equals `share.spec.path` — that's the intended key. The plan called out this exact `spec.path`-vs-`export_path` trap *twice* (plan 13717, 13931); the impl chose `export_path` anyway and shaped the fixtures to the wrong key (the fixtures even use two *different* values for `path` vs `export_path`, so a correct join would have failed them). This nullifies the two headline deliverables of I5 and I6 in production.
+- **Fix:** Join on `share.spec.path`. Re-seed tests with the real single-field Share shape (`spec.path` only) and real-shaped ExportRule/NfsSession rows.
+
+**[J] `agent.health` collector-in-error never maps to `degraded` — tracker is purely time-based**
+- **Location:** `xiNAS-MCP/src/api/heartbeat.ts:297-308` (`#computeState` ignores `#collectors`); `convergence.ts:243-254` (forces systemd collector to error)
+- **What's wrong:** Spec §668 requires the tracker to interpret a collector-in-error `agent.health` as `degraded`. The agent *does* compute `status='degraded'` (`health.ts:34`), but the probe discards the `status` field and `#computeState()` only uses elapsed time — it never inspects `#collectors`. Phase J's own convergence wires the systemd collector to always reject (`'systemd dbus probe unavailable'`), *unconditionally* (outside the fixture branch), so on every real boot the agent reports `degraded` but the api reports `healthy` and mutating routes return UNSUPPORTED with **no** `EXECUTOR_DEGRADED` warning (spec §312/§702). The contract and the captured data are both present but disconnected. Not deferred (§668 carries no S2 marker, unlike line 655).
+- **Fix:** In `#computeState()`, OR the time-based state with a collector-error check (`degraded` if any `#collectors` entry starts with `error:`). Restore `simulateDegraded()` in the mock-agent helper and add a heartbeat unit test for the mapping.
+
+**[KL] `MemoryDenyWriteExecute=true` on a Node service risks crashing V8 JIT (or forcing no-JIT) — the api unit deliberately omits it**
+- **Location:** `xiNAS-MCP/xinas-agent.service:64`
+- **What's wrong:** V8's JIT must `mprotect` code pages to `PROT_EXEC`; MDWE installs a seccomp filter (returning EPERM) that blocks exactly that. Default non-jitless Node 20 (the confirmed target) will abort or degrade when V8 arms a JIT code page. The sibling `xinas-api.service` runs the identical Node runtime and **deliberately omits** MDWE while keeping the rest of the hardening stack — strong evidence the team already knows Node + MDWE conflict. `systemd-analyze verify` (the plan's only gate) cannot catch a runtime JIT abort.
+- **Fix:** Drop `MemoryDenyWriteExecute=true` to match the api unit (or prove safe on the exact target Node build with a real start test).
+
+**[KL] No test exercises the missing-`socket_group` path; L1 smoke is non-root so it masks the P0**
+- **Location:** `collection/roles/xinas_agent` (no test dir); `src/__tests__/agent/config.test.ts:20,43`; plan L15780-15811
+- **What's wrong:** The P0 has zero coverage at every layer: no molecule/ansible test renders the template and asserts its keys; the TS config test always supplies `socket_group:'xinas-api'`; and the L1 manual smoke both omits the field *and* runs the agent as a normal user, so `server.ts` takes the `isRoot===false` warn-only branch and passes green while production-as-root mis-chowns. The phase's own verification is structurally incapable of catching the defect.
+- **Fix:** Add a rendered-template key-set assertion (ansible/molecule) and a root-mode (or injected-uid) integration test that exercises the getent-fallback branch.
+
+---
+
+## 4. Cross-cutting themes
+
+1. **"Built but not wired" is the dominant failure mode.** The P0 and most P1s are not logic bugs in isolated functions — they are *disconnected* mechanisms. The split-secret store (A), the `pendingReconcile` set (F), `pollIntervalMs` (F), the captured `#collectors` map (J), and the `socket_group` field (KL) are all *implemented* but never activated by the config field / driver / consumer that would make them live. The producer side and the consumer side each landed correctly; the connecting hop was repeatedly the casualty.
+
+2. **The test suite was shaped around the gaps, not through them.** Every confirmed P0/P1 is invisible to the 459 unit + 5 e2e tests because the fixtures encode the *wrong* shape that makes the broken code pass: e2e inlines the agent token into `config.json` (hiding A1); e2e/schema tests assert only kinds that *are* in OBSERVED_KINDS (hiding E/J1); I-phase fixtures bake `export_path` onto the Share (hiding I1); KL's smoke runs non-root and omits the field (hiding the P0). This is the single most important systemic finding: **no test renders an Ansible template or drives a real producer-shaped value end-to-end.** The recurring P2 "tests are seed-and-echo / never render the template" is the leading indicator of the P0/P1 class.
+
+3. **Inbound schema-validation strictness is a sharp edge.** The type-only validator strips `required` but keeps `enum`/`const` and fail-closes the *whole batch* on any single bad delta or unknown kind. Combined with per-kind batching at boot, one rejected kind (ExportRule) poisons its co-batched real kinds (NfsSession). The design is defensible but the OBSERVED_KINDS list must be kept exhaustively in sync with what collectors emit, and out-of-enum probe values are an unguarded batch-kill risk (P2, E).
+
+4. **Intermediate-shape vs public-schema name collisions are accumulating as adapter debt.** Disk, ExportRule, NfsSession observed values diverge from their identically-named public read schemas (B/E/G P2s), relying on type-only validation passing vacuously. This is intentional and documented, but the `export_path` vs `path` confusion (I1) is exactly the failure that this naming collision invites — a maintainer assumed the observed and desired shapes shared a field they don't.
+
+5. **`observed_at` required on non-agent-emitted kinds** (Share, NfsProfile, XiraidArray) and `metadata` required while the producer never sets it (G P2) rely on the api stamping fields before any consumer validates the full kind. Currently fine because inbound validation is type-only and the KV layer injects metadata, but it is a standing assumption worth a single tracking note.
+
+---
+
+## 5. Spec/plan coverage gaps (specced/planned, not built or only stubbed)
+
+- **Steady-state observation refresh** (debounce flush + poll backstop + reconcile consumption) — specced in §Flow A/C/D, *not built* (F P1s ×3). After boot, a quiet node's observed state is permanently static and outage-recovery never fires. This is the largest behavioral gap.
+- **Collector-error → degraded mapping** — specced §668/§312/§702, *not built* (J P1). The agent computes it; the api ignores it.
+- **`XiraidArray` and `managed_files` stub deferral rows** — specced (spec 271: "every observation kind is a public schema… including managed_files"), built as collectors but *rejected by the validator* (E/J P1), so the `_stub` deferral row never persists; `managed_files` has no schema in api-v1.yaml at all.
+- **`last_publish_error` on `agent.health` + structured drop log** — specced line 674, *not built* (F P2): retry exhaustion discards `lastStatus` with a `// omitted for test simplicity` comment. For a root daemon, the missing drop-log is the operator's only window into silent batch loss.
+- **dbus subscription for the systemd collector** — intentionally stubbed (`start()` is a commented-out stub; `dbus-native` dep is orphaned, D P2). This is an *accepted* deferral (spec §coverage #8) but currently *forces* the degraded state in convergence (the trigger for J P1), so it is coupled to a real bug.
+- **`/users` and `/groups` `?limit`** — declared in the contract (QueryLimit), *ignored* by the handlers (I P2): contract-vs-impl divergence.
+
+---
+
+## 6. Carried-forward items (confirmed / refined)
+
+| Item | Verdict |
+|------|---------|
+| **(a) 8 collector↔probe adapters as debt** | **Confirmed, refine to a tracking note.** Real (NFS double-parse, intermediate-shape renames, mount_unit_state field reuse). Mostly benign P2 debt — *except* it is the breeding ground for I1's `export_path`/`path` confusion. Keep as debt but add a single doc mapping observed-shape ↔ public-schema field names per kind. |
+| **(b) `pollIntervalMs` backstop poll driver unwired** | **Confirmed P1, NOT a deferral.** This is finding F2/F3 — promote out of "carried-forward" and into the FIX-FIRST set. Spec mandates it; nothing reads `pollIntervalMs`; event-only and no-event kinds go stale after boot. |
+| **(c) ProtectSystem=strict-vs-full on the agent unit** | **Confirmed accepted deviation, leave as-is.** Documented and justified against ADR-0002. Not a defect. (Distinct from the MDWE P1 on the same unit, which *must* be fixed.) |
+| **(d) `observed_at` required on Share/NfsProfile/XiraidArray** | **Confirmed standing assumption, low risk.** Safe while inbound validation is type-only and the api stamps the field. Add one tracking note; revisit if validation tightens. |
+| **(e) Heartbeat bootstrap-event suppression** | **Confirmed intentional, leave as-is.** The `#bootstrapped` flag suppressing the first offline→live event is a documented, sound H-review fix. Not a defect. |
+| **(f) I6 join O(shares×rules)** | **Confirmed, acceptable at S0/S1 scale, leave as debt.** Note this is moot until I1 is fixed (the join currently returns `[]` for all real shares). After the fix, the O(n×m) cost is real but bounded by small cardinalities. |
+
+---
+
+## 7. Top 5 recommended next actions (prioritized)
+
+1. **Fix the P0 socket-group break (KL).** Add `socket_group` to the agent config template + a `xinas_agent_socket_group: xinas-api` default, and add a rendered-template key-set assertion. Without this, nothing downstream works on a real node — the heartbeat never connects.
+
+2. **Close the observation-path rejections (E/J).** Add `XiraidArray`, `managed_files`, `inventory`, **and `ExportRule`** to `OBSERVED_KINDS` with type-only validators for the schema-less kinds. This is one fix resolving two phase findings and prevents NFS-session data loss via batch fail-close. Add an e2e assertion that `GET /api/v1/arrays` returns the deferral `_stub` after boot.
+
+3. **Wire steady-state publishing (F).** Add the debounce flush timer, the per-collector `pollIntervalMs` poll loop, the 5-min backstop reconcile, and make the loop consume `pendingReconcile`. These four are one coherent change to the publisher/convergence and together restore live observation + outage recovery. While here, populate `last_publish_error` and log retry-exhaustion drops.
+
+4. **Fix the read-path join key (I) and the degraded mapping (J).** Change both joins to `share.spec.path` and re-seed tests with the real Share shape. Wire collector-error → `degraded` in `#computeState()` and restore `simulateDegraded()`. Both are small, high-value correctness fixes on already-shipped read/heartbeat surfaces.
+
+5. **Activate the split-secret token + drop MDWE, then add the missing template/integration tests (A/KL).** Emit `internalTokensPath` in the api config template; drop `MemoryDenyWriteExecute=true` from the agent unit to match the api unit. Critically, add the **rendered-template and root-mode integration tests** that were absent across A and KL — this is the structural gap that let the P0 and three P1s ship green, and it must be closed so the fixes above can't silently regress.

--- a/xiNAS-MCP/src/__tests__/agent/boot-sequence.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/boot-sequence.test.ts
@@ -169,4 +169,56 @@ describe('Boot sequence — initial sweep + agent_started', () => {
     expect(body.complete_snapshots).toEqual(['User']);
     expect(body.deltas).toEqual([]);
   });
+
+  // Regression: a FAILED initial sweep must NOT reconcile. deltas=[] from a
+  // throw means "unknown", not "no entities"; a complete_snapshots:[kind] flush
+  // would make the api delete every existing observed row for that kind, wiping
+  // good data on a transient probe failure at agent restart.
+  it('a FAILED initial sweep does not POST a reconcile batch for that kind', async () => {
+    const pub = new Publisher({
+      apiSocketPath: socketPath,
+      agentToken: 'tok',
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+    });
+
+    const registry = new CollectorRegistry();
+    // A collector whose probe transiently fails at boot.
+    registry.register({
+      kind: 'Disk',
+      async initialSweep() {
+        throw new Error('probe transient failure');
+      },
+      async start() {
+        /* no-op */
+      },
+      async stop() {
+        /* no-op */
+      },
+      health() {
+        return { state: 'error', reason: 'probe transient failure' };
+      },
+    });
+    // A healthy collector in the same boot — its reconcile must still happen.
+    registry.register(makeStubCollector('User', []));
+
+    await runBootSequence({
+      publisher: pub,
+      registry,
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+    });
+
+    const observedPosts = requestLog.filter((r) => r.path === '/internal/v1/observed');
+    // No Disk reconcile — the failed sweep was skipped, preserving existing state.
+    const diskReconcile = observedPosts.find((r) =>
+      (r.body as { complete_snapshots?: string[] }).complete_snapshots?.includes('Disk'),
+    );
+    expect(diskReconcile).toBeUndefined();
+    // The healthy User collector still reconciled.
+    const userReconcile = observedPosts.find((r) =>
+      (r.body as { complete_snapshots?: string[] }).complete_snapshots?.includes('User'),
+    );
+    expect(userReconcile).toBeDefined();
+    // agent_started still posts (boot completes despite one failed collector).
+    expect(requestLog.filter((r) => r.path === '/internal/v1/agent_started')).toHaveLength(1);
+  });
 });

--- a/xiNAS-MCP/src/__tests__/agent/config-template.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/config-template.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Rendered-template contract tests for the two Ansible config templates.
+ *
+ * WHY THIS EXISTS: the independent S0+S1 review found a P0 (the agent config
+ * template omitted `socket_group`, so the deployed socket was chowned
+ * root:root and the api heartbeat could never connect) and a P1 (the api
+ * config template never emitted `internalTokensPath`, so the agent token was
+ * never loaded and every observation push 401'd). BOTH shipped green because
+ * NO test rendered an Ansible template and asserted its key-set — the unit
+ * tests always hand-built config objects with the right keys. This test closes
+ * that structural gap: it renders each `.j2` (Jinja vars are not the point —
+ * the JSON SHAPE is) and asserts every key the runtime loader requires is
+ * present. If a key the loader reads is dropped from a template, this fails.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// src/__tests__/agent -> repo root is four levels up (agent -> __tests__ ->
+// src -> xiNAS-MCP -> ROOT). Templates live under ROOT/collection/roles/.
+const ROOT = resolve(HERE, '..', '..', '..', '..');
+
+/**
+ * Render a Jinja-templated JSON file to a parseable object. Every `{{ ... }}`
+ * expression — quoted ("{{ x }}" -> "0"), bare ({{ x }} -> 0), or embedded
+ * inside a string ("{{ x }}/foo" -> "0/foo") — is replaced with `0`, which is
+ * a valid JSON token in all three positions. The result is structurally the
+ * rendered config; only the placeholder *values* differ, and this test asserts
+ * on KEYS, not values.
+ */
+function renderTemplateKeys(relPath: string): Record<string, unknown> {
+  const raw = readFileSync(resolve(ROOT, relPath), 'utf8');
+  const substituted = raw.replace(/\{\{[^}]*\}\}/g, '0');
+  return JSON.parse(substituted) as Record<string, unknown>;
+}
+
+describe('xinas-agent config template (collection/roles/xinas_agent)', () => {
+  const cfg = renderTemplateKeys(
+    'collection/roles/xinas_agent/templates/xinas-agent-config.json.j2',
+  );
+
+  // Exactly the fields loadAgentConfig() reads off the on-disk JSON
+  // (src/agent/config.ts). socket_group is the one the P0 was missing.
+  const REQUIRED_KEYS = [
+    'api_socket',
+    'agent_socket',
+    'controller_id_path',
+    'agent_token_path',
+    'socket_group',
+    'heartbeat_interval_ms',
+  ];
+
+  for (const key of REQUIRED_KEYS) {
+    it(`emits ${key}`, () => {
+      expect(cfg).toHaveProperty(key);
+    });
+  }
+
+  it('socket_group is a non-empty string (chown target for the api↔agent socket)', () => {
+    // Rendered to "0" by the substitution; the point is the key is a JSON
+    // string position, not a bare/numeric one.
+    expect(typeof cfg['socket_group']).toBe('string');
+  });
+});
+
+describe('xinas-api config template (collection/roles/xinas_api)', () => {
+  const cfg = renderTemplateKeys('collection/roles/xinas_api/templates/xinas-api-config.json.j2');
+
+  // Keys loadConfig() reads (src/api/config.ts). internalTokensPath is the one
+  // the P1 was missing — without it loadConfig never merges internal-tokens.json
+  // and the agent bearer is unknown to the api.
+  const REQUIRED_KEYS = [
+    'controller_id',
+    'listen',
+    'tokens',
+    'agent',
+    'internalTokensPath',
+    'state',
+  ];
+
+  for (const key of REQUIRED_KEYS) {
+    it(`emits ${key}`, () => {
+      expect(cfg).toHaveProperty(key);
+    });
+  }
+
+  it('internalTokensPath points at internal-tokens.json', () => {
+    expect(String(cfg['internalTokensPath'])).toContain('internal-tokens.json');
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/poll.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/poll.test.ts
@@ -1,0 +1,153 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { type Server, createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  type Collector,
+  CollectorRegistry,
+  type Kind,
+  type ObservationDelta,
+} from '../../agent/collectors/base.js';
+import { PollDriver } from '../../agent/poll.js';
+import { Publisher } from '../../agent/publisher.js';
+
+/**
+ * A fake collector whose initialSweep returns a fixed set of deltas and whose
+ * pollIntervalMs is tunable so the driver can be exercised in <100ms.
+ */
+function fakeCollector(
+  kind: Kind,
+  deltas: ObservationDelta[],
+  pollIntervalMs?: number,
+): Collector<Kind> {
+  return {
+    kind,
+    async initialSweep() {
+      return deltas;
+    },
+    async start() {
+      /* no-op */
+    },
+    async stop() {
+      /* no-op */
+    },
+    health() {
+      return { state: 'running' };
+    },
+    ...(pollIntervalMs !== undefined ? { pollIntervalMs } : {}),
+  };
+}
+
+describe('PollDriver — steady-state re-sweep + reconcile (review F2/F3/F4)', () => {
+  let dir: string;
+  let socketPath: string;
+  let server: Server;
+  let observedPosts: Array<{ deltas: unknown[]; complete_snapshots: string[] }>;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'xinas-poll-test-'));
+    socketPath = join(dir, 'api.sock');
+    observedPosts = [];
+    await new Promise<void>((resolve) => {
+      server = createServer((req, res) => {
+        let body = '';
+        req.on('data', (c) => {
+          body += String(c);
+        });
+        req.on('end', () => {
+          if (req.url === '/internal/v1/observed') {
+            observedPosts.push(JSON.parse(body));
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ accepted: 1, deleted_by_reconcile: 0, state_revision: 1 }));
+        });
+      });
+      server.listen(socketPath, resolve);
+    });
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function makePublisher(): Publisher {
+    return new Publisher({
+      apiSocketPath: socketPath,
+      agentToken: 'tok',
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+      debounceMs: 0, // the driver flushes explicitly; isolate from the debounce path
+    });
+  }
+
+  it('re-sweeps a pollIntervalMs collector and POSTs a reconcile batch on its interval', async () => {
+    const pub = makePublisher();
+    const registry = new CollectorRegistry();
+    registry.register(
+      fakeCollector('NfsSession', [{ kind: 'NfsSession', id: 's1', op: 'upsert', value: {} }], 20),
+    );
+    const driver = new PollDriver({ registry, publisher: pub, backstopMs: 10_000 });
+    driver.start();
+    await new Promise((r) => setTimeout(r, 80));
+    driver.stop();
+    pub.dispose();
+
+    expect(observedPosts.length).toBeGreaterThanOrEqual(1);
+    // Each tick is a full snapshot → complete_snapshots names the kind.
+    expect(observedPosts[0]?.complete_snapshots).toContain('NfsSession');
+  });
+
+  it('uses the backstop interval for a collector with no pollIntervalMs', async () => {
+    const pub = makePublisher();
+    const registry = new CollectorRegistry();
+    // No pollIntervalMs → driven by the (overridden) backstop.
+    registry.register(fakeCollector('Disk', [{ kind: 'Disk', id: 'd1', op: 'upsert', value: {} }]));
+    const driver = new PollDriver({ registry, publisher: pub, backstopMs: 20 });
+    driver.start();
+    await new Promise((r) => setTimeout(r, 80));
+    driver.stop();
+    pub.dispose();
+
+    expect(observedPosts.length).toBeGreaterThanOrEqual(1);
+    expect(observedPosts[0]?.complete_snapshots).toContain('Disk');
+  });
+
+  it('consumes pendingReconcile: a kind marked after a dropped batch clears on the next tick', async () => {
+    const pub = makePublisher();
+    // Simulate a prior retry-exhaustion having marked NfsSession for reconcile.
+    pub.pendingReconcile.add('NfsSession');
+    expect(pub.needsReconcile('NfsSession')).toBe(true);
+
+    const registry = new CollectorRegistry();
+    registry.register(
+      fakeCollector('NfsSession', [{ kind: 'NfsSession', id: 's1', op: 'upsert', value: {} }], 20),
+    );
+    const driver = new PollDriver({ registry, publisher: pub, backstopMs: 10_000 });
+    driver.start();
+    await new Promise((r) => setTimeout(r, 80));
+    driver.stop();
+    pub.dispose();
+
+    // The full re-sweep + flushWithSnapshot reconciled the kind → cleared.
+    expect(pub.needsReconcile('NfsSession')).toBe(false);
+  });
+
+  it('stop() halts further sweeps', async () => {
+    const pub = makePublisher();
+    const registry = new CollectorRegistry();
+    registry.register(
+      fakeCollector('NfsSession', [{ kind: 'NfsSession', id: 's1', op: 'upsert', value: {} }], 20),
+    );
+    const driver = new PollDriver({ registry, publisher: pub, backstopMs: 10_000 });
+    driver.start();
+    await new Promise((r) => setTimeout(r, 60));
+    driver.stop();
+    const countAfterStop = observedPosts.length;
+    expect(countAfterStop).toBeGreaterThanOrEqual(1);
+    await new Promise((r) => setTimeout(r, 80));
+    pub.dispose();
+    // No new posts after stop().
+    expect(observedPosts.length).toBe(countAfterStop);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/publisher.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/publisher.test.ts
@@ -125,4 +125,63 @@ describe('Publisher — core enqueue + flush', () => {
     expect(receivedBodies.length).toBeGreaterThanOrEqual(1);
     expect((receivedBodies[0] as { deltas: unknown[] }).deltas.length).toBeGreaterThan(0);
   });
+
+  // Regression for the independent-review F1 finding: a single steady-state
+  // delta on a quiet node must flush via the debounce timer — without an
+  // explicit flush and without crossing a ceiling. Previously it sat in the
+  // queue forever and observed state froze after the boot sweep.
+  it('debounces a sub-ceiling enqueue and flushes it within the debounce window', async () => {
+    const pub = new Publisher({
+      apiSocketPath: socketPath,
+      agentToken: 'tok',
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+      debounceMs: 20,
+    });
+    pub.enqueue({ kind: 'Disk', id: 'nvme0n1', op: 'upsert', value: { name: 'x' } });
+    // No explicit flush — the debounce timer fires on its own.
+    await new Promise((r) => setTimeout(r, 80));
+    expect(receivedBodies).toHaveLength(1);
+    expect((receivedBodies[0] as { deltas: unknown[] }).deltas).toHaveLength(1);
+    pub.dispose();
+  });
+
+  it('debounceMs:0 disables the timed flush (delta waits for an explicit flush)', async () => {
+    const pub = new Publisher({
+      apiSocketPath: socketPath,
+      agentToken: 'tok',
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+      debounceMs: 0,
+    });
+    pub.enqueue({ kind: 'Disk', id: 'nvme0n1', op: 'upsert', value: { name: 'x' } });
+    await new Promise((r) => setTimeout(r, 60));
+    expect(receivedBodies).toHaveLength(0);
+    pub.dispose();
+  });
+
+  // Regression for the independent-review F (boot data-loss) finding: in boot
+  // mode the ceiling auto-flush is suppressed so a kind exceeding the ceiling is
+  // sent as ONE flushWithSnapshot reconcile batch — not a partial flush (no
+  // reconcile) that the trailing reconcile batch would then delete.
+  it('boot mode suppresses the ceiling flush; the kind is sent as one reconcile batch', async () => {
+    const pub = new Publisher({
+      apiSocketPath: socketPath,
+      agentToken: 'tok',
+      controllerId: '00000000-0000-0000-0000-0000000000aa',
+      maxBatchSize: 3, // would normally early-flush after 3 entries
+      debounceMs: 0,
+    });
+    pub.setBootMode(true);
+    for (let i = 0; i < 5; i++) {
+      pub.enqueue({ kind: 'Disk', id: `d${i}`, op: 'upsert', value: {} });
+    }
+    // No early flush despite exceeding maxBatchSize=3.
+    expect(receivedBodies).toHaveLength(0);
+    await pub.flushWithSnapshot(['Disk']);
+    expect(receivedBodies).toHaveLength(1);
+    const body = receivedBodies[0] as { deltas: unknown[]; complete_snapshots: string[] };
+    expect(body.deltas).toHaveLength(5);
+    expect(body.complete_snapshots).toEqual(['Disk']);
+    pub.setBootMode(false);
+    pub.dispose();
+  });
 });

--- a/xiNAS-MCP/src/__tests__/agent/rpc/methods/stubs.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/rpc/methods/stubs.test.ts
@@ -22,6 +22,15 @@ describe('makeStubHandler', () => {
 // ---- all ADR-0002 enumerated methods are in the stub list ----
 
 const REQUIRED_STUB_METHODS = [
+  // On-demand observation reads (deferred to WS12; push model is live in S0/S1).
+  'inventory.collect',
+  'disks.list',
+  'filesystems.list',
+  'mounts.list',
+  'network.snapshot',
+  'systemd.units_status',
+  'exports.list',
+  'nfs.sessions.list',
   'arrays.create',
   'arrays.delete',
   'arrays.import',

--- a/xiNAS-MCP/src/__tests__/api/heartbeat.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/heartbeat.test.ts
@@ -147,4 +147,59 @@ describe('HeartbeatTracker — state transitions', () => {
     tracker.recordHeartbeatSuccess(new Date());
     expect(tracker.currentWarnings({ routeIsMutating: true })).toHaveLength(0);
   });
+
+  // Regression for the independent-review J finding: an on-schedule heartbeat
+  // whose agent.health reports a collector in error must read as `degraded`
+  // (spec §668), not `healthy`. The tracker previously ignored #collectors.
+  describe('collector-error → degraded (review J, spec §668)', () => {
+    it('downgrades a fresh heartbeat to degraded when a collector is in error', () => {
+      const tracker = makeTracker();
+      tracker.recordHeartbeatSuccess(new Date(), {
+        version: '1.0.0',
+        collectors: { Disk: 'running', SystemdUnit: 'error: systemd dbus probe unavailable' },
+      });
+      expect(tracker.currentState()).toBe('degraded');
+    });
+
+    it('stays healthy when all collectors are running/stubbed (stubbed is not a fault)', () => {
+      const tracker = makeTracker();
+      tracker.recordHeartbeatSuccess(new Date(), {
+        version: '1.0.0',
+        collectors: { Disk: 'running', XiraidArray: 'stubbed' },
+      });
+      expect(tracker.currentState()).toBe('healthy');
+    });
+
+    it('emits EXECUTOR_DEGRADED on mutating routes when a collector errors', () => {
+      const tracker = makeTracker();
+      tracker.recordHeartbeatSuccess(new Date(), {
+        collectors: { SystemdUnit: 'error: dbus unavailable' },
+      });
+      const warnings = tracker.currentWarnings({ routeIsMutating: true });
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.code).toBe('EXECUTOR_DEGRADED');
+    });
+
+    it('a collector error does NOT override offline (connect-refused wins)', () => {
+      const tracker = makeTracker();
+      tracker.recordHeartbeatSuccess(new Date(), {
+        collectors: { SystemdUnit: 'error: dbus unavailable' },
+      });
+      tracker.recordHeartbeatFailure(new Date(), { connectRefused: true });
+      expect(tracker.currentState()).toBe('offline');
+    });
+
+    it('clears back to healthy once the collector recovers', () => {
+      const tracker = makeTracker();
+      const t0 = new Date('2026-05-28T12:00:00.000Z');
+      vi.setSystemTime(t0);
+      tracker.recordHeartbeatSuccess(t0, { collectors: { SystemdUnit: 'error: boom' } });
+      expect(tracker.currentState()).toBe('degraded');
+      // Next heartbeat reports the collector running again.
+      tracker.recordHeartbeatSuccess(new Date(t0.getTime() + 1_000), {
+        collectors: { SystemdUnit: 'running' },
+      });
+      expect(tracker.currentState()).toBe('healthy');
+    });
+  });
 });

--- a/xiNAS-MCP/src/__tests__/api/internal-observed-schema.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/internal-observed-schema.test.ts
@@ -213,3 +213,137 @@ describe('POST /internal/v1/observed — schema enforcement (J3)', () => {
     expect(res.body.errors[0]?.message).toMatch(/unknown kind/);
   });
 });
+
+/**
+ * Regression for the independent-review E/J finding: the agent's OWN collectors
+ * emit XiraidArray, managed_files, and inventory deltas, but OBSERVED_KINDS
+ * omitted the first two and `inventory` was schema-less (so it 400'd). Each
+ * rejected kind fail-closes the whole batch and the publisher drops it as a
+ * non-retryable 4xx — so on a real node these (and any co-batched real kind)
+ * were silently lost. All three must now be ACCEPTED.
+ */
+describe('POST /internal/v1/observed — agent-emitted kinds are accepted (review E/J)', () => {
+  let setup: TestSetup & { cleanup(): Promise<void>; observedLoaded: boolean };
+
+  beforeEach(async () => {
+    setup = await buildAppWithSchemas();
+  });
+
+  afterEach(() => setup.cleanup());
+
+  /** The exact `_stub` deferral row the XiraidArray/managed_files stubs emit. */
+  function stubRow(kind: string, reason: string): Record<string, unknown> {
+    return {
+      kind,
+      id: '_stub',
+      status: { deferred: true, reason, observed_at: new Date().toISOString() },
+    };
+  }
+
+  it('accepts the XiraidArray _stub deferral row (200, stored)', async () => {
+    const res = await request(setup.app)
+      .post('/internal/v1/observed')
+      .set('Authorization', `Bearer ${AGENT_TOKEN}`)
+      .send({
+        observed_at: new Date().toISOString(),
+        controller_id: CONTROLLER_ID,
+        deltas: [
+          {
+            kind: 'XiraidArray',
+            id: '_stub',
+            op: 'upsert',
+            value: stubRow('XiraidArray', 'XIRAID_ADAPTER_DEFERRED'),
+          },
+        ],
+        complete_snapshots: ['XiraidArray'],
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.result.accepted).toBe(1);
+    expect(setup.state.kv.get('/xinas/v1/observed/XiraidArray/_stub')).not.toBeNull();
+  });
+
+  it('accepts the managed_files _stub deferral row (schema-less kind, 200, stored)', async () => {
+    const res = await request(setup.app)
+      .post('/internal/v1/observed')
+      .set('Authorization', `Bearer ${AGENT_TOKEN}`)
+      .send({
+        observed_at: new Date().toISOString(),
+        controller_id: CONTROLLER_ID,
+        deltas: [
+          {
+            kind: 'managed_files',
+            id: '_stub',
+            op: 'upsert',
+            value: stubRow('managed_files', 'DRIFT_FRAMEWORK_DEFERRED'),
+          },
+        ],
+        complete_snapshots: ['managed_files'],
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.result.accepted).toBe(1);
+    expect(setup.state.kv.get('/xinas/v1/observed/managed_files/_stub')).not.toBeNull();
+  });
+
+  it('accepts an inventory upsert (schema-less kind, 200, stored)', async () => {
+    const res = await request(setup.app)
+      .post('/internal/v1/observed')
+      .set('Authorization', `Bearer ${AGENT_TOKEN}`)
+      .send({
+        observed_at: new Date().toISOString(),
+        controller_id: CONTROLLER_ID,
+        deltas: [
+          {
+            kind: 'inventory',
+            id: 'node',
+            op: 'upsert',
+            value: { kind: 'inventory', id: 'node', status: { hostname: 'test-host' } },
+          },
+        ],
+        complete_snapshots: ['inventory'],
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.result.accepted).toBe(1);
+    expect(setup.state.kv.get('/xinas/v1/observed/inventory/node')).not.toBeNull();
+  });
+
+  it('co-batch integrity: a previously-broken kind no longer fail-closes a real co-batched kind', async () => {
+    // The agent ships NfsSession + ExportRule in one batch, and the boot sweep
+    // mixes kinds. Before the fix, one rejected kind dropped the whole batch.
+    // Here XiraidArray (was broken) rides with a valid NfsSession; both persist.
+    const res = await request(setup.app)
+      .post('/internal/v1/observed')
+      .set('Authorization', `Bearer ${AGENT_TOKEN}`)
+      .send({
+        observed_at: new Date().toISOString(),
+        controller_id: CONTROLLER_ID,
+        deltas: [
+          {
+            kind: 'NfsSession',
+            id: '10.1.2.3:share01',
+            op: 'upsert',
+            value: {
+              kind: 'NfsSession',
+              id: '10.1.2.3:share01',
+              spec: { client_addr: '10.1.2.3', export_path: '/srv/nfs/share01' },
+              status: {
+                proto_version: 'v4.2',
+                locked_files: 0,
+                observed_at: new Date().toISOString(),
+              },
+            },
+          },
+          {
+            kind: 'XiraidArray',
+            id: '_stub',
+            op: 'upsert',
+            value: stubRow('XiraidArray', 'XIRAID_ADAPTER_DEFERRED'),
+          },
+        ],
+        complete_snapshots: [],
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.result.accepted).toBe(2);
+    expect(setup.state.kv.get('/xinas/v1/observed/NfsSession/10.1.2.3:share01')).not.toBeNull();
+    expect(setup.state.kv.get('/xinas/v1/observed/XiraidArray/_stub')).not.toBeNull();
+  });
+});

--- a/xiNAS-MCP/src/__tests__/api/read-metadata.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/read-metadata.test.ts
@@ -1,0 +1,73 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ADMIN_TOKEN, buildTestApp } from './_helpers.js';
+
+/**
+ * Regression for the independent-review #6 finding: public observed-resource
+ * responses omitted the api-v1.yaml-required `metadata` object. The KV layer
+ * tracks revision/created_at/modified_at/owner/source/validation_status PER ROW
+ * (not inside the stored value), so the read path must project them into the
+ * response. embedMetadata()/unwrapResources() now do that for resource reads.
+ */
+describe('read path embeds the schema-required metadata (review #6)', () => {
+  let setup: Awaited<ReturnType<typeof buildTestApp>>;
+
+  beforeEach(async () => {
+    setup = await buildTestApp();
+    // The agent's observed value carries NO metadata (collectors emit partial
+    // shapes); the KV row supplies the tracking fields.
+    setup.state.kv.put('/xinas/v1/observed/User/1000', {
+      kind: 'User',
+      id: '1000',
+      status: { uid: 1000, name: 'alice', source: 'nss' },
+    });
+  });
+
+  afterEach(async () => {
+    await setup.cleanup();
+  });
+
+  function assertMetadata(meta: Record<string, unknown>): void {
+    expect(typeof meta.revision).toBe('number');
+    // created_at / modified_at are projected as ISO-8601 date-time strings.
+    expect(typeof meta.created_at).toBe('string');
+    expect(Number.isNaN(Date.parse(meta.created_at as string))).toBe(false);
+    expect(typeof meta.modified_at).toBe('string');
+    expect(Number.isNaN(Date.parse(meta.modified_at as string))).toBe(false);
+    expect(typeof meta.owner).toBe('string');
+    expect(typeof meta.source).toBe('string');
+    expect(['valid', 'drift', 'invalid', 'pending']).toContain(meta.validation_status);
+  }
+
+  it('GET /api/v1/users/{uid} returns a metadata object', async () => {
+    const res = await request(setup.app)
+      .get('/api/v1/users/1000')
+      .set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result.metadata).toBeDefined();
+    assertMetadata(res.body.result.metadata);
+    // The stored value is preserved alongside the injected metadata.
+    expect(res.body.result.status.name).toBe('alice');
+  });
+
+  it('GET /api/v1/users list embeds metadata on each row', async () => {
+    const res = await request(setup.app).get('/api/v1/users').set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result).toHaveLength(1);
+    assertMetadata(res.body.result[0].metadata);
+  });
+
+  it('event records (non-resources) are NOT given synthesized metadata', async () => {
+    // Events are echoed raw via unwrapValues — they have no Metadata schema.
+    setup.state.kv.put('/xinas/v1/events/2026-06-03T00:00:00.000Z/evt1', {
+      kind: 'agent_state_changed',
+      from: 'offline',
+      to: 'healthy',
+    });
+    const res = await request(setup.app).get('/api/v1/events').set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    const evt = res.body.result.find((e: { kind?: string }) => e.kind === 'agent_state_changed');
+    expect(evt).toBeDefined();
+    expect(evt.metadata).toBeUndefined();
+  });
+});

--- a/xiNAS-MCP/src/__tests__/api/routes-nfs-exports-join.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/routes-nfs-exports-join.test.ts
@@ -10,12 +10,14 @@ describe('Share read-join: status.exports[] populated from observed ExportRule',
 
   beforeEach(async () => {
     setup = await buildTestApp();
+    // Real Share shape: only spec.path (the exported directory). It has NO
+    // export_path — the join keys share.spec.path against the observed
+    // ExportRule's spec.export_path, which the agent stamps with that same dir.
     setup.state.kv.put(`/xinas/v1/desired/Share/${SHARE_ID}`, {
       kind: 'Share',
       id: SHARE_ID,
       spec: {
-        path: '/data/share01',
-        export_path: EXPORT_PATH,
+        path: EXPORT_PATH,
         clients: [{ pattern: '10.0.0.0/8', options: ['rw', 'sync'] }],
         fsid: 42,
       },

--- a/xiNAS-MCP/src/__tests__/api/routes-nfs-sessions.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/routes-nfs-sessions.test.ts
@@ -11,12 +11,13 @@ describe('GET /api/v1/shares/{id}/sessions — populated from observed state', (
   beforeEach(async () => {
     setup = await buildTestApp();
 
+    // Real Share shape: only spec.path (the exported directory, no export_path).
+    // The sessions join keys share.spec.path against NfsSession.spec.export_path.
     setup.state.kv.put(`/xinas/v1/desired/Share/${SHARE_ID}`, {
       kind: 'Share',
       id: SHARE_ID,
       spec: {
-        path: '/data/share01',
-        export_path: EXPORT_PATH,
+        path: EXPORT_PATH,
         clients: [{ pattern: '10.0.0.0/8', options: ['rw', 'sync'] }],
         fsid: 42,
       },

--- a/xiNAS-MCP/src/agent-server.ts
+++ b/xiNAS-MCP/src/agent-server.ts
@@ -101,7 +101,15 @@ async function main(): Promise<void> {
       process.exit(0);
     }, 3000);
     forced.unref?.();
-    // Stop collectors FIRST so their event subprocesses (udevadm / ip
+    // Stop the steady-state poll driver and the publisher's debounce timer
+    // FIRST so no new sweep/flush starts while collectors are being torn down.
+    try {
+      convergence.pollDriver.stop();
+      convergence.publisher.dispose();
+    } catch {
+      /* ignore — both are best-effort timer teardown */
+    }
+    // Stop collectors next so their event subprocesses (udevadm / ip
     // monitor) and the subprocess-monitor restart timers are torn down and
     // don't survive past shutdown. allSettled inside registry.stop() means
     // one stubborn collector can't block the rest; the 3s timer is the

--- a/xiNAS-MCP/src/agent/boot.ts
+++ b/xiNAS-MCP/src/agent/boot.ts
@@ -33,7 +33,7 @@ export async function runBootSequence(opts: BootSequenceOptions): Promise<void> 
   publisher.setBootMode(true);
   try {
     for (const collector of registry.list()) {
-      let deltas: ObservationDelta[] = [];
+      let deltas: ObservationDelta[];
       try {
         deltas = await collector.initialSweep();
       } catch (err) {
@@ -47,7 +47,14 @@ export async function runBootSequence(opts: BootSequenceOptions): Promise<void> 
             error: err instanceof Error ? err.message : String(err),
           })}\n`,
         );
-        deltas = [];
+        // Do NOT reconcile on a FAILED sweep. An empty result here means
+        // "unknown", not "no entities" — sending flushWithSnapshot([kind])
+        // (complete_snapshots:[kind]) would make the api reconcile-DELETE every
+        // existing observed row for this kind, wiping good data on a transient
+        // probe failure. Skip this collector entirely: its health=error already
+        // surfaces the failure via agent.health, and the poll backstop
+        // (PollDriver) re-sweeps + reconciles once the probe recovers.
+        continue;
       }
       for (const delta of deltas) {
         publisher.enqueue(delta);

--- a/xiNAS-MCP/src/agent/boot.ts
+++ b/xiNAS-MCP/src/agent/boot.ts
@@ -25,28 +25,38 @@ export interface BootSequenceOptions {
 export async function runBootSequence(opts: BootSequenceOptions): Promise<void> {
   const { publisher, registry, controllerId } = opts;
 
-  for (const collector of registry.list()) {
-    let deltas: ObservationDelta[] = [];
-    try {
-      deltas = await collector.initialSweep();
-    } catch (err) {
-      process.stderr.write(
-        `${JSON.stringify({
-          time: new Date().toISOString(),
-          level: 'error',
-          subsystem: 'boot',
-          event: 'initial_sweep_failed',
-          kind: collector.kind,
-          error: err instanceof Error ? err.message : String(err),
-        })}\n`,
-      );
-      deltas = [];
+  // Boot mode: suppress enqueue's ceiling/debounce auto-flush so each kind is
+  // sent as exactly ONE flushWithSnapshot([kind]) reconcile batch below. Without
+  // this, a kind exceeding 256/1MB would early-flush a partial (no reconcile),
+  // then the trailing flushWithSnapshot would reconcile-delete it. Restored in
+  // the finally so steady-state debounce/ceiling resume after boot.
+  publisher.setBootMode(true);
+  try {
+    for (const collector of registry.list()) {
+      let deltas: ObservationDelta[] = [];
+      try {
+        deltas = await collector.initialSweep();
+      } catch (err) {
+        process.stderr.write(
+          `${JSON.stringify({
+            time: new Date().toISOString(),
+            level: 'error',
+            subsystem: 'boot',
+            event: 'initial_sweep_failed',
+            kind: collector.kind,
+            error: err instanceof Error ? err.message : String(err),
+          })}\n`,
+        );
+        deltas = [];
+      }
+      for (const delta of deltas) {
+        publisher.enqueue(delta);
+      }
+      const kinds = new Set<Kind>([collector.kind, ...deltas.map((d) => d.kind)]);
+      await publisher.flushWithSnapshot([...kinds]);
     }
-    for (const delta of deltas) {
-      publisher.enqueue(delta);
-    }
-    const kinds = new Set<Kind>([collector.kind, ...deltas.map((d) => d.kind)]);
-    await publisher.flushWithSnapshot([...kinds]);
+  } finally {
+    publisher.setBootMode(false);
   }
 
   await publisher.postOnce('/internal/v1/agent_started', { controller_id: controllerId });

--- a/xiNAS-MCP/src/agent/convergence.ts
+++ b/xiNAS-MCP/src/agent/convergence.ts
@@ -58,6 +58,7 @@ import { SystemdUnitCollector } from './collectors/systemd.js';
 import { UsersCollector } from './collectors/users.js';
 import type { AgentConfig } from './config.js';
 import { log } from './log.js';
+import { PollDriver } from './poll.js';
 import { createDiskProbe } from './probe/disk.js';
 import { createFilesystemProbe } from './probe/filesystem.js';
 import {
@@ -90,6 +91,7 @@ const NOOP_HANDLE: SyncStopHandle = { stop(): void {} };
 export interface Convergence {
   registry: CollectorRegistry;
   publisher: Publisher;
+  pollDriver: PollDriver;
   controllerId: string;
 }
 
@@ -318,7 +320,12 @@ export function buildConvergence(config: AgentConfig): Convergence {
     controllerId: config.controller_id,
   });
 
-  return { registry, publisher, controllerId: config.controller_id };
+  // Steady-state poll/backstop driver (started in runConvergence after the
+  // boot sweep). Drives pollIntervalMs collectors + the 5-min reconcile
+  // backstop and consumes publisher.pendingReconcile.
+  const pollDriver = new PollDriver({ registry, publisher });
+
+  return { registry, publisher, pollDriver, controllerId: config.controller_id };
 }
 
 /**
@@ -332,7 +339,7 @@ export function buildConvergence(config: AgentConfig): Convergence {
  * caller's `void runConvergence()` never produces an unhandled rejection.
  */
 export async function runConvergence(c: Convergence): Promise<void> {
-  const { registry, publisher, controllerId } = c;
+  const { registry, publisher, pollDriver, controllerId } = c;
   try {
     await runBootSequence({ publisher, registry, controllerId });
   } catch (err) {
@@ -344,6 +351,16 @@ export async function runConvergence(c: Convergence): Promise<void> {
     await registry.start((delta) => publisher.enqueue(delta));
   } catch (err) {
     log('error', 'boot', 'registry_start_failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  // Start the steady-state poll/backstop loop AFTER the boot sweep + event
+  // streams. Pure timer setup — never throws — but guard anyway so a future
+  // change can't break convergence startup.
+  try {
+    pollDriver.start();
+  } catch (err) {
+    log('error', 'boot', 'poll_driver_start_failed', {
       error: err instanceof Error ? err.message : String(err),
     });
   }

--- a/xiNAS-MCP/src/agent/poll.ts
+++ b/xiNAS-MCP/src/agent/poll.ts
@@ -1,0 +1,78 @@
+import type { Collector, CollectorRegistry, Kind } from './collectors/base.js';
+import { log } from './log.js';
+import type { Publisher } from './publisher.js';
+
+/**
+ * Default backstop reconcile interval for collectors that declare no
+ * pollIntervalMs (event-driven kinds like Disk/Network). Spec Flow C/D
+ * mandates a ~5-minute full reconcile so a missed/lost kernel event can't
+ * leave observed state permanently stale.
+ */
+const DEFAULT_BACKSTOP_MS = 300_000;
+
+export interface PollDriverOptions {
+  registry: CollectorRegistry;
+  publisher: Publisher;
+  /** Override the 5-min backstop interval (tests). */
+  backstopMs?: number;
+}
+
+/**
+ * Drives the steady-state observation refresh that event streams alone don't
+ * cover (spec Flow C/D). Without it, a quiet node's observed state freezes
+ * after the boot sweep and an api-outage drop never recovers — the exact F2/F3
+ * gap the independent review found (`pollIntervalMs` had no consumer and
+ * `pendingReconcile` was never read).
+ *
+ * Per registered collector it arms ONE interval:
+ *   - collectors WITH pollIntervalMs (NFS, NfsIdmap, Inventory, Users, …) — many
+ *     of which have no event source at all — re-sweep on their own interval;
+ *   - collectors WITHOUT one (event-driven Disk/Network) get the 5-min backstop.
+ *
+ * Each tick runs a FULL initialSweep() + flushWithSnapshot([kinds]). Because
+ * that is a complete snapshot with reconcile, it also CONSUMES
+ * publisher.pendingReconcile (F4): a kind marked after a dropped batch is
+ * re-swept and reconciled on its next tick, and flush success clears it from
+ * the set. The poll is the "next tick" the retry path was waiting on.
+ */
+export class PollDriver {
+  readonly #timers: Array<ReturnType<typeof setInterval>> = [];
+  #started = false;
+
+  constructor(private readonly opts: PollDriverOptions) {}
+
+  start(): void {
+    if (this.#started) return;
+    this.#started = true;
+    const backstop = this.opts.backstopMs ?? DEFAULT_BACKSTOP_MS;
+    for (const collector of this.opts.registry.list()) {
+      const interval = collector.pollIntervalMs ?? backstop;
+      const timer = setInterval(() => void this.#sweep(collector), interval);
+      // Never keep the process (or a test runner) alive on the poll timer.
+      timer.unref?.();
+      this.#timers.push(timer);
+    }
+  }
+
+  stop(): void {
+    for (const timer of this.#timers) clearInterval(timer);
+    this.#timers.length = 0;
+    this.#started = false;
+  }
+
+  /** Full re-sweep + reconcile for one collector. Absorbs every error so a
+   *  single failing collector can't crash the interval callback. */
+  async #sweep(collector: Collector): Promise<void> {
+    try {
+      const deltas = await collector.initialSweep();
+      for (const delta of deltas) this.opts.publisher.enqueue(delta);
+      const kinds = new Set<Kind>([collector.kind, ...deltas.map((d) => d.kind)]);
+      await this.opts.publisher.flushWithSnapshot([...kinds]);
+    } catch (err) {
+      log('error', 'poll', 'poll_sweep_failed', {
+        kind: collector.kind,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}

--- a/xiNAS-MCP/src/agent/publisher.ts
+++ b/xiNAS-MCP/src/agent/publisher.ts
@@ -16,6 +16,16 @@ export interface PublisherOptions {
   retryBaseMs?: number;
   /** Maximum retry attempts. Default: 5. */
   maxRetries?: number;
+  /**
+   * Debounced steady-state flush window in ms (spec §217/§249, ~50–100ms).
+   * Every enqueue that does NOT cross a ceiling arms a single timer; the queue
+   * flushes ~debounceMs after the FIRST event in the window (leading-arm, not
+   * reset-on-each — so a burst batches and a continuous stream can't starve).
+   * Without this a single event on a quiet node sits in the queue forever.
+   * Default: 75. Set to 0 to disable (used by boot/unit tests that flush
+   * explicitly).
+   */
+  debounceMs?: number;
 }
 
 interface PostResult {
@@ -38,6 +48,17 @@ export class Publisher {
   #queue: ObservationDelta[] = [];
   /** Running serialized-byte estimate of #queue, for the maxBatchBytes cap. */
   #queueBytes = 0;
+  /** Armed by enqueue in steady state; fires a debounced flush. */
+  #debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * While true (during the boot sweep), enqueue does NOT auto-flush at a
+   * ceiling or arm a debounce timer. The boot sequence flushes each kind
+   * explicitly with complete_snapshots:[kind]; suppressing the ceiling flush
+   * means a kind that exceeds 256/1MB on boot is sent as ONE reconcile batch
+   * rather than a partial complete_snapshots:[] flush (which the api would
+   * reconcile-delete) followed by the remainder — i.e. no boot data loss.
+   */
+  #bootMode = false;
 
   /** Public so collectors can read and tests can inspect. */
   readonly pendingReconcile: Set<Kind> = new Set();
@@ -48,6 +69,7 @@ export class Publisher {
       maxBatchBytes: 1_048_576,
       retryBaseMs: 250,
       maxRetries: 5,
+      debounceMs: 75,
       ...opts,
     };
   }
@@ -55,6 +77,9 @@ export class Publisher {
   enqueue(delta: ObservationDelta): void {
     this.#queue.push(delta);
     this.#queueBytes += Buffer.byteLength(JSON.stringify(delta));
+    // During the boot sweep, defer entirely to the explicit per-kind
+    // flushWithSnapshot — no ceiling flush, no debounce (see #bootMode).
+    if (this.#bootMode) return;
     // Early flush at EITHER ceiling (spec: 256 entries or 1 MB). The
     // .catch keeps this fire-and-forget flush from ever surfacing an
     // unhandled rejection — #doFlush is written to resolve on every
@@ -64,7 +89,40 @@ export class Publisher {
       this.#queue.length >= this.#opts.maxBatchSize ||
       this.#queueBytes >= this.#opts.maxBatchBytes
     ) {
+      this.#clearDebounce();
       void this.flush().catch(() => {});
+      return;
+    }
+    // Below the ceiling: arm a debounced flush so a single steady-state event
+    // doesn't sit in the queue forever on a quiet node.
+    this.#armDebounce();
+  }
+
+  /** Toggle boot mode (see #bootMode). Turning it off does NOT auto-flush —
+   *  the boot sequence has already flushed every kind explicitly. */
+  setBootMode(on: boolean): void {
+    this.#bootMode = on;
+  }
+
+  /** Clear the debounce timer (clean shutdown). Safe to call repeatedly. */
+  dispose(): void {
+    this.#clearDebounce();
+  }
+
+  #armDebounce(): void {
+    if (this.#opts.debounceMs <= 0) return;
+    if (this.#debounceTimer !== null) return; // leading-arm: don't reset
+    this.#debounceTimer = setTimeout(() => {
+      this.#debounceTimer = null;
+      void this.flush().catch(() => {});
+    }, this.#opts.debounceMs);
+    this.#debounceTimer.unref?.();
+  }
+
+  #clearDebounce(): void {
+    if (this.#debounceTimer !== null) {
+      clearTimeout(this.#debounceTimer);
+      this.#debounceTimer = null;
     }
   }
 
@@ -86,6 +144,9 @@ export class Publisher {
   }
 
   async #doFlush(completeSnapshots: Kind[]): Promise<void> {
+    // We're flushing now — cancel any pending debounce so it doesn't fire a
+    // redundant empty flush after the queue is drained below.
+    this.#clearDebounce();
     if (this.#queue.length === 0 && completeSnapshots.length === 0) return;
 
     const batch = this.#queue.splice(0);

--- a/xiNAS-MCP/src/agent/rpc/methods/stubs.ts
+++ b/xiNAS-MCP/src/agent/rpc/methods/stubs.ts
@@ -32,6 +32,20 @@ export function makeStubHandler(method: string): RpcHandler {
 }
 
 const STUB_METHOD_NAMES = [
+  // On-demand observation reads (deferred to WS12 convergence). The spec's RPC
+  // table once marked these "Real", but the LIVE data path in S0/S1 is the push
+  // model (Flow A: collectors -> publisher -> POST /internal/v1/observed); no
+  // S0/S1 caller uses the on-demand pull surface. Registering them here makes
+  // them enumerated-but-stubbed (EXECUTOR_UNSUPPORTED) instead of an unknown
+  // -32601, which is the correct contract signal until WS12 wires the reads.
+  'inventory.collect',
+  'disks.list',
+  'filesystems.list',
+  'mounts.list',
+  'network.snapshot',
+  'systemd.units_status',
+  'exports.list',
+  'nfs.sessions.list',
   // Arrays (xiRAID adapter — S3/WS5)
   'arrays.create',
   'arrays.delete',

--- a/xiNAS-MCP/src/api/handlers/reads.ts
+++ b/xiNAS-MCP/src/api/handlers/reads.ts
@@ -40,7 +40,37 @@ export function getOrNull<T>(state: OpenedStateStore, key: string): RevisionedVa
   return state.kv.get<T>(key);
 }
 
-/** Unwrap an array of RevisionedValue to just the values. */
+/** Unwrap an array of RevisionedValue to just the values (raw — no metadata).
+ *  Use for non-resource records (events, audit) that have no Metadata schema. */
 export function unwrapValues<T>(rows: RevisionedValue<T>[]): T[] {
   return rows.map((r) => r.value);
+}
+
+/**
+ * Synthesize the api-v1.yaml `metadata` object from a RevisionedValue's row
+ * tracking and embed it into the value. The KV layer tracks revision +
+ * created_at/modified_at + owner/source/validation_status PER ROW, not inside
+ * the stored value — so a public resource read that returns the raw value omits
+ * the schema-required `metadata`. Every resource schema ($ref Metadata, required)
+ * needs this projection at read time. Non-object values are returned unchanged.
+ */
+export function embedMetadata<T>(row: RevisionedValue<T>): T {
+  const value = row.value;
+  if (value === null || typeof value !== 'object') return value;
+  return {
+    ...(value as Record<string, unknown>),
+    metadata: {
+      revision: row.revision,
+      created_at: new Date(row.created_at).toISOString(),
+      modified_at: new Date(row.modified_at).toISOString(),
+      owner: row.owner,
+      source: row.source,
+      validation_status: row.validation_status,
+    },
+  } as T;
+}
+
+/** Like unwrapValues, but embeds the synthesized metadata into each resource. */
+export function unwrapResources<T>(rows: RevisionedValue<T>[]): T[] {
+  return rows.map(embedMetadata);
 }

--- a/xiNAS-MCP/src/api/heartbeat.ts
+++ b/xiNAS-MCP/src/api/heartbeat.ts
@@ -302,9 +302,34 @@ export class HeartbeatTracker {
     const elapsedMs = nowMs - this.#lastHeartbeatAt.getTime();
     const { intervalMs } = this.#opts;
 
-    if (elapsedMs <= 2 * intervalMs) return 'healthy';
-    if (elapsedMs <= 6 * intervalMs) return 'degraded';
-    return 'offline';
+    let timeState: AgentState;
+    if (elapsedMs <= 2 * intervalMs) timeState = 'healthy';
+    else if (elapsedMs <= 6 * intervalMs) timeState = 'degraded';
+    else timeState = 'offline';
+
+    // Spec §668: a collector reporting error degrades the node even when the
+    // heartbeat itself is on schedule. The agent computes status='degraded' in
+    // its agent.health result, but the api derives state independently, so the
+    // captured #collectors map (set on every successful heartbeat) must be
+    // consulted here — otherwise a fully-degraded agent reads as `healthy` and
+    // mutating routes never emit the EXECUTOR_DEGRADED warning (§312/§702).
+    // Only downgrade an otherwise-healthy node; an already degraded/offline
+    // (stale/unreachable) heartbeat is strictly worse and is preserved.
+    if (timeState === 'healthy' && this.#hasCollectorError()) return 'degraded';
+    return timeState;
+  }
+
+  /**
+   * True when any captured collector health string denotes an error. The
+   * registry serializes an errored collector as `error: <reason>` (see
+   * CollectorRegistry.healthSnapshot); `running` / `stubbed` do NOT degrade —
+   * a stubbed (deferred) collector is an expected state, not a fault.
+   */
+  #hasCollectorError(): boolean {
+    for (const health of Object.values(this.#collectors)) {
+      if (health.startsWith('error')) return true;
+    }
+    return false;
   }
 
   #emitStateChange(from: AgentState, to: AgentState): void {

--- a/xiNAS-MCP/src/api/observed-schemas.ts
+++ b/xiNAS-MCP/src/api/observed-schemas.ts
@@ -23,11 +23,21 @@ const addFormats = addFormatsImport as any;
 export type ValidateFn = ((data: unknown) => boolean) & { errors?: unknown };
 
 /**
- * Observed kinds the agent pushes through /internal/v1/observed whose
- * kind-object schema from api-v1.yaml is compiled into a TYPE-ONLY inbound
+ * Observed kinds the agent pushes through /internal/v1/observed. This list MUST
+ * be kept exhaustively in sync with every `kind` the agent's collectors emit
+ * (see src/agent/collectors/base.ts `Kind`), because a delta whose kind is not
+ * here is rejected as an "unknown kind" 400 — which fail-closes the WHOLE batch
+ * and silently drops every co-batched real kind (e.g. an absent ExportRule
+ * would poison the NfsSession deltas it ships with). The independent S0+S1
+ * review found `XiraidArray` and `managed_files` missing here, and `inventory`
+ * present but schema-less (so it 400'd too), causing exactly that batch loss.
+ *
+ * Each kind WITH a kind-object schema in api-v1.yaml gets a TYPE-ONLY inbound
  * validator (see stripRequired + loadObservedSchemas for why completeness is
- * NOT enforced). `inventory` is lowercase to match its observedSegment; its
- * schema may not exist in api-v1.yaml, in which case it is silently skipped.
+ * NOT enforced). Each kind WITHOUT a schema (`inventory`, `managed_files` are
+ * lowercase intermediate/deferred kinds with no public schema) gets a
+ * permissive object-validator so it is still RECOGNIZED and accepted — inbound
+ * validation is a type/garbage net, not a completeness gate.
  */
 const OBSERVED_KINDS = [
   'Disk',
@@ -39,6 +49,8 @@ const OBSERVED_KINDS = [
   'User',
   'Group',
   'ExportRule',
+  'XiraidArray',
+  'managed_files',
   'inventory',
 ] as const;
 
@@ -162,11 +174,22 @@ export function loadObservedSchemas(): {
     // required-stripped subschemas when each kind schema is compiled.
     ajv.addSchema(strippedDoc, 'api-v1.yaml');
 
+    // Permissive validator for kinds with no api-v1.yaml schema: accept any
+    // structurally-valid (non-null) object. This is what makes a schema-less
+    // observed kind RECOGNIZED instead of 400'd as "unknown kind" (which would
+    // fail-close the batch). Type-completeness for these intermediate/deferred
+    // kinds is enforced by the public READ schema if/when one is added.
+    const acceptObject: ValidateFn = (data: unknown) => typeof data === 'object' && data !== null;
+
     const schemas: Record<string, ValidateFn> = {};
     for (const kind of OBSERVED_KINDS) {
-      // Guard against a kind absent from the spec (e.g. lowercase `inventory`).
-      if (!strippedDoc.components?.schemas?.[kind]) continue;
-      schemas[kind] = ajv.getSchema(`api-v1.yaml#/components/schemas/${kind}`) as ValidateFn;
+      // A kind in OBSERVED_KINDS is intended to be accepted. If it has a
+      // component schema, compile a TYPE-ONLY validator; otherwise (lowercase
+      // intermediate kinds like `inventory` / `managed_files`) register the
+      // permissive object-validator so the delta isn't rejected.
+      schemas[kind] = strippedDoc.components?.schemas?.[kind]
+        ? (ajv.getSchema(`api-v1.yaml#/components/schemas/${kind}`) as ValidateFn)
+        : acceptObject;
     }
 
     return {

--- a/xiNAS-MCP/src/api/routes/groups.ts
+++ b/xiNAS-MCP/src/api/routes/groups.ts
@@ -11,7 +11,13 @@
 import { Router } from 'express';
 import type { ApiContext } from '../context.js';
 import { ApiException } from '../errors.js';
-import { getOrNull, listByPrefix, sendOk, unwrapValues } from '../handlers/reads.js';
+import {
+  embedMetadata,
+  getOrNull,
+  listByPrefix,
+  sendOk,
+  unwrapResources,
+} from '../handlers/reads.js';
 
 export function groupsRouter(ctx: ApiContext): Router {
   const r = Router();
@@ -23,7 +29,7 @@ export function groupsRouter(ctx: ApiContext): Router {
       throw new ApiException('INVALID_ARGUMENT', `source must be local|nss|all, got '${source}'`);
     }
     const rows = listByPrefix<Record<string, unknown>>(ctx.state, '/xinas/v1/observed/Group/');
-    let values = unwrapValues(rows);
+    let values = unwrapResources(rows);
     if (source !== 'all') {
       values = values.filter(
         (g) => (g.status as { source?: string } | undefined)?.source === source,
@@ -44,7 +50,7 @@ export function groupsRouter(ctx: ApiContext): Router {
       `/xinas/v1/observed/Group/${req.params.gid}`,
     );
     if (!row) throw new ApiException('NOT_FOUND', `group gid=${req.params.gid} not found`);
-    sendOk(req, res, row.value, [row.revision]);
+    sendOk(req, res, embedMetadata(row), [row.revision]);
   });
 
   return r;

--- a/xiNAS-MCP/src/api/routes/network.ts
+++ b/xiNAS-MCP/src/api/routes/network.ts
@@ -1,6 +1,12 @@
 import { Router } from 'express';
 import { ApiException } from '../errors.js';
-import { sendOk, getOrNull, listByPrefix, unwrapValues } from '../handlers/reads.js';
+import {
+  embedMetadata,
+  getOrNull,
+  listByPrefix,
+  sendOk,
+  unwrapResources,
+} from '../handlers/reads.js';
 import type { ApiContext } from '../context.js';
 
 export function networkRouter(ctx: ApiContext): Router {
@@ -14,7 +20,7 @@ export function networkRouter(ctx: ApiContext): Router {
     sendOk(
       req,
       res,
-      { interfaces: unwrapValues(ifaces) },
+      { interfaces: unwrapResources(ifaces) },
       ifaces.map((x) => x.revision),
     );
   });
@@ -27,7 +33,7 @@ export function networkRouter(ctx: ApiContext): Router {
     sendOk(
       req,
       res,
-      unwrapValues(rows),
+      unwrapResources(rows),
       rows.map((x) => x.revision),
     );
   });
@@ -38,7 +44,7 @@ export function networkRouter(ctx: ApiContext): Router {
       `/xinas/v1/observed/NetworkInterface/${req.params.id}`,
     );
     if (!row) throw new ApiException('NOT_FOUND', `interface ${req.params.id} not found`);
-    sendOk(req, res, row.value, [row.revision]);
+    sendOk(req, res, embedMetadata(row), [row.revision]);
   });
 
   r.get('/service-ips', (req, res) => {
@@ -46,7 +52,7 @@ export function networkRouter(ctx: ApiContext): Router {
     sendOk(
       req,
       res,
-      unwrapValues(rows),
+      unwrapResources(rows),
       rows.map((x) => x.revision),
     );
   });

--- a/xiNAS-MCP/src/api/routes/nfs-idmap.ts
+++ b/xiNAS-MCP/src/api/routes/nfs-idmap.ts
@@ -15,7 +15,7 @@
 import { Router } from 'express';
 import type { ApiContext } from '../context.js';
 import { ApiException } from '../errors.js';
-import { getOrNull, sendOk } from '../handlers/reads.js';
+import { embedMetadata, getOrNull, sendOk } from '../handlers/reads.js';
 
 const SNAPSHOT_KEY = '/xinas/v1/observed/nfs_idmap/snapshot';
 
@@ -31,7 +31,7 @@ export function nfsIdmapRouter(ctx: ApiContext): Router {
         'NfsIdmap snapshot not yet observed; agent may not be running',
       );
     }
-    sendOk(req, res, row.value, [row.revision]);
+    sendOk(req, res, embedMetadata(row), [row.revision]);
   });
 
   return r;

--- a/xiNAS-MCP/src/api/routes/nfs.ts
+++ b/xiNAS-MCP/src/api/routes/nfs.ts
@@ -1,7 +1,13 @@
 import { Router } from 'express';
 import type { ApiContext } from '../context.js';
 import { ApiException } from '../errors.js';
-import { getOrNull, listByPrefix, sendOk, unwrapValues } from '../handlers/reads.js';
+import {
+  embedMetadata,
+  getOrNull,
+  listByPrefix,
+  sendOk,
+  unwrapResources,
+} from '../handlers/reads.js';
 
 /**
  * Read-time join: for a desired Share, look up the observed ExportRule
@@ -54,7 +60,7 @@ export function nfsRouter(ctx: ApiContext): Router {
     sendOk(
       req,
       res,
-      unwrapValues(rows).map((s) => joinExports(ctx.state, s)),
+      unwrapResources(rows).map((s) => joinExports(ctx.state, s)),
       rows.map((x) => x.revision),
     );
   });
@@ -65,7 +71,7 @@ export function nfsRouter(ctx: ApiContext): Router {
       `/xinas/v1/desired/Share/${req.params.id}`,
     );
     if (!row) throw new ApiException('NOT_FOUND', `share ${req.params.id} not found`);
-    sendOk(req, res, joinExports(ctx.state, row.value), [row.revision]);
+    sendOk(req, res, joinExports(ctx.state, embedMetadata(row)), [row.revision]);
   });
 
   r.get('/shares/:id/sessions', (req, res) => {
@@ -95,7 +101,7 @@ export function nfsRouter(ctx: ApiContext): Router {
     sendOk(
       req,
       res,
-      unwrapValues(sessions),
+      unwrapResources(sessions),
       sessions.map((row) => row.revision),
     );
   });
@@ -105,7 +111,7 @@ export function nfsRouter(ctx: ApiContext): Router {
     sendOk(
       req,
       res,
-      unwrapValues(rows),
+      unwrapResources(rows),
       rows.map((x) => x.revision),
     );
   });
@@ -116,7 +122,7 @@ export function nfsRouter(ctx: ApiContext): Router {
       `/xinas/v1/desired/NfsProfile/${req.params.id}`,
     );
     if (!row) throw new ApiException('NOT_FOUND', `nfs profile ${req.params.id} not found`);
-    sendOk(req, res, row.value, [row.revision]);
+    sendOk(req, res, embedMetadata(row), [row.revision]);
   });
 
   r.get('/export-groups', (req, res) => {
@@ -124,7 +130,7 @@ export function nfsRouter(ctx: ApiContext): Router {
     sendOk(
       req,
       res,
-      unwrapValues(rows),
+      unwrapResources(rows),
       rows.map((x) => x.revision),
     );
   });

--- a/xiNAS-MCP/src/api/routes/nfs.ts
+++ b/xiNAS-MCP/src/api/routes/nfs.ts
@@ -5,18 +5,27 @@ import { getOrNull, listByPrefix, sendOk, unwrapValues } from '../handlers/reads
 
 /**
  * Read-time join: for a desired Share, look up the observed ExportRule
- * whose spec.export_path matches the share's spec.export_path and set
+ * whose spec.export_path matches the share's spec.path and set
  * status.exports to that rule's status.rules[] (or [] if none). ExportRule
  * is an internal observed kind (no public endpoint of its own); this is the
  * only place it surfaces. Returns a new object — does not mutate the row,
  * and is safe when the desired Share has no status field.
+ *
+ * JOIN KEY: the desired Share has no `export_path` field — the api-v1.yaml
+ * Share schema requires [path, clients, fsid]; `path` IS the exported
+ * directory that lands in /etc/exports. The agent stamps that same directory
+ * onto the observed ExportRule/NfsSession as `spec.export_path`. So the
+ * correct join is `share.spec.path === exportRule.spec.export_path`. (The
+ * plan flagged this spec.path-vs-export_path trap twice; the original impl
+ * keyed off the non-existent `share.spec.export_path` and so returned [] for
+ * every real Share.)
  */
 function joinExports(
   state: ApiContext['state'],
   share: Record<string, unknown>,
 ): Record<string, unknown> {
   const shareSpec = share.spec as Record<string, unknown> | undefined;
-  const exportPath = shareSpec?.export_path as string | undefined;
+  const exportPath = shareSpec?.path as string | undefined;
 
   let exports: unknown[] = [];
   if (exportPath) {
@@ -70,10 +79,11 @@ export function nfsRouter(ctx: ApiContext): Router {
 
     // Sessions are observed NfsSession entries (pushed by the agent). Filter
     // the full observed set to those whose spec.export_path matches this
-    // share's spec.export_path. A defensive client_addr type guard skips any
-    // malformed observed row.
+    // share's spec.path (the exported directory — see joinExports for why the
+    // Share side keys off `path`, not a non-existent `export_path`). A
+    // defensive client_addr type guard skips any malformed observed row.
     const shareSpec = shareRow.value.spec as Record<string, unknown> | undefined;
-    const exportPath = shareSpec?.export_path as string | undefined;
+    const exportPath = shareSpec?.path as string | undefined;
     const sessions = listByPrefix<Record<string, unknown>>(
       ctx.state,
       '/xinas/v1/observed/NfsSession/',

--- a/xiNAS-MCP/src/api/routes/storage.ts
+++ b/xiNAS-MCP/src/api/routes/storage.ts
@@ -1,6 +1,12 @@
 import { Router } from 'express';
 import { ApiException } from '../errors.js';
-import { sendOk, getOrNull, listByPrefix, unwrapValues } from '../handlers/reads.js';
+import {
+  embedMetadata,
+  getOrNull,
+  listByPrefix,
+  sendOk,
+  unwrapResources,
+} from '../handlers/reads.js';
 import type { ApiContext } from '../context.js';
 
 /**
@@ -30,7 +36,7 @@ export function storageRouter(ctx: ApiContext): Router {
     // Per api-v1.yaml: optional safe_for_use boolean filter on
     // disk.status.safe_for_use.
     const safeForUse = parseBoolQuery(req.query.safe_for_use, 'safe_for_use');
-    let values = unwrapValues(rows);
+    let values = unwrapResources(rows);
     if (safeForUse !== undefined) {
       values = values.filter((v) => {
         const status = (v as { status?: { safe_for_use?: boolean } }).status;
@@ -53,7 +59,7 @@ export function storageRouter(ctx: ApiContext): Router {
     sendOk(
       req,
       res,
-      unwrapValues(rows),
+      unwrapResources(rows),
       rows.map((x) => x.revision),
     );
   });
@@ -64,7 +70,7 @@ export function storageRouter(ctx: ApiContext): Router {
       `/xinas/v1/observed/XiraidArray/${req.params.id}`,
     );
     if (!row) throw new ApiException('NOT_FOUND', `array ${req.params.id} not found`);
-    sendOk(req, res, row.value, [row.revision]);
+    sendOk(req, res, embedMetadata(row), [row.revision]);
   });
 
   r.get('/filesystems', (req, res) => {
@@ -72,7 +78,7 @@ export function storageRouter(ctx: ApiContext): Router {
     sendOk(
       req,
       res,
-      unwrapValues(rows),
+      unwrapResources(rows),
       rows.map((x) => x.revision),
     );
   });
@@ -83,7 +89,7 @@ export function storageRouter(ctx: ApiContext): Router {
       `/xinas/v1/observed/Filesystem/${req.params.id}`,
     );
     if (!row) throw new ApiException('NOT_FOUND', `filesystem ${req.params.id} not found`);
-    sendOk(req, res, row.value, [row.revision]);
+    sendOk(req, res, embedMetadata(row), [row.revision]);
   });
 
   return r;

--- a/xiNAS-MCP/src/api/routes/system.ts
+++ b/xiNAS-MCP/src/api/routes/system.ts
@@ -1,7 +1,13 @@
 import { Router } from 'express';
 import type { ApiContext } from '../context.js';
 import { ApiException } from '../errors.js';
-import { getOrNull, listByPrefix, sendOk, unwrapValues } from '../handlers/reads.js';
+import {
+  embedMetadata,
+  getOrNull,
+  listByPrefix,
+  sendOk,
+  unwrapResources,
+} from '../handlers/reads.js';
 
 export function systemRouter(ctx: ApiContext): Router {
   const r = Router();
@@ -18,16 +24,18 @@ export function systemRouter(ctx: ApiContext): Router {
     // without a fresh RPC. Omitted when no tracker is wired (the optional
     // agent sub-object in api-v1.yaml). The pre-existing node.status.agent_state
     // field is preserved alongside it.
-    const nodeValue = nodes[0]!.value as Record<string, unknown>;
+    // Embed the synthesized metadata (from each row's KV tracking) so the
+    // public Node/Cluster responses carry the schema-required `metadata`.
+    const nodeWithMeta = embedMetadata(nodes[0]!) as Record<string, unknown>;
     const agent = ctx.tracker?.currentSnapshot();
     const node = agent
       ? {
-          ...nodeValue,
-          status: { ...((nodeValue.status as Record<string, unknown>) ?? {}), agent },
+          ...nodeWithMeta,
+          status: { ...((nodeWithMeta.status as Record<string, unknown>) ?? {}), agent },
         }
-      : nodeValue;
+      : nodeWithMeta;
 
-    sendOk(req, res, { cluster: cluster.value, node }, [
+    sendOk(req, res, { cluster: embedMetadata(cluster), node }, [
       cluster.revision,
       ...nodes.map((n) => n.revision),
     ]);
@@ -47,7 +55,7 @@ export function systemRouter(ctx: ApiContext): Router {
     sendOk(
       req,
       res,
-      unwrapValues(nodes),
+      unwrapResources(nodes),
       nodes.map((n) => n.revision),
     );
   });

--- a/xiNAS-MCP/src/api/routes/users.ts
+++ b/xiNAS-MCP/src/api/routes/users.ts
@@ -11,7 +11,13 @@
 import { Router } from 'express';
 import type { ApiContext } from '../context.js';
 import { ApiException } from '../errors.js';
-import { getOrNull, listByPrefix, sendOk, unwrapValues } from '../handlers/reads.js';
+import {
+  embedMetadata,
+  getOrNull,
+  listByPrefix,
+  sendOk,
+  unwrapResources,
+} from '../handlers/reads.js';
 
 export function usersRouter(ctx: ApiContext): Router {
   const r = Router();
@@ -23,7 +29,7 @@ export function usersRouter(ctx: ApiContext): Router {
       throw new ApiException('INVALID_ARGUMENT', `source must be local|nss|all, got '${source}'`);
     }
     const rows = listByPrefix<Record<string, unknown>>(ctx.state, '/xinas/v1/observed/User/');
-    let values = unwrapValues(rows);
+    let values = unwrapResources(rows);
     if (source !== 'all') {
       values = values.filter(
         (u) => (u.status as { source?: string } | undefined)?.source === source,
@@ -44,7 +50,7 @@ export function usersRouter(ctx: ApiContext): Router {
       `/xinas/v1/observed/User/${req.params.uid}`,
     );
     if (!row) throw new ApiException('NOT_FOUND', `user uid=${req.params.uid} not found`);
-    sendOk(req, res, row.value, [row.revision]);
+    sendOk(req, res, embedMetadata(row), [row.revision]);
   });
 
   return r;

--- a/xiNAS-MCP/xinas-agent.service
+++ b/xiNAS-MCP/xinas-agent.service
@@ -61,7 +61,12 @@ AmbientCapabilities=CAP_CHOWN
 
 # --- Process isolation ---
 LockPersonality=true
-MemoryDenyWriteExecute=true
+# MemoryDenyWriteExecute is intentionally OMITTED (matches xinas-api.service).
+# V8's JIT must mprotect code pages PROT_EXEC; MDWE installs a seccomp filter
+# that EPERMs exactly that, so a default (non-jitless) Node runtime aborts or
+# is forced to degrade. systemd-analyze verify cannot catch this runtime JIT
+# abort. Re-enable only if proven safe on the exact target Node build with a
+# real start test.
 RestrictRealtime=true
 RestrictSUIDSGID=true
 RemoveIPC=true


### PR DESCRIPTION
## Summary

Closes the **1 P0 + 12 P1** confirmed findings from the independent multi-agent review of the xinas-agent S0+S1 stack (PRs #205–#215). Stacked on **#215** (Phase K/L). **Draft — operator-gated; do not merge until the stack below it lands.**

Root cause the review named: *"built but not wired" + a test suite shaped around the gaps, not through them.* Every fix here adds the test that lives precisely in the rendered-template / real-data-shape / quiet-node path the suite previously routed around.

## Commits (each a self-contained fix + regression test)

| Finding | Fix |
|---|---|
| **P0 socket_group** (K/L) | Agent config template emits `socket_group` (+ `xinas_agent_socket_group: xinas-api` default) so the api↔agent socket is chowned to a group the api belongs to — without it the socket is `root:root`, the api gets EACCES, and the agent is pinned `offline` forever. |
| **A internalTokensPath** | Api config template emits `internalTokensPath` so `loadConfig()` actually merges `internal-tokens.json` — without it every `POST /internal/v1/observed` 401s and the split-secret store is inert end-to-end. |
| **E/J OBSERVED_KINDS** | Add `XiraidArray`/`managed_files`; schema-less kinds (incl. `inventory`, also 400ing) get a permissive object-validator. Stops the batch fail-close that dropped the agent's own deltas + co-batched `NfsSession`. |
| **I Share join key** | Join exports/sessions on `share.spec.path`, not the non-existent `share.spec.export_path` (was returning `[]` for every real Share). |
| **J degraded mapping** | `HeartbeatTracker.#computeState()` maps a collector-in-error (`error:`-prefixed) to `degraded` (spec §668); `stubbed` is not a fault. |
| **F ×4 steady-state** | Debounce flush (75ms) + new `PollDriver` (per-collector `pollIntervalMs` + 5-min backstop, consumes `pendingReconcile`) + boot-mode suppresses the >256 ceiling flush. A quiet node no longer freezes after boot; outage drops recover. |
| **K/L MDWE** | Drop `MemoryDenyWriteExecute` from the agent unit (V8 JIT abort risk; matches the api unit). |

The first commit is the synthesized review report (`docs/plans/2026-06-02-xinas-agent-s0s1-independent-review.md`) as the rationale.

## Verification
- `tsc --noEmit` clean · `npm run lint` exit 0 · `format:check` exit 0 · `ansible-lint --profile min` passed (cleared *production* profile).
- **489 unit tests** (was 459; +30 regression) + **5 e2e** pass.

## Out of scope (review confirmed leave-as-is)
ProtectSystem=strict deviation, bootstrap-event suppression, `observed_at`-required, I6 O(n×m) join, the 8 collector↔probe adapters (P2 debt), and the 38 P2s. The systemd-dbus stub still reports `error:` → with the J fix a real node now honestly reads `degraded` until dbus lands (deferred S-phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)