### PR TITLE
CI graduation: pyright standard, ansible-lint basic, envelope blocking, oasdiff, coverage floor (operator-gated)

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,15 +1,24 @@
 # Profile graduation:
-#   min   — what the existing roles pass today (current baseline)
-#   basic — next stop after var-naming + name + yaml cleanup
+#   min   — Phase 0 bootstrap baseline (2026-05-26)
+#   basic — current gate (graduated 2026-06-11): name/jinja/yaml/command
+#           findings fixed; var-naming[no-role-prefix] skipped (see below)
 #   production — long-term aspiration (tracked in
 #   docs/control-path/ci-bootstrap-design.md backfill plan)
 #
-# Recorded baseline on 2026-05-26: profile=production produces 463
-# failures, dominated by var-naming (355). Cleanup is its own PR
-# series; bootstrap uses 'min' to keep the gate blocking from day 1.
-profile: min
+# Recorded baseline on 2026-05-26: profile=production produced 463
+# failures, dominated by var-naming (355). On 2026-06-11 the gate
+# graduated to 'basic' at 0 failures.
+profile: basic
 skip_list:
   - risky-shell-pipe
+  # var-naming[no-role-prefix]: role variables (xfs_filesystems,
+  # xiraid_arrays, nvme_auto_namespace, ...) are the repo's PUBLIC preset
+  # contract — preset YAML under presets/, the whiptail menu scripts, the
+  # Python TUI, and the docs all reference them by name, and user-maintained
+  # presets in the field rely on them. Renaming to add role prefixes is a
+  # breaking change. Revisit only with an explicit deprecation path
+  # (aliases + migration window), not as a lint cleanup.
+  - var-naming[no-role-prefix]
 exclude_paths:
   - .claude/
   - .github/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,13 @@
 # gate matrix, and backfill plan.
 #
 # Flip-to-blocking TODOs (in spec order):
-#   TODO: flip openapi-envelope rule to blocking after 3 clean PRs
 #   TODO: expand typescript-lint to style/suspicious rule categories
-#   TODO: graduate pyright basic -> standard -> strict per module
-#   TODO: graduate ansible-lint min -> basic -> production
-#   TODO: add oasdiff between consecutive api-v1.yaml versions (after v1 published)
-#   TODO: add pytest --cov coverage gate (after meaningful coverage exists)
+#         (measured 2026-06-11, biome 1.9.4, style+suspicious "all" on src/:
+#         ~3.7k diagnostics (233 errors + ~3.5k warnings) — needs its own
+#         debt package, likely "recommended" first)
+#   TODO: graduate pyright standard -> strict per module
+#   TODO: graduate ansible-lint basic -> production
+#   TODO: ratchet the pytest --cov floor upward as xinas_history coverage grows
 #   TODO: add MCP integration smoke test (after containerized harness exists)
 #   TODO: add live contract test against the WS1 mock server (after mock ships)
 
@@ -104,7 +105,9 @@ jobs:
           cache: 'pip'
           cache-dependency-path: pyproject.toml
       - run: pip install -e '.[dev]'
-      - run: pytest
+      # Coverage floor measured at 22% on 2026-06-11; floor set just below.
+      # Ratchet upward when meaningful xinas_history coverage lands.
+      - run: pytest --cov=xinas_history --cov-fail-under=20
 
   python-lint:
     runs-on: ubuntu-latest
@@ -175,6 +178,22 @@ jobs:
           npx --yes -p @stoplight/spectral-cli@latest spectral lint \
             --ruleset .spectral.yaml \
             docs/control-path/api-v1.yaml
+
+  # Breaking-change gate between the PR's api-v1.yaml and the base branch's.
+  # PR-only: on push to main there is no base to diff against.
+  # The action runs in a Docker container that cannot see the runner's /tmp,
+  # so the base spec is passed as a git ref (the action's documented pattern).
+  openapi-compat:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: git fetch --depth=1 origin "$GITHUB_BASE_REF"
+      - uses: oasdiff/oasdiff-action/breaking@v0.0.57
+        with:
+          base: 'origin/${{ github.base_ref }}:docs/control-path/api-v1.yaml'
+          revision: docs/control-path/api-v1.yaml
+          fail-on: ERR
 
   secrets:
     runs-on: ubuntu-latest

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,7 +1,7 @@
 extends: ["spectral:oas"]
 rules:
   envelope-required-on-responses:
-    severity: warn
+    severity: error
     description: |
       Every non-stream JSON response must wrap with the Envelope schema,
       either directly via $ref or via allOf containing an Envelope $ref.

--- a/collection/roles/common/handlers/main.yml
+++ b/collection/roles/common/handlers/main.yml
@@ -2,10 +2,10 @@
 # handlers/main.yml
 # -------------------------------------------------------------
 ---
-- name: reload sysctl
+- name: Reload sysctl
   ansible.builtin.command: sysctl --system
 
-- name: restart unattended-upgrades
+- name: Restart unattended-upgrades
   ansible.builtin.service:
     name: unattended-upgrades
     state: restarted

--- a/collection/roles/common/tasks/main.yml
+++ b/collection/roles/common/tasks/main.yml
@@ -46,7 +46,7 @@
     owner: root
     group: root
     mode: '0644'
-  notify: restart unattended-upgrades
+  notify: Restart unattended-upgrades
   tags: [security]
 
 - name: Apply sysctl parameters
@@ -56,7 +56,7 @@
     state: present
     reload: yes
   loop: "{{ common_sysctl | dict2items }}"
-  notify: reload sysctl
+  notify: Reload sysctl
   tags: [sysctl]
 
 

--- a/collection/roles/doca_ofed/handlers/main.yml
+++ b/collection/roles/doca_ofed/handlers/main.yml
@@ -1,4 +1,4 @@
-- name: restart openibd
+- name: Restart openibd
   service:
     name: openibd
     state: restarted

--- a/collection/roles/doca_ofed/tasks/main.yml
+++ b/collection/roles/doca_ofed/tasks/main.yml
@@ -34,7 +34,7 @@
     state: present
     update_cache: yes
   register: ofed_pkgs
-  notify: restart openibd
+  notify: Restart openibd
   tags: [ofed, install]
 
 ## --- Post-install validation (prevent silent DKMS failures) ---

--- a/collection/roles/exports/handlers/main.yml
+++ b/collection/roles/exports/handlers/main.yml
@@ -1,3 +1,3 @@
-- name: reload exports
+- name: Reload exports
   ansible.builtin.command: exportfs -r
   changed_when: true

--- a/collection/roles/exports/tasks/main.yml
+++ b/collection/roles/exports/tasks/main.yml
@@ -16,5 +16,5 @@
     owner: root
     group: root
     mode: '0644'
-  notify: reload exports
+  notify: Reload exports
   tags: [exports]

--- a/collection/roles/motd/handlers/main.yml
+++ b/collection/roles/motd/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: reload sshd
+- name: Reload sshd
   ansible.builtin.service:
     name: sshd
     state: reloaded

--- a/collection/roles/motd/tasks/main.yml
+++ b/collection/roles/motd/tasks/main.yml
@@ -41,7 +41,7 @@
     regexp: "^#?PrintMotd"
     line: "PrintMotd no"
     state: present
-  notify: reload sshd
+  notify: Reload sshd
   failed_when: false
   tags: [motd]
 
@@ -51,7 +51,7 @@
     regexp: "^#?UsePAM"
     line: "UsePAM yes"
     state: present
-  notify: reload sshd
+  notify: Reload sshd
   failed_when: false
   tags: [motd]
 
@@ -98,7 +98,7 @@
     regexp: "^#?Banner"
     line: "Banner /etc/issue.net"
     state: present
-  notify: reload sshd
+  notify: Reload sshd
   when: banner_enabled | bool
   tags: [motd, banner]
 
@@ -107,7 +107,7 @@
     path: /etc/ssh/sshd_config
     regexp: "^Banner"
     state: absent
-  notify: reload sshd
+  notify: Reload sshd
   when: not (banner_enabled | bool)
   tags: [motd, banner]
 

--- a/collection/roles/net_controllers/handlers/main.yml
+++ b/collection/roles/net_controllers/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: flush stale PBR rules and secondary IPs
+- name: Flush stale PBR rules and secondary IPs
   ansible.builtin.shell: |
     # Flush PBR rules and routing tables (100-199)
     for table in $(ip rule show | grep -oP 'lookup \K(1[0-9]{2})'); do
@@ -19,7 +19,7 @@
   become: true
   listen: apply netplan
 
-- name: run netplan apply
+- name: Run netplan apply
   ansible.builtin.command: netplan apply  # NetPlan Apply
   become: true
   listen: apply netplan

--- a/collection/roles/nfs_server/handlers/main.yml
+++ b/collection/roles/nfs_server/handlers/main.yml
@@ -1,4 +1,4 @@
-- name: restart nfs
+- name: Restart nfs
   ansible.builtin.service:
     name: nfs-server
     state: restarted

--- a/collection/roles/nfs_server/tasks/main.yml
+++ b/collection/roles/nfs_server/tasks/main.yml
@@ -24,7 +24,7 @@
       vers4.2=y
       rdma=y
       rdma-port={{ nfs_rdma_port }}
-  notify: restart nfs
+  notify: Restart nfs
   tags: [nfs_server, config]
 
 - name: Enable and start nfs-server service

--- a/collection/roles/nvme_namespace/tasks/detect_all_drives.yml
+++ b/collection/roles/nvme_namespace/tasks/detect_all_drives.yml
@@ -69,10 +69,10 @@
          | list }}
 
 # Step 7: Split drives into log and data groups
-- name: Assign log drives (first {{ nvme_log_drive_count }} non-OS drives)
+- name: Assign log drives (first non-OS drives), count {{ nvme_log_drive_count }}
   ansible.builtin.set_fact:
-    nvme_small_ns_devices: "{{ nvme_data_drives[:nvme_log_drive_count | int] }}"
-    nvme_large_ns_devices: "{{ nvme_data_drives[nvme_log_drive_count | int:] }}"
+    nvme_small_ns_devices: "{{ nvme_data_drives[: nvme_log_drive_count | int] }}"
+    nvme_large_ns_devices: "{{ nvme_data_drives[nvme_log_drive_count | int :] }}"
 
 # Step 8: Display detection results
 - name: Display detected drives

--- a/collection/roles/nvme_namespace/tasks/generate_raid_config.yml
+++ b/collection/roles/nvme_namespace/tasks/generate_raid_config.yml
@@ -33,8 +33,8 @@
 # Trim device list for RAID 10 if odd count (use first N-1 devices)
 - name: Adjust log devices for RAID 10 (odd count uses N-1)
   ansible.builtin.set_fact:
-    _log_devices_adjusted: "{{ nvme_small_ns_devices[:_log_device_count | int] }}"
-    _log_device_dropped: "{{ nvme_small_ns_devices[_log_device_count | int:] }}"
+    _log_devices_adjusted: "{{ nvme_small_ns_devices[: _log_device_count | int] }}"
+    _log_device_dropped: "{{ nvme_small_ns_devices[_log_device_count | int :] }}"
   when:
     - nvme_raid_log_level | int == 10
     - nvme_small_ns_count | int % 2 == 1

--- a/collection/roles/nvme_namespace/tasks/rebuild_namespaces.yml
+++ b/collection/roles/nvme_namespace/tasks/rebuild_namespaces.yml
@@ -62,7 +62,7 @@
     - not nvme_skip_failed_devices | bool
 
 # Create small namespace (500MB) on each drive
-- name: Create small namespace ({{ nvme_small_ns_size_mb }}MB)
+- name: Create small namespace, size MB {{ nvme_small_ns_size_mb }}
   ansible.builtin.shell: |
     set -e
     controller="{{ item.controller }}"

--- a/collection/roles/perf_tuning/handlers/main.yml
+++ b/collection/roles/perf_tuning/handlers/main.yml
@@ -2,8 +2,8 @@
 # handlers/main.yml
 # -------------------------------------------------------------
 ---
-- name: update grub
+- name: Update grub
   ansible.builtin.command: update-grub
 
-- name: rebuild initramfs
+- name: Rebuild initramfs
   ansible.builtin.command: update-initramfs -u -k all

--- a/collection/roles/perf_tuning/tasks/main.yml
+++ b/collection/roles/perf_tuning/tasks/main.yml
@@ -17,18 +17,22 @@
   ansible.builtin.lineinfile:
     path: /etc/default/grub
     regexp: '^GRUB_CMDLINE_LINUX="(.*)"'
-    line: 'GRUB_CMDLINE_LINUX="intel_idle.max_cstate=0 {{ "transparent_hugepage=never" if perf_disable_thp else "" }} {{ "mitigations=off noibrs noibpb nopti nospectre_v2 nospec_store_bypass_disable no_stf_barrier mds=off" if perf_disable_mitigations else "" }} $1"'
+    line: >-
+      GRUB_CMDLINE_LINUX="intel_idle.max_cstate=0
+      {{ "transparent_hugepage=never" if perf_disable_thp else "" }}
+      {{ "mitigations=off noibrs noibpb nopti nospectre_v2 nospec_store_bypass_disable no_stf_barrier mds=off"
+      if perf_disable_mitigations else "" }} $1"
     backrefs: yes
-  notify: update grub
+  notify: Update grub
   when: ansible_facts['cmdline'] is defined
   tags: [kernel]
 
-- name: Configure NVMe polling mode ({{ perf_nvme_poll_queues }} queues)
+- name: Configure NVMe polling mode, poll queues {{ perf_nvme_poll_queues }}
   ansible.builtin.lineinfile:
     path: /etc/modprobe.d/nvme.conf
     create: yes
     line: "options nvme poll_queues={{ perf_nvme_poll_queues }}"
-  notify: rebuild initramfs
+  notify: Rebuild initramfs
   tags: [nvme]
 
 # ===== CPU governor & irqbalance =====
@@ -99,7 +103,7 @@
 # ===== I/O scheduler & queue depth =====
 # noop scheduler configuration removed
 
-- name: Increase nr_requests queue depth to {{ perf_nr_requests }} on NVMe devices
+- name: Increase NVMe nr_requests queue depth to {{ perf_nr_requests }}
   ansible.builtin.shell: |
     for dev in /sys/block/nvme*/queue/nr_requests; do
       [ -e "$dev" ] || continue
@@ -110,7 +114,7 @@
   changed_when: false
   tags: [io]
 
-- name: Set read-ahead to {{ perf_read_ahead_kb }} KB for NVMe devices
+- name: Set NVMe device read-ahead KB to {{ perf_read_ahead_kb }}
   ansible.builtin.shell: |
     for blk in /dev/nvme*n*; do
       [ -e "$blk" ] || continue
@@ -145,7 +149,7 @@
     ignoreerrors: yes
   tags: [network, nfs]
 
-- name: Configure MTU {{ perf_net_mtu }} on high-speed interfaces
+- name: Configure high-speed interface MTU to {{ perf_net_mtu }}
   ansible.builtin.command: "ip link set dev {{ item }} mtu {{ perf_net_mtu }}"
   loop: "{{ perf_net_ifaces }}"
   when: perf_net_ifaces | length > 0

--- a/collection/roles/raid_fs/handlers/main.yml
+++ b/collection/roles/raid_fs/handlers/main.yml
@@ -1,3 +1,3 @@
-- name: reload systemd
+- name: Reload systemd
   ansible.builtin.systemd:
     daemon_reload: yes

--- a/collection/roles/raid_fs/tasks/create_fs.yml
+++ b/collection/roles/raid_fs/tasks/create_fs.yml
@@ -28,14 +28,16 @@
     _fs_sw: "{{ item.sw }}"
   when: item.su_kb is defined and item.sw is defined
 
-- name: Check if {{ item.data_device }} is currently mounted
+- name: Check current mount state of {{ item.data_device }}
   ansible.builtin.command: findmnt -n -o TARGET {{ item.data_device }}
   register: _current_mount
   failed_when: false
   changed_when: false
   tags: [raid_fs, fs, mkfs]
 
-- name: Check if nfs-server is active before unmount
+# Read-only state probe: we need the `is-active` exit code, which the
+# systemd module does not expose.
+- name: Check if nfs-server is active before unmount  # noqa: command-instead-of-module
   ansible.builtin.command: systemctl is-active nfs-server
   register: _nfs_was_active
   failed_when: false
@@ -58,7 +60,7 @@
     - _nfs_was_active.rc == 0
   tags: [raid_fs, fs, mkfs]
 
-- name: Unmount {{ item.data_device }} before mkfs
+- name: Unmount data device before mkfs of {{ item.data_device }}
   ansible.builtin.command: umount {{ item.data_device }}
   when:
     - _current_mount.rc == 0
@@ -81,7 +83,7 @@
   when: (xfs_force_mkfs | default(false) | bool) or blkid_type.stdout != 'xfs' or blkid_label.stdout != item.label
   tags: [raid_fs, fs, mkfs]
 
-- name: Make filesystem {{ item.label }} on {{ item.data_device }}
+- name: Make XFS filesystem on {{ item.data_device }}
   ansible.builtin.command: >-
     mkfs.xfs -f -L {{ item.label }} -d su={{ _fs_su_kb }}k,sw={{ _fs_sw }}
     -l logdev={{ item.log_device }},size={{ _effective_log_size }}
@@ -104,13 +106,13 @@
 - name: Compute mount unit parameters for {{ item.label }}
   ansible.builtin.set_fact:
     block_device_unit: >-
-      {{ item.data_device | regex_replace('^/','') | replace('/', '-') }}.device
+      {{ item.data_device | regex_replace('^/', '') | replace('/', '-') }}.device
     log_device_unit: >-
-      {{ item.log_device | regex_replace('^/','') | replace('/', '-') }}.device
+      {{ item.log_device | regex_replace('^/', '') | replace('/', '-') }}.device
     unit_opts: >-
       {{ 'defaults' + (',' + item.mount_opts if (item.mount_opts | default('') | length > 0) else '') }}
     mount_unit: >-
-      {{ item.mountpoint | regex_replace('^/','') | replace('/', '-') }}.mount
+      {{ item.mountpoint | regex_replace('^/', '') | replace('/', '-') }}.mount
   tags: [raid_fs, fs]
 
 - name: Deploy systemd mount unit for {{ item.label }}
@@ -118,7 +120,7 @@
     src: mount.unit.j2
     dest: "/etc/systemd/system/{{ mount_unit }}"
     mode: '0644'
-  notify: reload systemd
+  notify: Reload systemd
   tags: [raid_fs, fs]
 
 - name: Reload systemd before enabling mount unit

--- a/collection/roles/roce_lossless/handlers/main.yml
+++ b/collection/roles/roce_lossless/handlers/main.yml
@@ -1,11 +1,11 @@
 ---
 # Handlers for roce_lossless role
 
-- name: reload systemd
+- name: Reload systemd
   ansible.builtin.systemd:
     daemon_reload: true
 
-- name: restart openibd
+- name: Restart openibd
   ansible.builtin.service:
     name: openibd
     state: restarted

--- a/collection/roles/roce_lossless/tasks/detect_nics.yml
+++ b/collection/roles/roce_lossless/tasks/detect_nics.yml
@@ -73,8 +73,7 @@
       {%- if rdma_mode == 'auto' -%}
       {%- if detected_roce_devices | length > 0 -%}roce{%- elif detected_ib_devices | length > 0 -%}ib{%- else -%}none{%- endif -%}
       {%- else -%}
-      {{ rdma_mode }}
-      {%- endif -%}
+      {{ rdma_mode }}{%- endif -%}
 
 # Step 6: Get RDMA-capable network interfaces
 - name: Get RDMA-capable interfaces via rdma link

--- a/collection/roles/roce_lossless/tasks/persist_config.yml
+++ b/collection/roles/roce_lossless/tasks/persist_config.yml
@@ -31,7 +31,7 @@
 
       [Install]
       WantedBy=multi-user.target
-  notify: reload systemd
+  notify: Reload systemd
   tags: [roce_lossless, persist]
 
 # Step 3: Enable and start the service

--- a/collection/roles/roce_lossless/tasks/validate.yml
+++ b/collection/roles/roce_lossless/tasks/validate.yml
@@ -22,7 +22,7 @@
   when: item.rc != 0
 
 # Validation 1b: Verify correct PFC priority is enabled in mlnx_qos output
-- name: Check PFC priority {{ roce_pfc_priority }} is enabled on each interface
+- name: Check each interface has enabled PFC priority {{ roce_pfc_priority }}
   ansible.builtin.shell: |
     set -o pipefail
     output=$(mlnx_qos -i {{ item }} 2>/dev/null)

--- a/collection/roles/xinas_agent/handlers/main.yml
+++ b/collection/roles/xinas_agent/handlers/main.yml
@@ -1,12 +1,12 @@
 ---
 # xinas_agent role handlers
 
-- name: reload systemd
+- name: Reload systemd
   ansible.builtin.systemd:
     daemon_reload: true
   listen: reload systemd
 
-- name: restart xinas-agent
+- name: Restart xinas-agent
   ansible.builtin.systemd:
     name: xinas-agent.service
     state: restarted

--- a/collection/roles/xinas_agent/tasks/main.yml
+++ b/collection/roles/xinas_agent/tasks/main.yml
@@ -55,7 +55,7 @@
     owner: root
     group: root
     mode: '0640'
-  notify: restart xinas-agent
+  notify: Restart xinas-agent
   tags: [xinas_agent, config]
 
 # --- Systemd unit ---
@@ -69,8 +69,8 @@
     mode: '0644'
     remote_src: true
   notify:
-    - reload systemd
-    - restart xinas-agent
+    - Reload systemd
+    - Restart xinas-agent
   tags: [xinas_agent, unit]
 
 - name: Force systemd reload before enabling (flush handlers now)

--- a/collection/roles/xinas_api/handlers/main.yml
+++ b/collection/roles/xinas_api/handlers/main.yml
@@ -1,11 +1,11 @@
 ---
 # xinas_api role handlers.
 
-- name: reload systemd
+- name: Reload systemd
   ansible.builtin.systemd:
     daemon_reload: true
 
-- name: restart xinas-api
+- name: Restart xinas-api
   ansible.builtin.service:
     name: xinas-api
     state: restarted

--- a/collection/roles/xinas_api/tasks/main.yml
+++ b/collection/roles/xinas_api/tasks/main.yml
@@ -26,7 +26,7 @@
 
 # 2. Create the admin group (no-op if it already exists). gid is
 #    system-assigned; we look it up in the next step.
-- name: Create the {{ xinas_api_socket_group }} group
+- name: Create the socket group {{ xinas_api_socket_group }}
   ansible.builtin.group:
     name: "{{ xinas_api_socket_group }}"
     state: present
@@ -35,7 +35,7 @@
 # 3. Look up the gid. getent always returns the gid as the third
 #    colon-separated field; we register the whole row and parse it
 #    in the next step.
-- name: Look up {{ xinas_api_socket_group }} gid
+- name: Look up the gid of {{ xinas_api_socket_group }}
   ansible.builtin.getent:
     database: group
     key: "{{ xinas_api_socket_group }}"
@@ -73,7 +73,7 @@
 #     system-assigned. Primary group is the socket group (xinas-admin
 #     by default) so files the api creates default to that group, no
 #     setgid trickery needed.
-- name: Create the {{ xinas_api_user }} system user
+- name: Create the api system user {{ xinas_api_user }}
   ansible.builtin.user:
     name: "{{ xinas_api_user }}"
     group: "{{ xinas_api_socket_group }}"
@@ -183,7 +183,7 @@
 # though they can read /etc/xinas-api/config.json (which contains
 # only the admin token, never the agent token).
 
-- name: stat /etc/xinas-api/internal-tokens.json
+- name: Stat /etc/xinas-api/internal-tokens.json
   ansible.builtin.stat:
     path: /etc/xinas-api/internal-tokens.json
   register: _xinas_api_internal_tokens_stat
@@ -221,7 +221,7 @@
     group: xinas-api
     mode: '0640'
   no_log: true
-  notify: restart xinas-api
+  notify: Restart xinas-api
   when: not _xinas_api_internal_tokens_stat.stat.exists
   tags: [xinas_api, config]
 
@@ -283,7 +283,7 @@
 # admin-token file re-derives it from config on the next run.
 # Deleting both forces a fresh token (rotation procedure).
 
-- name: stat {{ xinas_api_config_dir }}/config.json
+- name: Stat config.json under {{ xinas_api_config_dir }}
   ansible.builtin.stat:
     path: "{{ xinas_api_config_dir }}/config.json"
   register: _xinas_api_config_stat
@@ -316,7 +316,7 @@
     mode: '0640'
     force: true
   no_log: true
-  notify: restart xinas-api
+  notify: Restart xinas-api
   when: not _xinas_api_config_stat.stat.exists
   tags: [xinas_api, config]
 
@@ -371,7 +371,7 @@
 
 # --- Both branches converge here: write/refresh admin-token mirror ---
 
-- name: Write/refresh {{ xinas_api_config_dir }}/admin-token
+- name: Write/refresh the admin-token mirror in {{ xinas_api_config_dir }}
   ansible.builtin.copy:
     content: "{{ _xinas_api_admin_token }}\n"
     dest: "{{ xinas_api_config_dir }}/admin-token"
@@ -393,8 +393,8 @@
     mode: '0644'
     remote_src: true
   notify:
-    - reload systemd
-    - restart xinas-api
+    - Reload systemd
+    - Restart xinas-api
   tags: [xinas_api, service]
 
 # 9. Force daemon-reload before enable so systemd picks up the new

--- a/collection/roles/xinas_mcp/handlers/main.yml
+++ b/collection/roles/xinas_mcp/handlers/main.yml
@@ -1,19 +1,19 @@
 ---
-- name: reload systemd
+- name: Reload systemd
   ansible.builtin.systemd:
     daemon_reload: true
 
-- name: restart xinas-nfs-helper
+- name: Restart xinas-nfs-helper
   ansible.builtin.service:
     name: xinas-nfs-helper
     state: restarted
 
-- name: restart xinas-mcp
+- name: Restart xinas-mcp
   ansible.builtin.service:
     name: xinas-mcp
     state: restarted
 
-- name: restart sshd
+- name: Restart sshd
   ansible.builtin.service:
     name: ssh    # Ubuntu uses "ssh", not "sshd"
     state: restarted

--- a/collection/roles/xinas_mcp/tasks/main.yml
+++ b/collection/roles/xinas_mcp/tasks/main.yml
@@ -28,7 +28,9 @@
         state: directory
         mode: '0755'
 
-    - name: Import NodeSource GPG key
+    # curl pipes into `gpg --dearmor`; get_url cannot dearmor, and the
+    # task is already guarded by creates:.
+    - name: Import NodeSource GPG key  # noqa: command-instead-of-module
       ansible.builtin.shell: >
         curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
         | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
@@ -78,7 +80,7 @@
     cmd: npm run build
     chdir: "{{ xinas_mcp_repo_path }}"
   changed_when: true
-  notify: restart xinas-mcp
+  notify: Restart xinas-mcp
   tags: [xinas_mcp, build]
 
 # ─── 3. NFS helper daemon ──────────────────────────────────────────────────────
@@ -100,7 +102,7 @@
     group: root
     mode: '0644'
     remote_src: true
-  notify: restart xinas-nfs-helper
+  notify: Restart xinas-nfs-helper
   tags: [xinas_mcp, nfs_helper]
 
 - name: Make nfs_helper.py executable
@@ -118,8 +120,8 @@
     mode: '0644'
     remote_src: true
   notify:
-    - reload systemd
-    - restart xinas-nfs-helper
+    - Reload systemd
+    - Restart xinas-nfs-helper
   tags: [xinas_mcp, nfs_helper]
 
 - name: Force systemd daemon-reload before enabling service
@@ -176,8 +178,8 @@
     mode: '0644'
     remote_src: true
   notify:
-    - reload systemd
-    - restart xinas-mcp
+    - Reload systemd
+    - Restart xinas-mcp
   tags: [xinas_mcp, service]
 
 - name: Force systemd daemon-reload before enabling xinas-mcp
@@ -228,7 +230,7 @@
     group: root
     mode: '0644'
   when: xinas_mcp_allow_root_ssh
-  notify: restart sshd
+  notify: Restart sshd
   tags: [xinas_mcp, ssh]
 
 - name: Create xinas-mcp wrapper script

--- a/collection/roles/xinas_uninstall/tasks/40_remove_mounts.yml
+++ b/collection/roles/xinas_uninstall/tasks/40_remove_mounts.yml
@@ -25,7 +25,7 @@
 
 - name: "Mounts | parse mount unit list"
   ansible.builtin.set_fact:
-    _xinas_mount_units: "{{ (_xinas_mounts.stdout_lines | default([])) | reject('equalto','') | list }}"
+    _xinas_mount_units: "{{ (_xinas_mounts.stdout_lines | default([])) | reject('equalto', '') | list }}"
 
 - name: "Mounts | stop xiNAS mount units"
   ansible.builtin.systemd:

--- a/collection/roles/xinas_uninstall/tasks/70_remove_paths.yml
+++ b/collection/roles/xinas_uninstall/tasks/70_remove_paths.yml
@@ -71,7 +71,8 @@
       {{
         uninstall_summary | combine({
           'removed': uninstall_summary.removed + [
-            ['Paths', '/opt/xiNAS, /var/lib/xinas, /var/log/xinas, /etc/xinas-mcp, /usr/lib/xinas-mcp, /etc/netplan/99-xinas.yaml, /etc/sudoers.d/xinas-update, /etc/profile.d/99-xinas-menu.sh, /etc/update-motd.d/99-xinas-status, /etc/cron.d/xinas-banner, /etc/ssh/sshd_config.d/10-xinas-root-access.conf']
+            ['Paths', '/opt/xiNAS, /var/lib/xinas, /var/log/xinas, /etc/xinas-mcp, /usr/lib/xinas-mcp, /etc/netplan/99-xinas.yaml, /etc/sudoers.d/xinas-update, '
+              + '/etc/profile.d/99-xinas-menu.sh, /etc/update-motd.d/99-xinas-status, /etc/cron.d/xinas-banner, /etc/ssh/sshd_config.d/10-xinas-root-access.conf']
           ],
           'manual': uninstall_summary.manual + [
             'Run `netplan apply` to release xiNAS-managed IPs from your NICs.'

--- a/collection/roles/xinas_uninstall/tasks/91_optional_xiraid.yml
+++ b/collection/roles/xinas_uninstall/tasks/91_optional_xiraid.yml
@@ -2,7 +2,7 @@
 # Optional phase 91 — remove the xiRAID package, repo, and DKMS module.
 # Gated by uninstall_remove_xiraid in tasks/main.yml.
 
-- name: "xiRAID | stop and disable xiraid-exporter"
+- name: "XiRAID | stop and disable xiraid-exporter"
   ansible.builtin.systemd:
     name: xiraid-exporter.service
     state: stopped
@@ -11,7 +11,7 @@
   failed_when: false
   changed_when: _xiraid_exp_stop.changed | default(false)
 
-- name: "xiRAID | purge xiraid packages"
+- name: "XiRAID | purge xiraid packages"
   ansible.builtin.apt:
     name: "{{ xinas_xiraid_apt_purge }}"
     state: absent
@@ -22,7 +22,7 @@
     - _apt_xiraid.failed | default(false)
     - "'is not installed' not in (_apt_xiraid.msg | default(''))"
 
-- name: "xiRAID | also purge xiraid-repo metadata package"
+- name: "XiRAID | also purge xiraid-repo metadata package"
   ansible.builtin.shell: |
     set +e
     dpkg -l | awk '/^ii.*xiraid-repo/ {print $2}' | xargs -r apt-get purge -y
@@ -31,7 +31,7 @@
     executable: /bin/bash
   changed_when: false
 
-- name: "xiRAID | dkms remove kernel module"
+- name: "XiRAID | dkms remove kernel module"
   ansible.builtin.shell: |
     set +e
     dkms status 2>/dev/null | awk -F'[,/ ]' '/^xiraid/ {print $1}' | sort -u | while read mod; do
@@ -42,12 +42,12 @@
     executable: /bin/bash
   changed_when: false
 
-- name: "xiRAID | remove /etc/xiraid"
+- name: "XiRAID | remove /etc/xiraid"
   ansible.builtin.file:
     path: /etc/xiraid
     state: absent
 
-- name: "xiRAID | remove Xinnor APT sources"
+- name: "XiRAID | remove Xinnor APT sources"
   ansible.builtin.shell: |
     set +e
     grep -rl 'pkg\.xinnor\.io' /etc/apt/sources.list.d/ 2>/dev/null | xargs -r rm -f
@@ -56,7 +56,7 @@
     executable: /bin/bash
   changed_when: false
 
-- name: "xiRAID | record removal"
+- name: "XiRAID | record removal"
   ansible.builtin.set_fact:
     uninstall_summary: >-
       {{

--- a/collection/roles/xinas_uninstall/tasks/main.yml
+++ b/collection/roles/xinas_uninstall/tasks/main.yml
@@ -5,47 +5,61 @@
 # Every phase appends entries to `uninstall_summary` (removed / preserved /
 # failed / manual / reboot) so the final fact carries the full report.
 
-- ansible.builtin.import_tasks: 00_preflight.yml
+- name: Phase 00 — preflight checks
+  ansible.builtin.import_tasks: 00_preflight.yml
   tags: [xinas_uninstall, preflight]
 
-- ansible.builtin.import_tasks: 10_quiesce_services.yml
+- name: Phase 10 — quiesce services
+  ansible.builtin.import_tasks: 10_quiesce_services.yml
   tags: [xinas_uninstall, services]
 
-- ansible.builtin.import_tasks: 20_remove_exports.yml
+- name: Phase 20 — remove NFS exports
+  ansible.builtin.import_tasks: 20_remove_exports.yml
   tags: [xinas_uninstall, exports]
 
-- ansible.builtin.import_tasks: 30_teardown_raid.yml
+- name: Phase 30 — tear down RAID
+  ansible.builtin.import_tasks: 30_teardown_raid.yml
   tags: [xinas_uninstall, raid]
 
-- ansible.builtin.import_tasks: 40_remove_mounts.yml
+- name: Phase 40 — remove mounts
+  ansible.builtin.import_tasks: 40_remove_mounts.yml
   tags: [xinas_uninstall, mounts]
 
-- ansible.builtin.import_tasks: 50_remove_services.yml
+- name: Phase 50 — remove services
+  ansible.builtin.import_tasks: 50_remove_services.yml
   tags: [xinas_uninstall, services]
 
-- ansible.builtin.import_tasks: 60_remove_binaries.yml
+- name: Phase 60 — remove binaries
+  ansible.builtin.import_tasks: 60_remove_binaries.yml
   tags: [xinas_uninstall, binaries]
 
-- ansible.builtin.import_tasks: 70_remove_paths.yml
+- name: Phase 70 — remove paths
+  ansible.builtin.import_tasks: 70_remove_paths.yml
   tags: [xinas_uninstall, paths]
 
-- ansible.builtin.import_tasks: 80_revert_inplace_edits.yml
+- name: Phase 80 — revert in-place edits
+  ansible.builtin.import_tasks: 80_revert_inplace_edits.yml
   tags: [xinas_uninstall, edits]
 
-- ansible.builtin.import_tasks: 90_remove_packages.yml
+- name: Phase 90 — remove packages
+  ansible.builtin.import_tasks: 90_remove_packages.yml
   tags: [xinas_uninstall, packages]
 
-- ansible.builtin.import_tasks: 91_optional_xiraid.yml
+- name: Phase 91 — optionally remove xiRAID
+  ansible.builtin.import_tasks: 91_optional_xiraid.yml
   when: uninstall_remove_xiraid | bool
   tags: [xinas_uninstall, optional, xiraid]
 
-- ansible.builtin.import_tasks: 92_optional_ofed.yml
+- name: Phase 92 — optionally remove OFED
+  ansible.builtin.import_tasks: 92_optional_ofed.yml
   when: uninstall_remove_ofed | bool
   tags: [xinas_uninstall, optional, ofed]
 
-- ansible.builtin.import_tasks: 93_optional_perf.yml
+- name: Phase 93 — optionally revert perf tuning
+  ansible.builtin.import_tasks: 93_optional_perf.yml
   when: uninstall_revert_perf | bool
   tags: [xinas_uninstall, optional, perf]
 
-- ansible.builtin.import_tasks: 99_finalize.yml
+- name: Phase 99 — finalize and report
+  ansible.builtin.import_tasks: 99_finalize.yml
   tags: [xinas_uninstall, finalize]

--- a/collection/roles/xiraid_classic/tasks/main.yml
+++ b/collection/roles/xiraid_classic/tasks/main.yml
@@ -14,6 +14,7 @@
   tags: [xiraid, cleanup]
 
 - name: Download xiRAID repo package
+  tags: [xiraid, download]
   block:
     - name: Download xiRAID repo package (get_url)
       ansible.builtin.get_url:
@@ -27,15 +28,15 @@
       until: xiraid_repo_dl is succeeded
 
   rescue:
-    - name: Download xiRAID repo package (wget fallback)
+    # wget is the deliberate fallback path for when get_url itself has
+    # already failed; converting it to get_url would defeat the rescue.
+    - name: Download xiRAID repo package (wget fallback)  # noqa: command-instead-of-module
       ansible.builtin.command:
         cmd: "wget -q -O /tmp/{{ xiraid_repo_pkg }} {{ xiraid_repo_pkg_url }}"
       register: xiraid_repo_dl
       retries: 5
       delay: 10
       until: xiraid_repo_dl.rc == 0
-
-  tags: [xiraid, download]
 
 - name: Install xiRAID repo package
   ansible.builtin.apt:

--- a/collection/roles/xiraid_exporter/defaults/main.yml
+++ b/collection/roles/xiraid_exporter/defaults/main.yml
@@ -8,7 +8,11 @@ xiraid_exporter_arch: "amd64"
 xiraid_exporter_github_repo: "E4-Computer-Engineering/xiraid-exporter"
 
 # Download URL of the .deb package
-xiraid_exporter_download_url: "https://github.com/{{ xiraid_exporter_github_repo }}/releases/download/v{{ xiraid_exporter_version }}/xiraid-exporter_{{ xiraid_exporter_version }}_linux_{{ xiraid_exporter_arch }}.deb"
+# (Folded scalar broken inside the Jinja braces, where whitespace is
+# insignificant — the rendered URL is identical.)
+xiraid_exporter_download_url: >-
+  https://github.com/{{ xiraid_exporter_github_repo }}/releases/download/v{{
+  xiraid_exporter_version }}/xiraid-exporter_{{ xiraid_exporter_version }}_linux_{{ xiraid_exporter_arch }}.deb
 
 # Metrics listen port
 xiraid_exporter_port: 9827

--- a/collection/roles/xiraid_exporter/handlers/main.yml
+++ b/collection/roles/xiraid_exporter/handlers/main.yml
@@ -1,4 +1,4 @@
-- name: reload xiraid_exporter
+- name: Reload xiraid_exporter
   ansible.builtin.systemd:
     daemon_reload: yes
     name: xiraid-exporter

--- a/docs/control-path/ci-bootstrap-design.md
+++ b/docs/control-path/ci-bootstrap-design.md
@@ -70,12 +70,13 @@ PRs" anti-pattern while still surfacing every issue.
 | `typescript-contracts` (vitest schema-fixture validation against `api-v1.yaml`) | **Blocking** | n/a; expands as real handlers and mock server land |
 | `python-lint` (`ruff check`) | **Blocking** (flipped 2026-06-10 — ruff cleanup PR) | satisfied |
 | `python-format` (`ruff format --check`) | **Blocking** (flipped 2026-06-10 — format pass PR) | satisfied |
-| `python-typecheck` (`pyright`, `basic` mode) | **Blocking** (flipped 2026-06-10 — runtime deps + typing tail landed) | satisfied |
-| `python-tests` (`pytest`) | **Blocking** (one sanity test) | n/a |
-| `ansible` (`ansible-lint`) | **Blocking** | n/a |
+| `python-typecheck` (`pyright`, `standard` mode) | **Blocking** (graduated `basic` → `standard` 2026-06-11 — 28 possibly-unbound/override errors fixed) | next: `strict` per module |
+| `python-tests` (`pytest --cov=xinas_history --cov-fail-under=20`) | **Blocking** (coverage floor added 2026-06-11 at measured 22%) | ratchet the floor as coverage grows |
+| `ansible` (`ansible-lint`, profile `basic`) | **Blocking** (graduated `min` → `basic` 2026-06-11 — 67 findings fixed; `var-naming[no-role-prefix]` skipped: role vars are the public preset contract, renaming is breaking) | next: profile `production` |
 | `yamllint` | **Blocking** (flipped 2026-06-10 — house style codified in `.yamllint.yml`) | satisfied |
 | `openapi` (`spectral lint`, ruleset `spectral:oas`) | **Blocking** | n/a |
-| `openapi-envelope` (custom Spectral rule, loaded via `.spectral.yaml`) | **Warn-only** | After 3 production PRs land without violation |
+| `openapi-envelope` (custom Spectral rule, loaded via `.spectral.yaml`) | **Blocking** (flipped 2026-06-11 — far more than 3 clean PRs landed; 0 violations at `error`) | satisfied |
+| `openapi-compat` (`oasdiff breaking` vs the PR base's `api-v1.yaml`; PR-only) | **Blocking** (added 2026-06-11) | n/a |
 | `secrets` (`gitleaks`) | **Blocking** | n/a |
 | `markdown` (`markdownlint-cli2`) | **Blocking** (flipped 2026-06-10 — house style codified in `.markdownlint-cli2.jsonc`) | satisfied |
 
@@ -117,6 +118,8 @@ Verified empirically against the current tree on 2026-05-26.
   current `api-v1.yaml` (all 38 `application/json` response uses
   correctly wrap with the `Envelope`), but kept warn-only for the
   first three PRs as a guardrail while the spec expands.
+  *(Flipped to `severity: error` 2026-06-11 — the guardrail period is
+  long past and the rule still reports 0 violations.)*
 
 ### Evidence behind blocking choices
 
@@ -284,9 +287,9 @@ real envelope-missing cases.
 extends: ["spectral:oas"]
 rules:
   # Custom: every non-stream response must reference the envelope.
-  # WARN-ONLY initially; see ci-bootstrap-design.md gate matrix.
+  # Blocking since 2026-06-11; see ci-bootstrap-design.md gate matrix.
   envelope-required-on-responses:
-    severity: warn
+    severity: error
     description: |
       Every non-stream JSON response must wrap with the Envelope schema,
       either directly via $ref or via allOf containing an Envelope $ref.
@@ -731,9 +734,14 @@ schema-conformance backbone, not just a fixture validator.
 
 ## Future work (tracked in workflow comments)
 
-- Add `oasdiff` between consecutive `api-v1.yaml` versions (after v1
-  is published).
-- Add `pytest --cov` coverage gate (after real tests exist).
+- ~~Add `oasdiff`~~ — done 2026-06-11: the `openapi-compat` job runs
+  `oasdiff breaking` against the PR base's `api-v1.yaml` (PR-only).
+- ~~Add `pytest --cov` coverage gate~~ — done 2026-06-11:
+  `--cov=xinas_history --cov-fail-under=20`; ratchet as coverage grows.
+- Expand `typescript-lint` beyond `correctness` (measured 2026-06-11
+  with biome 1.9.4, `style`+`suspicious` at `all` on `src/`: ~3.7k
+  diagnostics, 233 errors + ~3.5k warnings — its own debt package;
+  start from `recommended`).
 - Add MCP integration smoke test (after a containerized test harness
   exists).
 - Add a live contract test against the WS1 mock server (after the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,13 +58,12 @@ indent-style = "space"
 [tool.pyright]
 include = ["xinas_menu", "xinas_history", "xiNAS-MCP/nfs-helper"]
 exclude = ["**/__pycache__", "**/.git", "**/node_modules", "**/.venv"]
-reportMissingTypeStubs = "none"
 # textual's screen/mount APIs (push_screen, mount, recompose, ...) return
 # optionally-awaitable objects; the fire-and-forget call is the framework's
 # documented idiom, so an unawaited result is not a bug in this codebase.
 # Warning keeps the signal visible without failing CI.
 reportUnusedCoroutine = "warning"
-typeCheckingMode = "basic"
+typeCheckingMode = "standard"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dev = [
   "pyright>=1.1.380",
   "ruff>=0.6.0",
   "pytest>=8.0",
+  "pytest-cov>=5.0",
   # TUI runtime deps, mirrored from collection/roles/xinas_menu/tasks/main.yml
   # (the deployment venv) so pyright resolves imports in CI. Keep the version
   # floors in sync with the role.

--- a/tests/test_render_nfs_profile.py
+++ b/tests/test_render_nfs_profile.py
@@ -227,8 +227,11 @@ def test_rejects_non_dict_spec(env):
     root, lock_path, _calls, run_systemctl = env
     with pytest.raises(ValueError):
         nfs_profile.render_nfs_profile(
-            ["not", "a", "dict"], False,
-            root=root, lock_path=lock_path, run_systemctl=run_systemctl,
+            ["not", "a", "dict"],
+            False,
+            root=root,
+            lock_path=lock_path,
+            run_systemctl=run_systemctl,
         )
 
 
@@ -250,7 +253,8 @@ def test_rdma_disabled_renders_no_rdma_port(env):
     nfs_profile.render_nfs_profile(
         spec, False, root=root, lock_path=lock_path, run_systemctl=run_systemctl
     )
-    nfsd = open(os.path.join(root, "etc/nfs/nfsd.conf")).read()
+    with open(os.path.join(root, "etc/nfs/nfsd.conf")) as f:
+        nfsd = f.read()
     assert "rdma=n" in nfsd
     assert "rdma-port" not in nfsd
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -1,4 +1,5 @@
 """First-green sanity test for the Python toolchain."""
+
 import re
 
 from xinas_menu.version import XINAS_MENU_VERSION

--- a/tests/test_set_idmapd_domain.py
+++ b/tests/test_set_idmapd_domain.py
@@ -45,17 +45,10 @@ def test_rewrites_existing_domain(paths):
     conf_path, lock_path = paths
     _write(
         conf_path,
-        "[General]\n"
-        "Verbosity = 0\n"
-        "Domain = old.com\n"
-        "\n"
-        "[Mapping]\n"
-        "Nobody-User = nobody\n",
+        "[General]\nVerbosity = 0\nDomain = old.com\n\n[Mapping]\nNobody-User = nobody\n",
     )
 
-    nfs_idmap.set_idmapd_domain(
-        "new.example.com", conf_path=conf_path, lock_path=lock_path
-    )
+    nfs_idmap.set_idmapd_domain("new.example.com", conf_path=conf_path, lock_path=lock_path)
 
     out = _read(conf_path)
     assert "Domain = new.example.com" in out
@@ -72,16 +65,10 @@ def test_inserts_domain_under_existing_general(paths):
     conf_path, lock_path = paths
     _write(
         conf_path,
-        "[General]\n"
-        "Verbosity = 0\n"
-        "\n"
-        "[Mapping]\n"
-        "Nobody-User = nobody\n",
+        "[General]\nVerbosity = 0\n\n[Mapping]\nNobody-User = nobody\n",
     )
 
-    nfs_idmap.set_idmapd_domain(
-        "new.example.com", conf_path=conf_path, lock_path=lock_path
-    )
+    nfs_idmap.set_idmapd_domain("new.example.com", conf_path=conf_path, lock_path=lock_path)
 
     out = _read(conf_path)
     lines = out.splitlines()
@@ -99,9 +86,7 @@ def test_creates_general_when_absent(paths):
     conf_path, lock_path = paths
     _write(conf_path, "[Mapping]\nNobody-User = nobody\n")
 
-    nfs_idmap.set_idmapd_domain(
-        "new.example.com", conf_path=conf_path, lock_path=lock_path
-    )
+    nfs_idmap.set_idmapd_domain("new.example.com", conf_path=conf_path, lock_path=lock_path)
 
     out = _read(conf_path)
     assert "[General]" in out
@@ -118,9 +103,7 @@ def test_creates_file_when_empty(paths):
     conf_path, lock_path = paths
     _write(conf_path, "")
 
-    nfs_idmap.set_idmapd_domain(
-        "new.example.com", conf_path=conf_path, lock_path=lock_path
-    )
+    nfs_idmap.set_idmapd_domain("new.example.com", conf_path=conf_path, lock_path=lock_path)
 
     out = _read(conf_path)
     lines = out.splitlines()
@@ -133,9 +116,7 @@ def test_creates_file_when_missing(paths):
     # conf_path does not exist yet.
     assert not os.path.exists(conf_path)
 
-    nfs_idmap.set_idmapd_domain(
-        "new.example.com", conf_path=conf_path, lock_path=lock_path
-    )
+    nfs_idmap.set_idmapd_domain("new.example.com", conf_path=conf_path, lock_path=lock_path)
 
     out = _read(conf_path)
     assert "[General]" in out
@@ -147,13 +128,10 @@ def test_preserves_indented_domain_style(paths):
     conf_path, lock_path = paths
     _write(
         conf_path,
-        "[General]\n"
-        "  domain = old.com\n",
+        "[General]\n  domain = old.com\n",
     )
 
-    nfs_idmap.set_idmapd_domain(
-        "new.example.com", conf_path=conf_path, lock_path=lock_path
-    )
+    nfs_idmap.set_idmapd_domain("new.example.com", conf_path=conf_path, lock_path=lock_path)
 
     out = _read(conf_path)
     assert "new.example.com" in out
@@ -166,9 +144,7 @@ def test_rejects_domain_without_dot(paths):
     _write(conf_path, "[General]\nDomain = old.com\n")
 
     with pytest.raises(ValueError):
-        nfs_idmap.set_idmapd_domain(
-            "localdomain", conf_path=conf_path, lock_path=lock_path
-        )
+        nfs_idmap.set_idmapd_domain("localdomain", conf_path=conf_path, lock_path=lock_path)
     # File untouched on validation failure.
     assert "old.com" in _read(conf_path)
 

--- a/xinas_history/drift.py
+++ b/xinas_history/drift.py
@@ -430,6 +430,7 @@ class DriftDetector:
             current_cksum = self._sha256(current_bytes) if current_bytes is not None else ""
 
             # We also check the live systemd state for semantic comparison.
+            live_repr = b""
             live_state = self._get_live_mount_state(unit_name)
             if live_state is not None:
                 live_repr = json.dumps(live_state, sort_keys=True).encode()

--- a/xinas_menu/app.py
+++ b/xinas_menu/app.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from pathlib import Path
-from typing import ClassVar
 
 _log = logging.getLogger(__name__)
 
@@ -29,9 +28,9 @@ __all__ = ["XiNASApp"]
 class XiNASApp(App):
     """Main management application (post-deploy xinas-menu)."""
 
-    CSS_PATH: ClassVar[Path] = Path(__file__).parent / "styles.tcss"
+    CSS_PATH = Path(__file__).parent / "styles.tcss"
 
-    BINDINGS: ClassVar[list[Binding]] = [
+    BINDINGS = [
         Binding("ctrl+c", "quit", "Quit", show=False, priority=True),
         Binding("ctrl+y", "copy_content", "Copy output", show=True),
         Binding("u", "check_update", "Check updates", show=True),

--- a/xinas_menu/screens/config_history.py
+++ b/xinas_menu/screens/config_history.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+from typing import TYPE_CHECKING
 
 from textual import work
 from textual.app import ComposeResult
@@ -23,12 +24,15 @@ from xinas_menu.widgets.text_view import ScrollableTextView
 
 _log = logging.getLogger(__name__)
 
-try:
-    from xinas_history.drift import DriftDetector
+if TYPE_CHECKING:
     from xinas_history.engine import SnapshotEngine
-    from xinas_history.gc import GarbageCollector, load_retention_policy
-    from xinas_history.runner import TransactionalRunner
     from xinas_history.store import FilesystemStore
+
+# Availability probe only — the package __init__ imports every submodule we
+# use, so a successful import guarantees the deferred per-method imports
+# below succeed too. xinas_history may not be installed on dev machines.
+try:
+    import xinas_history  # noqa: F401
 
     HAS_HISTORY = True
 except ImportError:
@@ -213,6 +217,9 @@ class ConfigHistoryScreen(XiNASAppMixin, Screen):
 
         loop = asyncio.get_running_loop()
         try:
+            from xinas_history.drift import DriftDetector
+            from xinas_history.store import FilesystemStore
+
             store = FilesystemStore()
             engine = _create_engine(store=store)
             detector = DriftDetector(store=store, engine=engine)
@@ -417,6 +424,10 @@ class ConfigHistoryScreen(XiNASAppMixin, Screen):
             )
 
         try:
+            from xinas_history.engine import SnapshotEngine
+            from xinas_history.runner import TransactionalRunner
+            from xinas_history.store import FilesystemStore
+
             store = FilesystemStore()
             runner = TransactionalRunner(
                 engine=SnapshotEngine(store=store),
@@ -505,6 +516,9 @@ class ConfigHistoryScreen(XiNASAppMixin, Screen):
 
         loop = asyncio.get_running_loop()
         try:
+            from xinas_history.gc import GarbageCollector, load_retention_policy
+            from xinas_history.store import FilesystemStore
+
             store = FilesystemStore()
             gc = GarbageCollector(store, load_retention_policy())
             engine = _create_engine(store=store)
@@ -647,6 +661,9 @@ class ConfigHistoryScreen(XiNASAppMixin, Screen):
 
 def _create_engine(store: FilesystemStore | None = None) -> SnapshotEngine:
     """Create a SnapshotEngine with default settings."""
+    from xinas_history.engine import SnapshotEngine
+    from xinas_history.store import FilesystemStore
+
     s = store or FilesystemStore()
     return SnapshotEngine(store=s)
 

--- a/xinas_menu/screens/mcp.py
+++ b/xinas_menu/screens/mcp.py
@@ -652,6 +652,7 @@ class RemoteAccessScreen(XiNASAppMixin, Screen):
         proto = "https" if tls else "http"
         tokens = cfg.get("tokens", {})
         first_token = next(iter(tokens), None)
+        masked = f"{first_token[:8]}...{first_token[-4:]}" if first_token else ""
 
         _GRN, CYN, BLD, DIM, NC = "\033[32m", "\033[36m", "\033[1m", "\033[2m", "\033[0m"
         lines = [
@@ -663,7 +664,6 @@ class RemoteAccessScreen(XiNASAppMixin, Screen):
             "",
         ]
         if first_token:
-            masked = f"{first_token[:8]}...{first_token[-4:]}"
             lines.append("  claude mcp add \\")
             lines.append("    --transport http \\")
             lines.append(f'    --header "Authorization: Bearer {masked}" \\')

--- a/xinas_menu/screens/snapshot_detail.py
+++ b/xinas_menu/screens/snapshot_detail.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+from typing import TYPE_CHECKING
 
 from textual import work
 from textual.app import ComposeResult
@@ -19,11 +20,15 @@ from xinas_menu.widgets.text_view import ScrollableTextView
 
 _log = logging.getLogger(__name__)
 
-try:
-    from xinas_history.collector import CONFIG_SOURCES
+if TYPE_CHECKING:
     from xinas_history.engine import SnapshotEngine
-    from xinas_history.models import SnapshotType
     from xinas_history.store import FilesystemStore
+
+# Availability probe only — the package __init__ imports every submodule we
+# use, so a successful import guarantees the deferred per-method imports
+# below succeed too. xinas_history may not be installed on dev machines.
+try:
+    import xinas_history  # noqa: F401
 
     HAS_HISTORY = True
 except ImportError:
@@ -205,6 +210,8 @@ class SnapshotDetailScreen(XiNASAppMixin, Screen):
 
         loop = asyncio.get_running_loop()
         try:
+            from xinas_history.store import FilesystemStore
+
             store = FilesystemStore()
             engine = _create_engine(store)
             manifest = await loop.run_in_executor(
@@ -244,6 +251,8 @@ class SnapshotDetailScreen(XiNASAppMixin, Screen):
 
         loop = asyncio.get_running_loop()
         try:
+            from xinas_history.store import FilesystemStore
+
             store = FilesystemStore()
             engine = _create_engine(store)
             manifest = await loop.run_in_executor(
@@ -276,6 +285,9 @@ class SnapshotDetailScreen(XiNASAppMixin, Screen):
 
 def _create_engine(store: FilesystemStore | None = None) -> SnapshotEngine:
     """Create a SnapshotEngine with default settings."""
+    from xinas_history.engine import SnapshotEngine
+    from xinas_history.store import FilesystemStore
+
     s = store or FilesystemStore()
     return SnapshotEngine(store=s)
 
@@ -492,6 +504,8 @@ def _format_full_diff(diff_result) -> str:
 
 def _format_config_files(store, engine, manifest) -> str:
     """Format config file contents captured in the snapshot."""
+    from xinas_history.collector import CONFIG_SOURCES
+    from xinas_history.models import SnapshotType
 
     lines: list[str] = []
     lines.append(f"{_BLD}{_CYN}{'=' * 60}{_NC}")
@@ -546,6 +560,8 @@ def _format_config_files(store, engine, manifest) -> str:
 def _format_runtime_state(store, engine, manifest) -> str:
     """Format runtime state JSON files captured in the snapshot."""
     import json as _json
+
+    from xinas_history.models import SnapshotType
 
     lines: list[str] = []
     lines.append(f"{_BLD}{_CYN}{'=' * 60}{_NC}")

--- a/xinas_menu/screens/startup/startup_menu.py
+++ b/xinas_menu/screens/startup/startup_menu.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import ClassVar
 
 from textual.app import App, ComposeResult
 from textual.binding import Binding
@@ -27,9 +26,9 @@ _MENU_ITEMS_MAIN = [
 class StartupApp(App):
     """Provisioning app (xinas-setup / startup_menu.sh replacement)."""
 
-    CSS_PATH: ClassVar[Path] = Path(__file__).parent.parent.parent / "styles.tcss"
+    CSS_PATH = Path(__file__).parent.parent.parent / "styles.tcss"
 
-    BINDINGS: ClassVar[list[Binding]] = [
+    BINDINGS = [
         Binding("ctrl+c", "quit", "Quit", show=False, priority=True),
     ]
 

--- a/xinas_menu/utils/snapshot_helper.py
+++ b/xinas_menu/utils/snapshot_helper.py
@@ -12,14 +12,6 @@ from typing import Any
 
 _log = logging.getLogger(__name__)
 
-# Guard: xinas_history may not be installed on dev machines.
-try:
-    from xinas_history import FilesystemStore, SnapshotEngine
-
-    _HAS_ENGINE = True
-except ImportError:
-    _HAS_ENGINE = False
-
 
 class SnapshotHelper:
     """Convenience wrapper exposed as ``app.snapshots``."""
@@ -32,15 +24,20 @@ class SnapshotHelper:
         # Any: SnapshotEngine may be unimportable on dev machines, so the
         # attribute cannot reference the class statically.
         self._engine: Any = None
-        if _HAS_ENGINE:
-            try:
-                self._engine = SnapshotEngine(
-                    store=FilesystemStore(),
-                    repo_root=repo_root,
-                    grpc_address=grpc_address,
-                )
-            except Exception:
-                _log.warning("Failed to init SnapshotEngine", exc_info=True)
+        try:
+            # Guard: xinas_history may not be installed on dev machines, so
+            # the import happens here and ImportError means "no engine".
+            from xinas_history import FilesystemStore, SnapshotEngine
+
+            self._engine = SnapshotEngine(
+                store=FilesystemStore(),
+                repo_root=repo_root,
+                grpc_address=grpc_address,
+            )
+        except ImportError:
+            _log.debug("snapshot engine unavailable: xinas_history not installed")
+        except Exception:
+            _log.warning("Failed to init SnapshotEngine", exc_info=True)
 
     @property
     def available(self) -> bool:

--- a/xinas_menu/widgets/menu_list.py
+++ b/xinas_menu/widgets/menu_list.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import ClassVar
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -31,7 +30,7 @@ class NavigableMenu(Widget, can_focus=True):
     auto_focus on the parent screen.
     """
 
-    BINDINGS: ClassVar[list[Binding]] = [
+    BINDINGS = [
         Binding("up", "move_up", "Navigate", show=True, key_display="↑↓"),
         Binding("down", "move_down", "Navigate", show=False),
         Binding("enter", "select", "Select", show=True),

--- a/xinas_menu/widgets/text_view.py
+++ b/xinas_menu/widgets/text_view.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import re
 
 from rich.text import Text
+from textual.types import AnimationLevel, CallbackType, EasingFunction
 from textual.widget import Widget
 from textual.widgets import RichLog
 
@@ -110,18 +111,57 @@ class ScrollableTextView(Widget):
         """Return plain text content (for clipboard operations)."""
         return self._plain_text
 
-    def scroll_page_up(self) -> None:
-        """Scroll content up by one page."""
+    # Signature mirrors Widget.scroll_page_up/down so the override stays
+    # compatible with framework-driven calls; the TUI's own no-arg calls keep
+    # the instant (animate=False) scroll they always had.
+    def scroll_page_up(
+        self,
+        *,
+        animate: bool = False,
+        speed: float | None = None,
+        duration: float | None = None,
+        easing: EasingFunction | str | None = None,
+        force: bool = False,
+        on_complete: CallbackType | None = None,
+        level: AnimationLevel = "basic",
+    ) -> None:
+        """Scroll content up by one page (instant unless animate=True)."""
         try:
             log = self.query_one("#text-view-area", _DisplayLog)
-            log.scroll_page_up(animate=False)
+            log.scroll_page_up(
+                animate=animate,
+                speed=speed,
+                duration=duration,
+                easing=easing,
+                force=force,
+                on_complete=on_complete,
+                level=level,
+            )
         except Exception:
             pass
 
-    def scroll_page_down(self) -> None:
-        """Scroll content down by one page."""
+    def scroll_page_down(
+        self,
+        *,
+        animate: bool = False,
+        speed: float | None = None,
+        duration: float | None = None,
+        easing: EasingFunction | str | None = None,
+        force: bool = False,
+        on_complete: CallbackType | None = None,
+        level: AnimationLevel = "basic",
+    ) -> None:
+        """Scroll content down by one page (instant unless animate=True)."""
         try:
             log = self.query_one("#text-view-area", _DisplayLog)
-            log.scroll_page_down(animate=False)
+            log.scroll_page_down(
+                animate=animate,
+                speed=speed,
+                duration=duration,
+                easing=easing,
+                force=force,
+                on_complete=on_complete,
+                level=level,
+            )
         except Exception:
             pass


### PR DESCRIPTION
Retires four of the deferred CI-bootstrap TODOs and graduates two more gates. Governing doc (`docs/control-path/ci-bootstrap-design.md`) gate matrix updated in the same package.

**Do not merge without operator approval** — lands on `main` via cherry-pick per house rule.

## Commits
1. **pyright `basic` → `standard`** — fixed all 28 resulting errors properly (21 possibly-unbound: the missing-`xinas_history` import paths in the config-history/snapshot screens now degrade to the intended error message instead of latent `NameError`; 7 override-variance: textual base-class signatures mirrored, incl. a latent `TypeError` in `text_view` scroll overrides). No new suppressions.
2. **ansible-lint `min` → `basic`** — 67 findings fixed (31 name-casing with all 22 renamed handlers' `notify:` updated in lockstep, 15 name-templates, 14 missing names, 9 jinja spacing, 3 line-length folds proven byte-identical, 1 key-order); 3 justified `# noqa` for command-vs-module; `var-naming[no-role-prefix]` (357) skipped with documented rationale — role vars are the **public preset contract**, renaming is a breaking change.
3. **Gate flips + new gates** — `openapi-envelope` Spectral rule warn → **error** (0 violations); new **`openapi-compat`** job: `oasdiff breaking` vs the PR base's `api-v1.yaml` (PR-only, action-documented git-ref pattern); **coverage floor** `pytest --cov=xinas_history --cov-fail-under=20` (measured 22.45%); TODO header pruned to the five remaining items with the measured biome expansion blast radius recorded.

## Review
Combined package review: handler/notify set-diff = 0 orphans; YAML folds byte-identical; pyright import restructure proven behavior-equivalent (probe ≡ old failure surface). One Critical caught and fixed pre-push: the oasdiff action runs in a Docker container that cannot see the runner's `/tmp` — base spec now passed as a git ref.

## Gates
pyright 0/0 at standard · ruff check/format clean · pytest 30/30 with cov ≥ 20% · ansible-lint 0 failures at basic · 4/4 playbook syntax-checks · yamllint/markdownlint/spectral clean.

Remaining TODOs after this PR: typescript-lint category expansion (~3.7k diagnostics, own debt package), pyright → strict per module, ansible-lint → production, cov ratchet, MCP smoke test, live contract test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)