### PR TITLE
docs(uninstall-spec): sync §5 banner example with #27's permanent-loss wording

### DIFF
--- a/docs/Installer/uninstall-spec.md
+++ b/docs/Installer/uninstall-spec.md
@@ -380,11 +380,13 @@ Before any phase runs, `uninstall.sh` displays:
 ```
 This will permanently remove xiNAS from this host.
 
+This permanently destroys data and CANNOT be undone.
+
 Mandatory cleanup includes:
   - Stopping and removing the xiNAS MCP server and NFS helper
   - Removing NFS exports created by xiNAS
   - Unmounting and removing xiRAID Classic arrays + XFS filesystems
-    (THIS DESTROYS THE DATA ON /mnt/data AND ANY OTHER xiNAS-MANAGED MOUNT)
+    (THIS PERMANENTLY DESTROYS THE DATA ON /mnt/data AND ANY OTHER xiNAS-MANAGED MOUNT)
   - Removing the /opt/xiNAS source tree
   - Removing xiNAS history at /var/lib/xinas/config-history
 


### PR DESCRIPTION
## Summary
- PR #233 (finding #27) added a new "This permanently destroys data and CANNOT be undone." line to `uninstall.sh`'s confirmation banner and reworded the mount-destruction warning to "PERMANENTLY DESTROYS", but the §5 example banner in `docs/Installer/uninstall-spec.md` (the uninstaller contract doc) wasn't updated to match — a spec/code drift caught during review of #233.
- This is a doc-only sync: no behavior change.

## Test plan
- [x] Diffed the updated example against `uninstall.sh`'s actual banner output (lines match for the two changed lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)