### PR TITLE
fix(raid_fs): default raid_create_min_free_mb inline (survives preset-apply)

### DIFF
--- a/collection/roles/raid_fs/tasks/create_array.yml
+++ b/collection/roles/raid_fs/tasks/create_array.yml
@@ -32,11 +32,11 @@
   ansible.builtin.fail:
     msg: >-
       Only {{ _mem_avail_kb.stdout | int // 1024 }} MiB free after reclaim, but
-      creating array '{{ item.name }}' needs >= {{ raid_create_min_free_mb }} MiB
+      creating array '{{ item.name }}' needs >= {{ raid_create_min_free_mb | default(2560) }} MiB
       for the xiRAID mempool (memory_prealloc). Proceeding would fail with a
       kernel '__get_free_pages() failed … RAID creation failed' error. Add RAM,
       reduce the disk count for this array, or lower its memory_prealloc_mb.
-  when: (_mem_avail_kb.stdout | int // 1024) < (raid_create_min_free_mb | int)
+  when: (_mem_avail_kb.stdout | int // 1024) < (raid_create_min_free_mb | default(2560) | int)
   tags: [raid_fs, raid]
 
 - name: Create array {{ item.name }}


### PR DESCRIPTION
Follow-up to the #23 memory-headroom fix.

`raid_create_min_free_mb` was defined only in `roles/raid_fs/defaults/main.yml`, but `autoinstall.sh`'s apply-preset step overwrites that file with `presets/<name>/raid_fs.yml` (which doesn't define it). At runtime the var was therefore undefined and the "Fail early if free memory is below the xiRAID mempool floor" conditional errored, aborting `raid_fs` on a fresh install:

```
The conditional check '(_mem_avail_kb.stdout | int // 1024) < (raid_create_min_free_mb | int)' failed …
'raid_create_min_free_mb' is undefined
```

Fix: reference it inline as `raid_create_min_free_mb | default(2560)` in both the `when:` and the fail message, so it no longer depends on the role-defaults file surviving the preset copy.

Verified on-host: a full `autoinstall.sh --preset default` now completes **exit 0**, the RAID builds, and install-state reports all 15 roles `:ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
