### PR TITLE
fix(mcp): deploy xinas_api/xinas_agent (#28) + agent runtime fixes (#17,#29,#30,#31)

### DIFF
--- a/collection/roles/xinas_uninstall/tasks/10_quiesce_services.yml
+++ b/collection/roles/xinas_uninstall/tasks/10_quiesce_services.yml
@@ -9,6 +9,10 @@
     state: stopped
     enabled: false
   loop:
+    # xinas-agent + xinas-api are the MCP/observation stack (finding #33,
+    # symmetric to #28). Stop the agent before the api it depends on.
+    - xinas-agent.service
+    - xinas-api.service
     - xinas-mcp.service
     - xinas-nfs-helper.service
   register: _quiesce_stop

--- a/collection/roles/xinas_uninstall/tasks/50_remove_services.yml
+++ b/collection/roles/xinas_uninstall/tasks/50_remove_services.yml
@@ -9,6 +9,8 @@
     state: stopped
     enabled: false
   loop:
+    - xinas-agent.service
+    - xinas-api.service
     - xinas-mcp.service
     - xinas-nfs-helper.service
     - xinas-perf-runtime.service
@@ -19,14 +21,20 @@
     path: "{{ item }}"
     state: absent
   loop:
+    - /etc/systemd/system/xinas-agent.service
+    - /etc/systemd/system/xinas-api.service
     - /etc/systemd/system/xinas-mcp.service
     - /etc/systemd/system/xinas-nfs-helper.service
     - /etc/systemd/system/xinas-perf-runtime.service
 
-- name: "Services | delete NFS-helper runtime directory"
+- name: "Services | delete xiNAS runtime directories"
   ansible.builtin.file:
-    path: /run/xinas-nfs-helper
+    path: "{{ item }}"
     state: absent
+  loop:
+    - /run/xinas-nfs-helper
+    - /run/xinas                 # api/agent sockets (finding #33)
+    - /usr/lib/tmpfiles.d/xinas-api.conf
 
 - name: "Services | daemon-reload"
   ansible.builtin.systemd:
@@ -38,7 +46,7 @@
       {{
         uninstall_summary | combine({
           'removed': uninstall_summary.removed + [
-            ['Service units', 'xinas-mcp.service, xinas-nfs-helper.service, xinas-perf-runtime.service']
+            ['Service units', 'xinas-agent.service, xinas-api.service, xinas-mcp.service, xinas-nfs-helper.service, xinas-perf-runtime.service']
           ]
         })
       }}

--- a/collection/roles/xinas_uninstall/tasks/70_remove_paths.yml
+++ b/collection/roles/xinas_uninstall/tasks/70_remove_paths.yml
@@ -16,6 +16,8 @@
     - "{{ xinas_log_dir }}"              # /var/log/xinas
     - "{{ xinas_mcp_etc_dir }}"          # /etc/xinas-mcp
     - "{{ xinas_mcp_lib_dir }}"          # /usr/lib/xinas-mcp
+    - /etc/xinas-api                     # api config + tokens (finding #33)
+    - /etc/xinas-agent                   # agent config + token (finding #33)
 
 - name: "Paths | remove xiNAS-owned single files"
   ansible.builtin.file:

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -13,6 +13,8 @@
     - role: exports       # manage /etc/exports
     - role: nfs_server    # configure kernel NFS server
     - role: xinas_node_build  # Node 20 + xiNAS-MCP build (dist/ for api/agent/mcp)
+    - role: xinas_api     # xinas-api.service: serves the /mcp endpoint on /run/xinas/api.sock (finding #28)
+    - role: xinas_agent   # xinas-agent.service (meta-depends on xinas_api for the agent-token)
     - role: xinas_nfs_helper  # NFS helper daemon (serves the agent + legacy MCP)
     - role: xinas_mcp     # LEGACY MCP server (retiring in S8; shim after T15)
     - role: xinas_menu    # Python/Textual management console (replaces Bash menus)

--- a/presets/default/playbook.yml
+++ b/presets/default/playbook.yml
@@ -12,6 +12,8 @@
     - role: exports       # manage /etc/exports
     - role: nfs_server    # configure kernel NFS server
     - role: xinas_node_build  # Node 20 + xiNAS-MCP build (dist/ for api/agent/mcp)
+    - role: xinas_api     # xinas-api.service: serves the /mcp endpoint on /run/xinas/api.sock (finding #28)
+    - role: xinas_agent   # xinas-agent.service (meta-depends on xinas_api for the agent-token)
     - role: xinas_nfs_helper  # NFS helper daemon (serves the agent + legacy MCP)
     - role: xinas_mcp     # legacy MCP server (AI assistant bridge)
     - role: xinas_menu    # Python/Textual management console (replaces Bash menus)

--- a/presets/xinnorVM/playbook.yml
+++ b/presets/xinnorVM/playbook.yml
@@ -15,6 +15,8 @@
     - role: exports       # manage /etc/exports
     - role: nfs_server    # configure kernel NFS server
     - role: xinas_node_build  # Node 20 + xiNAS-MCP build (dist/ for api/agent/mcp)
+    - role: xinas_api     # xinas-api.service: serves the /mcp endpoint on /run/xinas/api.sock (finding #28)
+    - role: xinas_agent   # xinas-agent.service (meta-depends on xinas_api for the agent-token)
     - role: xinas_nfs_helper  # NFS helper daemon (serves the agent + legacy MCP)
     - role: xinas_mcp     # legacy MCP server (AI assistant bridge)
     - role: xinas_menu    # Python/Textual management console (replaces Bash menus)

--- a/xiNAS-MCP/src/agent/task/xinas-history-bridge.ts
+++ b/xiNAS-MCP/src/agent/task/xinas-history-bridge.ts
@@ -98,7 +98,12 @@ export class XinasHistoryBridge {
 
   constructor(opts: XinasHistoryBridgeOptions) {
     this.#runSubprocess = opts.runSubprocess;
-    this.#python = opts.python ?? 'python3';
+    // Finding #30: bare 'python3' is the system interpreter, which has no
+    // xinas_history module ("No module named xinas_history") and fails every
+    // ConfigSnapshot sweep. The deployment points XINAS_HISTORY_PYTHON at the
+    // xiNAS venv (with PYTHONPATH=/opt/xiNAS) via the systemd unit — matching
+    // the xinas-history CLI wrapper.
+    this.#python = opts.python ?? process.env.XINAS_HISTORY_PYTHON ?? 'python3';
   }
 
   /**

--- a/xiNAS-MCP/src/agent/xiraid/client.ts
+++ b/xiNAS-MCP/src/agent/xiraid/client.ts
@@ -147,7 +147,10 @@ export function createGrpcTransport(): XiraidTransport {
   return {
     async raidShow(): Promise<unknown> {
       const client = await getClient();
-      const res = await raidShow(client, {});
+      // units:'g' is required — the xiRAID daemon's formatter throws
+      // "13 INTERNAL: Unsupported unit: None" on an unset unit (finding #17),
+      // which otherwise fails every array observation sweep.
+      const res = await raidShow(client, { units: 'g' });
       return res.data ?? [];
     },
     async raidCreate(req: RaidCreateRequest): Promise<void> {
@@ -188,7 +191,8 @@ export function createGrpcTransport(): XiraidTransport {
     },
     async poolShow(): Promise<unknown> {
       const client = await getClient();
-      const res = await poolShow(client, {});
+      // units:'g' — same daemon "Unsupported unit: None" crash as raidShow (#17).
+      const res = await poolShow(client, { units: 'g' });
       return res.data ?? [];
     },
     async raidImportShow(): Promise<unknown> {

--- a/xiNAS-MCP/xinas-agent.service
+++ b/xiNAS-MCP/xinas-agent.service
@@ -21,10 +21,20 @@ SyslogIdentifier=xinas-agent
 # drop after bind) is a future hardening step (see ADR-0002 open questions).
 User=root
 Group=root
+# Finding #31: the agent POSTs observations to the api's /internal/v1/observed
+# over /run/xinas/api.sock, which is 0660 xinas-api:xinas-admin. The sandbox
+# drops CAP_DAC_OVERRIDE, so root cannot bypass the mode — join xinas-admin so
+# the group bit grants access (auth is still the agent-token).
+SupplementaryGroups=xinas-admin
 
 # Environment
 Environment=XINAS_AGENT_CONFIG=/etc/xinas-agent/config.json
 Environment=NODE_ENV=production
+# Finding #30: the ConfigSnapshot collector shells out to xinas_history; point it
+# at the xiNAS venv + package root, exactly like the xinas-history CLI wrapper,
+# so `-m xinas_history` resolves (system python3 has no such module).
+Environment=XINAS_HISTORY_PYTHON=/opt/xiNAS/venv/bin/python3
+Environment=PYTHONPATH=/opt/xiNAS
 
 # --- Filesystem isolation ---
 # ProtectSystem=strict makes / read-only except for explicit ReadWritePaths.
@@ -45,7 +55,10 @@ ProtectHome=true
 # api's /internal/v1/observed. /var/lib/xinas is read-only below (the agent
 # only reads /var/lib/xinas/controller-id). Listing /var/lib/xinas/state in
 # both ReadWritePaths and under a ReadOnlyPaths parent was contradictory.
-ReadWritePaths=/run/xinas /var/log/xinas /etc/systemd/system /etc/netplan /run/netplan /run/systemd
+# Finding #29: /run/netplan (and /etc/netplan on netplan-less hosts) may not
+# exist; a non-optional ReadWritePaths entry fails namespace setup with
+# 226/NAMESPACE and the agent restart-loops. '-' makes them optional.
+ReadWritePaths=/run/xinas /var/log/xinas /etc/systemd/system -/etc/netplan -/run/netplan /run/systemd
 #   /etc/netplan         — S6 network executors (ADR-0008 §Sandbox): the
 #                          full-file 99-xinas.yaml render + the audited
 #                          cleanup of managed-iface stanzas in foreign files.


### PR DESCRIPTION
## Summary
The MCP `/mcp` endpoint lives in `xinas-api.service`, but **neither `xinas_api` nor `xinas_agent` was in `site.yml` or any preset** — so on every install the `xinas_mcp` stdio adapter had nothing to connect to (`xinas-api unreachable at /run/xinas/api.sock`). Deploying them surfaced four more bugs that had never executed in a real install. All found and fixed on-host during an install→share→MCP test loop.

| # | Bug | Fix |
|---|-----|-----|
| **28** | `xinas_api`/`xinas_agent` roles absent from all playbooks → MCP endpoint never deployed | add both after `xinas_node_build` (site.yml + both presets) |
| **29** | `xinas-agent.service` `ReadWritePaths=/run/netplan` (may not exist) → systemd `226/NAMESPACE` restart loop | mark netplan paths optional: `-/etc/netplan -/run/netplan` |
| **17** | agent's `raidShow`/`poolShow` called with no unit → xiRAID daemon `13 INTERNAL: Unsupported unit: None` → every array/pool sweep fails | pass `units:'g'` |
| **30** | ConfigSnapshot sweep runs bare `python3 -m xinas_history` → `No module named xinas_history` | read `XINAS_HISTORY_PYTHON`; unit points it + `PYTHONPATH` at the xiNAS venv |
| **31** | root agent (no `CAP_DAC_OVERRIDE`) can't open `0660 xinas-api:xinas-admin` `api.sock` → `EACCES` | `SupplementaryGroups=xinas-admin` |

## Verification (on-host)
- Before: `initialize` → `xinas-api unreachable`. After #28: `initialize` + `tools/list` return **60 tools**; `tools/call` executes.
- After #29/#17/#30/#31: `xinas-agent` runs with **zero sweep failures** and connects to the api (no more EACCES).
- MCP transport, protocol, tool discovery, and tool execution all functional.

## Known remaining gap (documented, not fixed here)
**#32** — the api never seeds `/xinas/v1/cluster` + `/xinas/v1/nodes/`, so observed-state reads (`arrays.list`, `system.get`) still return `cluster not initialized` / empty even though the agent observes cleanly. This is a control-plane bootstrap question (who seeds the cluster/node record on first install?) that needs product input rather than a blind fix.

Note: `dist/` is gitignored and rebuilt by `xinas_node_build` at install, so the TS fixes (#17, #30) take effect on the next install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
