### PR TITLE
TUI: fix the four latent crash sites — stacked on #222, operator-gated

### DIFF
--- a/xinas_menu/app.py
+++ b/xinas_menu/app.py
@@ -278,72 +278,15 @@ class XiNASApp(App):
             _log.debug("copy content failed (no text view on screen?)", exc_info=True)
 
     def _do_copy(self, text: str) -> None:
-        """Send *text* to the user's clipboard, with a recovery file.
+        """Send *text* to the clipboard with a recovery file.
 
-        Two paths run unconditionally:
-
-        1. OSC 52 escape via Textual — interpreted by the user's terminal
-           emulator on their workstation, so it works through SSH. Honored
-           by iTerm2 (with "Applications may access clipboard" enabled),
-           Ghostty, WezTerm, kitty, gnome-terminal, Windows Terminal,
-           Alacritty, etc. Silently dropped by Apple Terminal.app — which
-           has no setting to enable it, hence the second path.
-
-        2. A 0600 recovery file at ~/.xinas/clipboard.txt (the home of
-           whichever user runs xinas-menu). Users on terminals that don't
-           honor OSC 52 can always `cat` the file to retrieve the value.
+        Thin delegate to the shared, app-generic implementation in
+        ``xinas_menu.clipboard`` (hoisted so the Confirm/TextArea dialogs'
+        copy action also works under StartupApp).
         """
-        save_path = self._save_clipboard_recovery_file(text)
+        from xinas_menu.clipboard import copy_with_recovery
 
-        osc52_ok = False
-        copy_to_clipboard = getattr(self, "copy_to_clipboard", None)
-        if callable(copy_to_clipboard):
-            try:
-                copy_to_clipboard(text)
-                osc52_ok = True
-            except Exception:
-                _log.debug("OSC 52 copy_to_clipboard failed", exc_info=True)
-
-        if osc52_ok and save_path:
-            msg = f"Copied to clipboard (OSC 52). If paste fails, see {save_path}"
-        elif osc52_ok:
-            msg = "Copied to clipboard (OSC 52)."
-        elif save_path:
-            msg = f"Terminal doesn't accept clipboard escapes. Saved to {save_path} — cat the file to retrieve."
-        else:
-            msg = "Copy failed — clipboard and recovery file both unavailable."
-        self.notify(msg, timeout=8)
-
-    @staticmethod
-    def _save_clipboard_recovery_file(text: str) -> str | None:
-        """Write *text* to ~/.xinas/clipboard.txt with mode 0600.
-
-        Returns the path on success, None on failure. Atomically replaces
-        any previous content so only the most recent copy is retained.
-        """
-        import os
-        from pathlib import Path
-
-        try:
-            home = Path(os.path.expanduser("~"))
-            d = home / ".xinas"
-            d.mkdir(mode=0o700, exist_ok=True)
-            path = d / "clipboard.txt"
-            tmp = path.with_suffix(".tmp")
-            fd = os.open(
-                str(tmp),
-                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-                0o600,
-            )
-            try:
-                os.write(fd, text.encode("utf-8"))
-            finally:
-                os.close(fd)
-            os.replace(tmp, path)
-            return str(path)
-        except Exception:
-            _log.debug("recovery file save failed", exc_info=True)
-            return None
+        copy_with_recovery(self, text)
 
     def action_scroll_up(self) -> None:
         """Scroll the content panel up."""

--- a/xinas_menu/clipboard.py
+++ b/xinas_menu/clipboard.py
@@ -1,0 +1,87 @@
+"""Clipboard copy with a recovery file — shared by every Textual app.
+
+Hoisted out of ``XiNASApp._do_copy`` so the copy keybinding works in ANY of
+the package's apps (XiNASApp and the installer-phase StartupApp both push
+the Confirm/TextArea dialogs, whose copy action previously crashed under
+StartupApp with AttributeError because only XiNASApp defined ``_do_copy``).
+The logic is app-generic: it uses Textual's own ``App.copy_to_clipboard``
+(OSC 52) plus a plain-file fallback, and ``App.notify`` for feedback.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from textual.app import App
+
+_log = logging.getLogger(__name__)
+
+
+def copy_with_recovery(app: App, text: str) -> None:
+    """Send *text* to the user's clipboard, with a recovery file.
+
+    Two paths run unconditionally:
+
+    1. OSC 52 escape via Textual — interpreted by the user's terminal
+       emulator on their workstation, so it works through SSH. Honored
+       by iTerm2 (with "Applications may access clipboard" enabled),
+       Ghostty, WezTerm, kitty, gnome-terminal, Windows Terminal,
+       Alacritty, etc. Silently dropped by Apple Terminal.app — which
+       has no setting to enable it, hence the second path.
+
+    2. A 0600 recovery file at ~/.xinas/clipboard.txt (the home of
+       whichever user runs xinas-menu). Users on terminals that don't
+       honor OSC 52 can always `cat` the file to retrieve the value.
+    """
+    save_path = save_recovery_file(text)
+
+    osc52_ok = False
+    copy_to_clipboard = getattr(app, "copy_to_clipboard", None)
+    if callable(copy_to_clipboard):
+        try:
+            copy_to_clipboard(text)
+            osc52_ok = True
+        except Exception:
+            _log.debug("OSC 52 copy_to_clipboard failed", exc_info=True)
+
+    if osc52_ok and save_path:
+        msg = f"Copied to clipboard (OSC 52). If paste fails, see {save_path}"
+    elif osc52_ok:
+        msg = "Copied to clipboard (OSC 52)."
+    elif save_path:
+        msg = f"Terminal doesn't accept clipboard escapes. Saved to {save_path} — cat the file to retrieve."
+    else:
+        msg = "Copy failed — clipboard and recovery file both unavailable."
+    app.notify(msg, timeout=8)
+
+
+def save_recovery_file(text: str) -> str | None:
+    """Write *text* to ~/.xinas/clipboard.txt with mode 0600.
+
+    Returns the path on success, None on failure. Atomically replaces
+    any previous content so only the most recent copy is retained.
+    """
+    try:
+        home = Path(os.path.expanduser("~"))
+        d = home / ".xinas"
+        d.mkdir(mode=0o700, exist_ok=True)
+        path = d / "clipboard.txt"
+        tmp = path.with_suffix(".tmp")
+        fd = os.open(
+            str(tmp),
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o600,
+        )
+        try:
+            os.write(fd, text.encode("utf-8"))
+        finally:
+            os.close(fd)
+        os.replace(tmp, path)
+        return str(path)
+    except Exception:
+        _log.debug("recovery file save failed", exc_info=True)
+        return None

--- a/xinas_menu/screens/startup/install_screen.py
+++ b/xinas_menu/screens/startup/install_screen.py
@@ -102,11 +102,15 @@ class InstallScreen(StartupAppMixin, Screen):
             PlaybookRunScreen(cmd=cmd, title=f"Installing — {preset}", workdir=repo)
         )
         if exit_code == 0:
-            # StartupApp defines no `snapshots` helper — this call raises
-            # AttributeError today (pre-existing gap, kept as-is for behavior
-            # parity; the baseline is normally created by the xinas_history
-            # Ansible role during the install itself).
-            await self.app.snapshots.record_baseline(preset=preset)  # pyright: ignore[reportAttributeAccessIssue]
+            # Record a baseline snapshot when the running app provides the
+            # helper (XiNASApp). StartupApp does not — and does not need to:
+            # the xinas_history Ansible role creates the baseline during the
+            # install itself. The old unconditional call crashed the SUCCESS
+            # path under StartupApp with AttributeError before the
+            # notification below could ever show.
+            snapshots = getattr(self.app, "snapshots", None)
+            if snapshots is not None:
+                await snapshots.record_baseline(preset=preset)
             self.app.notify("Installation completed successfully!", severity="information")
         else:
             go_collect = await self.app.push_screen_wait(

--- a/xinas_menu/widgets/confirm_dialog.py
+++ b/xinas_menu/widgets/confirm_dialog.py
@@ -95,9 +95,11 @@ class ConfirmDialog(ModalScreen[bool]):
 
     def action_copy_message(self) -> None:
         if self._copy_text:
-            # _do_copy exists only on XiNASApp; under StartupApp this raises
-            # AttributeError (pre-existing gap, kept as-is for behavior parity).
-            self.app._do_copy(self._copy_text)  # pyright: ignore[reportAttributeAccessIssue]
+            # App-generic: works under both XiNASApp and StartupApp (the old
+            # self.app._do_copy crashed with AttributeError under StartupApp).
+            from xinas_menu.clipboard import copy_with_recovery
+
+            copy_with_recovery(self.app, self._copy_text)
 
     # ── Terminal mouse-capture toggle ────────────────────────────────────
     # While this modal is open, release mouse tracking back to the terminal

--- a/xinas_menu/widgets/drive_picker.py
+++ b/xinas_menu/widgets/drive_picker.py
@@ -249,20 +249,6 @@ class DrivePickerScreen(ModalScreen[list[str] | None]):
         )
         self.query_one("#picker-filter-bar", Static).update(filter_bar)
 
-    def _current_drive_name(self) -> str | None:
-        """Get the drive name at the current cursor row."""
-        table = self.query_one("#picker-table", DataTable)
-        try:
-            # get_row_at raises when the cursor is on an invalid row — keep
-            # the call as a guard even though its value is unused.
-            table.get_row_at(table.cursor_row)
-            # DataTable has no get_row_key() — this raises AttributeError and
-            # the except below returns None (pre-existing gap, kept as-is for
-            # behavior parity; self.get_row_key(table) was likely intended).
-            return str(table.get_row_key(table.cursor_row))  # pyright: ignore[reportAttributeAccessIssue]
-        except Exception:
-            return None
-
     def get_row_key(self, table: DataTable) -> str | None:
         """Get the key of the row at cursor."""
         try:

--- a/xinas_menu/widgets/textarea_dialog.py
+++ b/xinas_menu/widgets/textarea_dialog.py
@@ -99,6 +99,8 @@ class TextAreaDialog(ModalScreen[str | None]):
 
     def action_copy_message(self) -> None:
         if self._copy_text:
-            # _do_copy exists only on XiNASApp; under StartupApp this raises
-            # AttributeError (pre-existing gap, kept as-is for behavior parity).
-            self.app._do_copy(self._copy_text)  # pyright: ignore[reportAttributeAccessIssue]
+            # App-generic: works under both XiNASApp and StartupApp (the old
+            # self.app._do_copy crashed with AttributeError under StartupApp).
+            from xinas_menu.clipboard import copy_with_recovery
+
+            copy_with_recovery(self.app, self._copy_text)


### PR DESCRIPTION
# Fix the four latent TUI crash sites flagged by the pyright cleanup

**Stacked on #222** (it builds on the pyright-green commit's scoped ignores). **Draft / operator-gated.**

The pyright pass found these but preserved them behavior-identical (its constraint was zero behavior change). This PR fixes the underlying logic:

1. **Dialogs' copy crash under StartupApp** — `ConfirmDialog`/`TextAreaDialog`'s copy key called `XiNASApp._do_copy`, an `AttributeError` under the installer-phase `StartupApp`. The clipboard logic was already app-generic, so it's hoisted into a new `xinas_menu/clipboard.py` (`copy_with_recovery` — OSC 52 + the 0600 recovery file); `XiNASApp._do_copy` delegates; both dialogs use the shared function. **Copy now works in the installer instead of crashing.**
2. **Successful install crashed before its success message** — `install_screen` called `self.app.snapshots.record_baseline(...)` unconditionally; `StartupApp` has no `snapshots`, so a *successful* install hit `AttributeError` before "Installation completed successfully!" could show. Now guarded (the baseline is created by the `xinas_history` Ansible role during the install anyway); the notification always fires.
3. **`drive_picker._current_drive_name`** — an uncalled wrapper around a non-existent `DataTable.get_row_key` API that always returned `None` via its blanket except. Deleted; the correct `get_row_key` helper directly below it is the live path (used twice).

## Verification
`pyright` **0 errors / 0 warnings** (suppressions down 12 → 8 — only deploy-generated pb2 imports + one unreachable fallback remain) · `ruff check` clean · `ruff format --check` 104 files clean · `pytest` 26/26 · import smoke identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)