### PR TITLE
fix(installer): clear on-host install + uninstall blockers

### DIFF
--- a/collection/roles/doca_ofed/tasks/main.yml
+++ b/collection/roles/doca_ofed/tasks/main.yml
@@ -8,10 +8,17 @@
     state: present
   tags: [ofed, deps]
 
-- name: Add Mellanox GPG key
-  ansible.builtin.apt_key:
-    url: "{{ doca_repo_base }}/GPG-KEY-Mellanox.pub"
-    state: present
+# The DOCA-Host repo is signed by the "NVIDIA DOCA Host" key, published per
+# component as doca_keyring.gpg. The legacy base-path GPG-KEY-Mellanox.pub no
+# longer carries the active signing key (rotated 2026-01 to 70454E6B…DC726C5E41B9CC50),
+# so `apt update` fails with NO_PUBKEY. apt_key is also deprecated on 22.04+;
+# drop the dearmored keyring straight into trusted.gpg.d instead.
+- name: Install NVIDIA DOCA repository signing key
+  ansible.builtin.get_url:
+    url: "{{ doca_repo_base }}/{{ doca_repo_component }}/doca_keyring.gpg"
+    dest: /etc/apt/trusted.gpg.d/mellanox-doca.gpg
+    mode: '0644'
+    force: true
   tags: [ofed, repo]
 
 - name: Add DOCA-OFED APT repo

--- a/collection/roles/perf_tuning/tasks/main.yml
+++ b/collection/roles/perf_tuning/tasks/main.yml
@@ -82,35 +82,27 @@
 # knob lives under /sys, not /proc/sys), writing these keys makes the
 # xinas-perf-runtime service's `sysctl -p` exit 1 at every boot. Gate on the
 # actual sysctl path so unsupported kernels neither apply nor persist the keys.
+# Same stat-then-gate idiom as roce_lossless/tasks/configure_roce.yml; items
+# below opt in via `supported:` — undecorated items always apply.
 - name: Detect MGLRU sysctl support
   ansible.builtin.stat:
     path: /proc/sys/vm/lru_gen/enabled
   register: perf_mglru
   tags: [memory, vm]
 
-- name: Apply (or purge) MGLRU sysctl parameters based on kernel support
-  ansible.builtin.sysctl:
-    name: "{{ item.key }}"
-    value: "{{ item.value }}"
-    state: "{{ 'present' if perf_mglru.stat.exists else 'absent' }}"
-    sysctl_file: /etc/sysctl.d/90-perf-vm.conf
-    reload: "{{ perf_mglru.stat.exists }}"
-    ignoreerrors: yes
-  loop:
-    # MGLRU (Multi-Gen LRU) - kernel 6.1+ (only when /proc/sys/vm/lru_gen exists)
-    - { key: 'vm.lru_gen.enabled', value: '{{ perf_vm_lru_gen }}' }
-    - { key: 'vm.lru_gen.min_ttl_ms', value: '{{ perf_vm_min_ttl_ms }}' }
-  tags: [memory, vm]
-
 - name: Apply VM sysctl parameters for memory management
   ansible.builtin.sysctl:
     name: "{{ item.key }}"
     value: "{{ item.value }}"
-    state: present
+    state: "{{ 'present' if (item.supported | default(true) | bool) else 'absent' }}"
     sysctl_file: /etc/sysctl.d/90-perf-vm.conf
-    reload: yes
+    reload: "{{ item.supported | default(true) | bool }}"
     ignoreerrors: yes
   loop:
+    # MGLRU (Multi-Gen LRU) - kernel 6.1+ (only when /proc/sys/vm/lru_gen exists;
+    # 'absent' purges a stale entry left by a prior kernel that did support it)
+    - { key: 'vm.lru_gen.enabled', value: '{{ perf_vm_lru_gen }}', supported: "{{ perf_mglru.stat.exists }}" }
+    - { key: 'vm.lru_gen.min_ttl_ms', value: '{{ perf_vm_min_ttl_ms }}', supported: "{{ perf_mglru.stat.exists }}" }
     # Watermark
     - { key: 'vm.watermark_scale_factor', value: '{{ perf_vm_watermark_scale_factor }}' }
     # Writeback

--- a/collection/roles/perf_tuning/tasks/main.yml
+++ b/collection/roles/perf_tuning/tasks/main.yml
@@ -77,6 +77,31 @@
   tags: [memory]
 
 # ===== VM / Memory sysctl parameters =====
+# MGLRU (vm.lru_gen.*) is only exposed when the running kernel was built with
+# CONFIG_LRU_GEN_SYSFS/sysctl. On kernels without it (e.g. stock Ubuntu where the
+# knob lives under /sys, not /proc/sys), writing these keys makes the
+# xinas-perf-runtime service's `sysctl -p` exit 1 at every boot. Gate on the
+# actual sysctl path so unsupported kernels neither apply nor persist the keys.
+- name: Detect MGLRU sysctl support
+  ansible.builtin.stat:
+    path: /proc/sys/vm/lru_gen/enabled
+  register: perf_mglru
+  tags: [memory, vm]
+
+- name: Apply (or purge) MGLRU sysctl parameters based on kernel support
+  ansible.builtin.sysctl:
+    name: "{{ item.key }}"
+    value: "{{ item.value }}"
+    state: "{{ 'present' if perf_mglru.stat.exists else 'absent' }}"
+    sysctl_file: /etc/sysctl.d/90-perf-vm.conf
+    reload: "{{ perf_mglru.stat.exists }}"
+    ignoreerrors: yes
+  loop:
+    # MGLRU (Multi-Gen LRU) - kernel 6.1+ (only when /proc/sys/vm/lru_gen exists)
+    - { key: 'vm.lru_gen.enabled', value: '{{ perf_vm_lru_gen }}' }
+    - { key: 'vm.lru_gen.min_ttl_ms', value: '{{ perf_vm_min_ttl_ms }}' }
+  tags: [memory, vm]
+
 - name: Apply VM sysctl parameters for memory management
   ansible.builtin.sysctl:
     name: "{{ item.key }}"
@@ -86,9 +111,6 @@
     reload: yes
     ignoreerrors: yes
   loop:
-    # MGLRU (Multi-Gen LRU) - kernel 6.1+
-    - { key: 'vm.lru_gen.enabled', value: '{{ perf_vm_lru_gen }}' }
-    - { key: 'vm.lru_gen.min_ttl_ms', value: '{{ perf_vm_min_ttl_ms }}' }
     # Watermark
     - { key: 'vm.watermark_scale_factor', value: '{{ perf_vm_watermark_scale_factor }}' }
     # Writeback

--- a/collection/roles/xinas_uninstall/tasks/30_teardown_raid.yml
+++ b/collection/roles/xinas_uninstall/tasks/30_teardown_raid.yml
@@ -81,7 +81,9 @@
       changed_when: false
 
     - name: "RAID | delete xiNAS-named arrays"
-      ansible.builtin.command: "xicli raid delete -n {{ item }} --force"
+      # xicli's raid verb is 'destroy' (not 'delete'); 'delete' is an invalid
+      # choice and aborts the teardown, leaving the arrays online.
+      ansible.builtin.command: "xicli raid destroy -n {{ item }} --force"
       loop: "{{ _xinas_array_names | default([]) }}"
       register: _raid_delete
       changed_when: _raid_delete.rc == 0

--- a/collection/roles/xinas_uninstall/tasks/70_remove_paths.yml
+++ b/collection/roles/xinas_uninstall/tasks/70_remove_paths.yml
@@ -1,12 +1,16 @@
 ---
 # Phase G — remove xiNAS-owned directories and small per-file artifacts.
 
+# NOTE: xinas_install_dir (/opt/xiNAS) is intentionally NOT removed here. It
+# holds this playbook/role tree, which Ansible needs for module execution
+# through the remaining phases (80 edits, 90 packages, 91-93 optional). Removing
+# it now aborts all of them with "No such file or directory: /opt/xiNAS/playbooks".
+# It is removed as the very last step in phase 99 (finalize).
 - name: "Paths | remove xiNAS-owned directories"
   ansible.builtin.file:
     path: "{{ item }}"
     state: absent
   loop:
-    - "{{ xinas_install_dir }}"          # /opt/xiNAS
     - "{{ xinas_state_dir }}"            # /var/lib/xinas
     - "{{ xinas_log_dir }}"              # /var/log/xinas
     - "{{ xinas_mcp_etc_dir }}"          # /etc/xinas-mcp

--- a/collection/roles/xinas_uninstall/tasks/92_optional_ofed.yml
+++ b/collection/roles/xinas_uninstall/tasks/92_optional_ofed.yml
@@ -42,13 +42,14 @@
 - name: "OFED | remove Mellanox apt keys (legacy apt_key + keyring drop-ins)"
   ansible.builtin.shell: |
     set +e
-    # apt-key was the install method (collection/roles/doca_ofed/tasks/main.yml: apt_key url=...).
+    # apt-key was the legacy install method; current installer drops the
+    # dearmored keyring straight into trusted.gpg.d (collection/roles/doca_ofed/tasks/main.yml).
     if command -v apt-key >/dev/null 2>&1; then
       for key in $(apt-key list 2>/dev/null | awk '/Mellanox/{getline; print $2}'); do
         apt-key del "$key" 2>/dev/null || true
       done
     fi
-    rm -f /etc/apt/keyrings/mellanox.gpg /etc/apt/trusted.gpg.d/mellanox.gpg 2>/dev/null
+    rm -f /etc/apt/keyrings/mellanox.gpg /etc/apt/trusted.gpg.d/mellanox.gpg /etc/apt/trusted.gpg.d/mellanox-doca.gpg 2>/dev/null
     exit 0
   args:
     executable: /bin/bash

--- a/collection/roles/xinas_uninstall/tasks/99_finalize.yml
+++ b/collection/roles/xinas_uninstall/tasks/99_finalize.yml
@@ -68,3 +68,12 @@
 - name: "Finalize | echo summary path"
   ansible.builtin.debug:
     msg: "Uninstall summary written to {{ xinas_uninstall_summary_path }}."
+
+# MUST be the final task: this deletes the playbook/role tree Ansible is
+# running from. Anything after it fails with "No such file or directory:
+# {{ xinas_install_dir }}/playbooks". Moved here from phase 70 (see note there)
+# so the package/perf/state phases can complete first.
+- name: "Finalize | remove the xiNAS install dir (very last step)"
+  ansible.builtin.file:
+    path: "{{ xinas_install_dir }}"
+    state: absent

--- a/docs/Installer/uninstall-spec.md
+++ b/docs/Installer/uninstall-spec.md
@@ -250,7 +250,7 @@ mountpoints are gone.
    Fallback: `xicli raid show -f json` and `xicli pool show -f json`,
    then match against the names xiNAS uses (`data`, `log`,
    `*_spare_pool`).
-2. For every array found in (1): `xicli raid delete -n <name> --force`.
+2. For every array found in (1): `xicli raid destroy -n <name> --force`.
 3. For every pool found in (1): `xicli pool delete -n <name>`.
 4. For every NVMe device that backed an array: `xicli drive clean -d
    <device>` (best-effort).

--- a/presets/default/playbook.yml
+++ b/presets/default/playbook.yml
@@ -7,9 +7,11 @@
     - role: doca_ofed
     - role: net_controllers
     - role: xiraid_classic  # EULA is accepted automatically
+    - role: nvme_namespace  # Auto-detect drives and create namespaces (generates xiraid_arrays)
     - role: raid_fs
     - role: exports       # manage /etc/exports
     - role: nfs_server    # configure kernel NFS server
+    - role: xinas_node_build  # Node 20 + xiNAS-MCP build (dist/ for api/agent/mcp)
     - role: xinas_nfs_helper  # NFS helper daemon (serves the agent + legacy MCP)
     - role: xinas_mcp     # legacy MCP server (AI assistant bridge)
     - role: xinas_menu    # Python/Textual management console (replaces Bash menus)

--- a/presets/xinnorVM/playbook.yml
+++ b/presets/xinnorVM/playbook.yml
@@ -14,6 +14,7 @@
     - role: raid_fs
     - role: exports       # manage /etc/exports
     - role: nfs_server    # configure kernel NFS server
+    - role: xinas_node_build  # Node 20 + xiNAS-MCP build (dist/ for api/agent/mcp)
     - role: xinas_nfs_helper  # NFS helper daemon (serves the agent + legacy MCP)
     - role: xinas_mcp     # legacy MCP server (AI assistant bridge)
     - role: xinas_menu    # Python/Textual management console (replaces Bash menus)

--- a/xinas_history/store.py
+++ b/xinas_history/store.py
@@ -78,7 +78,7 @@ class FilesystemStore:
     def ensure_dirs(self) -> None:
         """Create the store directory structure if missing.  Directories are
         created with mode 0o700."""
-        for d in (self._root, self.baseline_path, self.snapshots_path, self.state_path):
+        for d in (self._root, self.snapshots_path, self.state_path):  # NOT baseline_path: write_snapshot creates it atomically; pre-creating it makes the baseline snapshot always fail with "already exists"
             d.mkdir(parents=True, exist_ok=True)
             os.chmod(str(d), _DIR_MODE)
 


### PR DESCRIPTION
Installing/uninstalling a fresh node from `main` on real hardware (Ubuntu 24.04, 22× Kioxia NVMe + Mellanox/DOCA) failed at several points. Each was root-caused on the host and verified with a fix→re-check loop until `autoinstall.sh --preset default` exits 0, all roles report `:ok`, and `uninstall.sh` fully tears down.

### Install fixes
1. **doca_ofed** — repo signing key rotated to the "NVIDIA DOCA Host" key (`70454E6B…DC726C5E41B9CC50`); role fetched the stale `GPG-KEY-Mellanox.pub`, so `apt update` died with `NO_PUBKEY`. Use the published `doca_keyring.gpg` (also drops deprecated `apt_key`).
2. **presets** — `autoinstall` runs `presets/<name>/playbook.yml` (copied over `site.yml`). `default` lacked `nvme_namespace` (→ `raid_fs`: `xiraid_arrays is not defined`) and `xinas_node_build` (→ `xinas_mcp`: missing `dist/mcp-stdio.js`); `xinnorVM` lacked `xinas_node_build`. Brought both in line with `site.yml`.
3. **xinas_history** — `ensure_dirs()` pre-created `baseline/`, so `write_snapshot` refused it; the baseline snapshot failed every run (`Snapshot path already exists`). `baseline/` is created atomically by `write_snapshot`.
4. **perf_tuning** — `vm.lru_gen.*` written even without `/proc/sys/vm/lru_gen`, so the `xinas-perf-runtime` oneshot's `sysctl -p` exited 1 at boot (defeating the THP/swappiness re-apply). Gate on kernel support; purge when unsupported.

### Uninstall fixes
5. **xinas_uninstall** — `xicli raid delete` is an invalid verb; it's `destroy`. Teardown aborted with the data/log arrays still online.
6. **xinas_uninstall** — phase 70 removed `/opt/xiNAS` (the running playbook tree) before the package/perf/state phases, aborting them (`No such file or directory: /opt/xiNAS/playbooks`) and leaving xiRAID, DOCA-OFED, perf tuning and state dirs behind. Moved install-dir removal to the last step of phase 99 (finalize).

### Verification (real on-host output)
- `autoinstall.sh --preset default` → exit 0; 15 roles `:ok` ending `motd:ok`; RAID5 online, XFS mounted at `/mnt/data`, license `status: valid`; `xinas-history snapshot list --format json` rc 0; baseline populated; `xinas-nfs-helper` active + socket; perf-runtime enabled+active; `defrag=[never]`, `swappiness=1`; unit suite `101 passed`.
- `uninstall.sh --yes --remove-xiraid --remove-ofed --revert-perf-tuning` → all packages, services, systemd units, state dirs, and OS tunings removed; host verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
