### PR TITLE
fix(installer): netplan empty-mode stub (#15) + uninstall non-tty safety & banner (#26,#27)

### DIFF
--- a/collection/roles/net_controllers/tasks/main.yml
+++ b/collection/roles/net_controllers/tasks/main.yml
@@ -196,6 +196,30 @@
   when: net_ip_pool_enabled | bool and (net_allocated_ips | default({}) | length > 0)
   tags: [network]
 
+# Empty mode: pool enabled but no high-speed interfaces detected. Neither the
+# pool-deploy (needs allocated_ips) nor the manual-deploy (needs pool disabled)
+# task fires, so without this the file is never created (finding #15). Render a
+# valid, commented placeholder so the file always exists and documents why it is
+# empty.
+- name: Render placeholder netplan stub when no high-speed interfaces detected (empty mode)
+  ansible.builtin.copy:
+    dest: /etc/netplan/99-xinas.yaml
+    owner: root
+    group: root
+    mode: '0600'
+    content: |
+      # Managed by xiNAS (net_controllers role).
+      # No high-speed InfiniBand/mlx5 interfaces were detected on this host, so
+      # no addresses were assigned. Re-run the installer after DOCA-OFED brings
+      # the NICs up, or add interfaces manually under network.ethernets below.
+      network:
+        version: 2
+        # ethernets: {}
+  become: true
+  notify: apply netplan
+  when: net_ip_pool_enabled | bool and (net_allocated_ips | default({}) | length == 0)
+  tags: [network]
+
 # Fallback: Manual mode (pool disabled)
 - name: Deploy static netplan configuration (manual mode)
   ansible.builtin.template:

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -83,8 +83,11 @@ warn() { echo -e "  ${YELLOW}⚠${NC} $*"; }
 ask_yes_no() {
     # ask_yes_no "Question text"  → echoes "true" or "false" (default false)
     local prompt="$1"
-    local reply
-    read -r -p "  $prompt [y/N] " reply </dev/tty
+    # Finding #26: default + swallow the read so a missing TTY (non-interactive
+    # run) answers "no" cleanly instead of leaving `reply` unset and tripping
+    # `set -u` with "unbound variable".
+    local reply=""
+    read -r -p "  $prompt [y/N] " reply </dev/tty || reply=""
     if [[ "$reply" =~ ^[Yy]$ ]]; then
         echo "true"
     else
@@ -155,11 +158,14 @@ echo -e "  ${RED}${BOLD}╭─────────────────�
 echo -e "  ${RED}${BOLD}│  DESTRUCTIVE ACTION                                       │${NC}"
 echo -e "  ${RED}${BOLD}╰───────────────────────────────────────────────────────────╯${NC}"
 echo ""
+# Finding #27 / uninstall-spec §5: the banner must call out *permanent* data loss.
+echo -e "  ${RED}${BOLD}This permanently destroys data and CANNOT be undone.${NC}"
+echo ""
 echo -e "  Mandatory cleanup includes:"
 echo -e "    ${DIM}-${NC} Stopping and removing xiNAS MCP and NFS-helper services"
 echo -e "    ${DIM}-${NC} Removing NFS exports created by xiNAS"
 echo -e "    ${DIM}-${NC} Unmounting and removing xiRAID Classic arrays + XFS filesystems"
-echo -e "      ${RED}(THIS DESTROYS THE DATA ON /mnt/data AND ANY OTHER xiNAS-MANAGED MOUNT)${NC}"
+echo -e "      ${RED}(THIS PERMANENTLY DESTROYS THE DATA ON /mnt/data AND ANY OTHER xiNAS-MANAGED MOUNT)${NC}"
 echo -e "    ${DIM}-${NC} Removing ${WHITE}${INSTALL_DIR}${NC} and xiNAS state under /var/lib/xinas, /var/log/xinas"
 echo -e "    ${DIM}-${NC} Removing xiNAS systemd units, wrappers, sudoers, and motd hooks"
 echo ""
@@ -177,7 +183,13 @@ fi
 # ── Confirmation gate ─────────────────────────────────────────────────────────
 if [[ "$SKIP_GATE" != "true" ]]; then
     echo -e "  To proceed, type this host's hostname (${BOLD}${HOSTNAME_VALUE}${NC}):"
-    read -r -p "  > " typed </dev/tty
+    # Finding #26: under `set -u`, a run with no controlling TTY (e.g. piped
+    # stdin) makes the /dev/tty redirect fail and leaves `typed` unset, so the
+    # comparison below aborts with "unbound variable" instead of the spec's clean
+    # "declined" exit 2. Default it and swallow the read failure so a missing TTY
+    # is treated as a non-match.
+    typed=""
+    read -r -p "  > " typed </dev/tty || typed=""
     if [[ "$typed" != "$HOSTNAME_VALUE" ]]; then
         echo ""
         warn "Hostname did not match. No changes made."


### PR DESCRIPTION
Closes the three findings from the 2026-07-01 feedback that were still open in code (the rest are already resolved on `main` — see the status note below).

### #15 — netplan stub not rendered in empty mode
`net_controllers` deploys `/etc/netplan/99-xinas.yaml` only when the pool is enabled **and** at least one IP was allocated, or when the pool is disabled (manual mode). When the pool is enabled but **no** high-speed InfiniBand/mlx5 interface is detected, `net_allocated_ips` is empty and neither task fires, so the file is never created (spec §3.5 wants a commented stub). Added an empty-mode task that renders a valid, commented placeholder in exactly that case.
Verified on-host: running the task with `net_allocated_ips={}` produces a valid netplan file (`network.version: 2`).

### #26 — uninstall.sh crashes with "unbound variable" on a non-tty run
Under `set -u`, `read … </dev/tty` fails when there is no controlling TTY (e.g. `echo '' | sudo uninstall.sh`), leaving `typed` (hostname gate) and `reply` (`ask_yes_no`) unset, so the script aborted with a bash error instead of the spec's clean exit 2. Both now default to `""` and swallow the read failure, so a missing TTY is treated as "declined".
Verified on-host: `echo '' | sudo uninstall.sh --dry-run` → **exit 2**, "No changes made", **zero** unbound-variable errors (previously exit 1 + 4 error lines). Fails safe, and now *cleanly*.

### #27 — destructive banner omits "permanently"
uninstall-spec §5 requires the banner to call out *permanent* data loss. Added an explicit "This permanently destroys data and CANNOT be undone." line and reworded the mount-destruction warning to "PERMANENTLY DESTROYS".

### Status of the rest of the 2026-07-01 findings (already resolved on `main`, re-verified this pass)
Resolved: #1, #2, #3 (hostname now = `xiNAS-<HWKEY>`), #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #16, #19, #22, #23 (+ the follow-up in #231), #24, #25.
Engine/spec (not fixable in this repo): #17 & #21 (closed-source xiRAID daemon/engine — client-side workarounds already in place), #18 & #20 (spec/engine drive-minimum reconciliation — doc-level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
