### PR TITLE
fix(api): self-seed cluster + node singletons at startup (ADR-0016, #32)

### DIFF
--- a/docs/control-path/adr/0016-infrastructure-bootstrap.md
+++ b/docs/control-path/adr/0016-infrastructure-bootstrap.md
@@ -1,0 +1,157 @@
+# ADR-0016: Infrastructure bootstrap — xinas-api self-seeds Cluster + Node
+
+- **Status:** accepted
+- **Date:** 2026-07-02
+- **Stream:** install-loop finding #32 (S8 follow-on; PR #236 documented, deferred)
+- **Supersedes / amends:** fills the seeding gap ADR-0003 left open — the
+  key layout defines `/xinas/v1/cluster` and `/xinas/v1/nodes/<node_id>`
+  and says "Phase 0 sets mode=single_node", but names no component that
+  writes the rows. Does NOT touch desired-state publishing
+  (phase0-requirements §5, S12/ADR-0015 adoption).
+
+## Context
+
+The first real install of the api/agent stack (finding #28) surfaced that
+the two infrastructure singletons are never created. Four facts, each
+verified against the code:
+
+1. **The api hard-fails without the rows.** `GET /system` throws
+   `NOT_FOUND "cluster not initialized"` when `/xinas/v1/cluster` is
+   absent and `NOT_FOUND "no node registered"` when no
+   `/xinas/v1/nodes/` row exists (`api/routes/system.ts`); `GET
+   /capabilities` needs only the Cluster row and fails the same way
+   when it is absent. Catalog-generated MCP reads
+   (`system.get` and everything gated on the singletons) surface these
+   errors verbatim to clients.
+
+2. **Nothing seeds them.** `openStateStore()` creates schema only, zero
+   rows (`api/server.ts`). The `xinas_api` Ansible role writes the
+   controller-id file and tokens but never touches the store; the
+   `xinas_agent` role only templates config and starts the unit. The
+   agent pushes observations to `/xinas/v1/observed/*` — a separate
+   keyspace that works fine without the singletons.
+
+3. **Tests mask the gap.** Every api test seeds both rows via
+   `seedCluster()`/`seedNode()` (`__tests__/api/_helpers.ts`) before
+   exercising routes, so the uninitialized path never ran until a real
+   install.
+
+4. **Everything needed to seed is already local to the api.** The api
+   loads `controller_id` from config (persisted at
+   `/var/lib/xinas/controller-id` by the `xinas_api` role — see
+   `docs/Installer/xinas-api-role-spec.md` §6a; ADR-0001's table still
+   names the legacy `/etc/xinas-mcp/config.json` location and is
+   superseded on this point), knows its hostname, and owns
+   `mcp.allow_apply` in its config. No fact required for the ADR-0003
+   shapes lives anywhere else.
+
+## Decision
+
+**`xinas-api` seeds the infrastructure singletons at startup**, in
+`startServer()` immediately after `openStateStore()` and before task
+engines, heartbeat tracker, or listeners are built. A dedicated module
+(`api/bootstrap.ts`, `seedInfrastructure(state, config)`) applies three
+idempotent rules:
+
+1. **Cluster — create if absent.** When `/xinas/v1/cluster` has no row,
+   write the ADR-0003 Phase 0 singleton:
+
+   ```jsonc
+   {
+     "kind": "Cluster",
+     "id": "default",
+     "spec": { "display_name": "<os.hostname()>" },
+     "status": {
+       "mode": "single_node",
+       "capabilities": {
+         "ha": "not_enabled",
+         "quorum": "not_enabled",
+         "witness": "not_enabled",
+         "nfs.v3_locking_managed": false,
+         "nfs.recovery_state_managed": false,
+         "mcp.allow_apply": <config.mcp.allow_apply === true>
+       },
+       "member_node_ids": ["<config.controller_id>"]
+     }
+   }
+   ```
+
+2. **Node — create if absent.** When
+   `/xinas/v1/nodes/<config.controller_id>` has no row, write:
+
+   ```jsonc
+   {
+     "kind": "Node",
+     "id": "<config.controller_id>",
+     "spec": { "hostname": "<os.hostname()>" },
+     "status": { "agent_state": "offline", "observation_age_seconds": 0 }
+   }
+   ```
+
+   The stored flat `agent_state: "offline"` is a static cold default,
+   not a live field: `GET /system` preserves it as-is and surfaces live
+   heartbeat state under the separate `node.status.agent` sub-object
+   (`api/routes/system.ts`; `routes-system-agent.test.ts` pins the
+   coexistence). The seed must NOT attempt to keep the flat field
+   current — nothing writes it after creation, so no writer race exists.
+
+3. **Config-mirror refresh.** When the cluster row EXISTS but
+   `status.capabilities["mcp.allow_apply"]` differs from the current
+   config value, update that one field (read-modify-write of the row).
+   The MCP dispatcher reads config directly, so the gate itself never
+   goes stale — this keeps the *advertised* capability truthful for
+   clients that plan UI around `/capabilities`. No other field of an
+   existing row is ever touched: operator edits (e.g. `display_name`)
+   survive restarts.
+
+Startup order guarantees single-writer: the seed runs before any
+listener binds, so no CAS/expected-revision handling is needed.
+
+### Why the api and not the installer or the agent
+
+- The rows must exist whenever the api serves — including after a state
+  DB wipe/restore or a manual `xinas.db` deletion, when no Ansible run
+  is in sight. Startup self-seed heals all of those for free.
+- The seed derives entirely from facts the api already holds (fact 4);
+  an installer seed would add HTTP choreography against the
+  just-started service and break the role's hermetic "provision OS +
+  services" posture.
+- The agent is an observer/executor under ADR-0002's privilege model;
+  cluster shape and membership are control-plane concerns it must not
+  own.
+
+## Alternatives considered
+
+1. **`xinas_api` Ansible role PUTs the rows after starting the
+   service.** Rejected: single-shot (dies with the DB), needs the api
+   up + admin auth mid-role, non-hermetic, and leaves test/dev servers
+   (started outside Ansible) uninitialized — the exact trap that hid
+   this bug.
+
+2. **Agent registers its node (and cluster) before first observation.**
+   Rejected: privilege-model violation (ADR-0002); also leaves the api
+   erroring until an agent connects, which is wrong for api-only
+   deployments and for the window before the agent's first push.
+
+3. **Lazy seed on first read (inside `GET /system`).** Rejected: hides
+   a write inside read handlers (audit/metadata semantics get murky),
+   and every gated route would need the same hook. Startup is one place
+   and provably runs first.
+
+## Consequences
+
+- Fresh install: `GET /system` and `GET /capabilities` return 200 with
+  `mode=single_node` immediately after `xinas-api.service` starts; MCP
+  `system.get` works with the agent not yet up.
+- `seedCluster()`/`seedNode()` remain in tests that want bespoke shapes,
+  but a new test exercises the real path: build the app with NO manual
+  seeding and assert the reads succeed; assert restart-over-existing-DB
+  preserves a modified `display_name`; assert flipping
+  `config.mcp.allow_apply` updates the advertised capability on next
+  startup.
+- `arrays.list` returning `[]` on a fresh box is NOT fixed here and is
+  not a bug in this scope: desired-state population is
+  phase0-requirements §5 / S12-adoption territory.
+- Multi-node phases will replace rule 1 with explicit cluster
+  formation; the create-if-absent seed stays valid for the first node
+  and this ADR gets amended then.

--- a/docs/control-path/adr/0016-infrastructure-bootstrap.md
+++ b/docs/control-path/adr/0016-infrastructure-bootstrap.md
@@ -100,9 +100,13 @@ idempotent rules:
    config value, update that one field (read-modify-write of the row).
    The MCP dispatcher reads config directly, so the gate itself never
    goes stale — this keeps the *advertised* capability truthful for
-   clients that plan UI around `/capabilities`. No other field of an
-   existing row is ever touched: operator edits (e.g. `display_name`)
-   survive restarts.
+   clients that plan UI around `/capabilities`. No other *value* field
+   of an existing row is ever touched: operator edits (e.g.
+   `display_name`) survive restarts. Row *metadata* is the exception a
+   refresh implies: the rewrite bumps the revision and restamps
+   `modified_at`/`source`/`owner` (to `api:bootstrap` defaults) like
+   any other put — acceptable because the refresh fires only when the
+   config flag actually changed.
 
 Startup order guarantees single-writer: the seed runs before any
 listener binds, so no CAS/expected-revision handling is needed.

--- a/docs/control-path/phase0-requirements.md
+++ b/docs/control-path/phase0-requirements.md
@@ -105,6 +105,9 @@ The format below is:
 **Requirement:** Existing Ansible roles must publish the initial desired state into the local Control Path store after provisioning.
 **How to verify:** Complete a clean install and compare API desired state with the generated xiRAID, XFS, NFS, network, and tuning configuration.
 
+**Requirement:** `xinas-api` must self-seed the infrastructure singletons — the `/xinas/v1/cluster` record (`mode=single_node`, Phase 0 capability flags) and its own `/xinas/v1/nodes/<controller_id>` record — at startup whenever they are absent, without any installer or agent involvement (ADR-0016). Existing rows must not be overwritten, except that the advertised `mcp.allow_apply` capability follows the api config.
+**How to verify:** On a fresh install (or after deleting the state database and restarting `xinas-api`), `GET /system` and `GET /capabilities` return 200 with `mode=single_node` and exactly one node, with no manual seeding step.
+
 **Requirement:** Shell menu scripts must remain compatibility wrappers only. New day-2 functionality must be implemented through the Control API and Python TUI/CLI clients.
 **How to verify:** Run static-code checks on new commits. Fail the check if a new day-2 feature is implemented only in shell menu scripts.
 

--- a/docs/plans/2026-07-02-cluster-node-bootstrap-plan.md
+++ b/docs/plans/2026-07-02-cluster-node-bootstrap-plan.md
@@ -1,0 +1,306 @@
+# Cluster/Node Infrastructure Bootstrap (ADR-0016) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `xinas-api` seeds `/xinas/v1/cluster` and `/xinas/v1/nodes/<controller_id>` at startup so `GET /system` / `GET /capabilities` (and MCP `system.get`) work on a fresh install with no manual seeding (bug #32).
+
+**Architecture:** A single new module `src/api/bootstrap.ts` exporting `seedInfrastructure(state, config)`, called from `startServer()` immediately after the state store opens and before any listener binds (single writer — no CAS needed). Create-if-absent for both rows; the one exception is the advertised `mcp.allow_apply` capability, which is refreshed to match the api config on every startup. Spec: `docs/control-path/adr/0016-infrastructure-bootstrap.md` + phase0-requirements §5 (already written, uncommitted).
+
+**Tech Stack:** TypeScript (strict, `exactOptionalPropertyTypes`), Node 20, vitest + supertest, biome. All commands run from `xiNAS-MCP/`.
+
+---
+
+### Task 0: Commit the spec
+
+**Files:**
+- Commit (already written): `docs/control-path/adr/0016-infrastructure-bootstrap.md`
+- Commit (already edited): `docs/control-path/phase0-requirements.md`
+
+- [ ] **Step 1: Commit the spec files** (from the repo root, not `xiNAS-MCP/`)
+
+```bash
+git add docs/control-path/adr/0016-infrastructure-bootstrap.md docs/control-path/phase0-requirements.md
+git commit -m "docs(control-path): ADR-0016 — xinas-api self-seeds cluster + node singletons (#32)
+
+Fills the seeding gap ADR-0003 left open: the api creates
+/xinas/v1/cluster and /xinas/v1/nodes/<controller_id> at startup when
+absent. phase0-requirements §5 gains the matching requirement + verify
+criterion.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 1: `seedInfrastructure()` module + tests
+
+**Files:**
+- Create: `xiNAS-MCP/src/__tests__/api/bootstrap.test.ts`
+- Create: `xiNAS-MCP/src/api/bootstrap.ts`
+
+Background for the implementer:
+- `buildTestApp()` (`src/__tests__/api/_helpers.ts`) returns `{ dir, config, state, app, ctx, cleanup }` with a temp SQLite store and **no** cluster/node rows — exactly the fresh-install state. `config.controller_id` is `'00000000-0000-0000-0000-0000000000aa'`.
+- `state.kv.get<T>(key)` returns `{ value: T, revision: number, ... } | null`; `state.kv.put(key, value)` writes (no CAS opts needed here).
+- Response envelope: route payloads are under `res.body.result`.
+- The routes under test: `src/api/routes/system.ts` — `GET /api/v1/system` needs the cluster row AND ≥1 node row; `GET /api/v1/capabilities` needs only the cluster row.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `xiNAS-MCP/src/__tests__/api/bootstrap.test.ts`:
+
+```typescript
+import os from 'node:os';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { seedInfrastructure } from '../../api/bootstrap.js';
+import { ADMIN_TOKEN, buildTestApp } from './_helpers.js';
+
+// ADR-0016: the api self-seeds the infrastructure singletons at startup.
+// These tests run against an UNSEEDED store — the fresh-install state that
+// bug #32 hit — with no seedCluster()/seedNode() helper calls.
+describe('ADR-0016 infrastructure bootstrap', () => {
+  let setup: Awaited<ReturnType<typeof buildTestApp>>;
+
+  beforeEach(async () => {
+    setup = await buildTestApp();
+  });
+
+  afterEach(async () => {
+    await setup.cleanup();
+  });
+
+  it('unseeded store still 404s (pins the pre-bootstrap failure mode)', async () => {
+    const res = await request(setup.app).get('/api/v1/system').set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(404);
+  });
+
+  it('seeds cluster + node so GET /system returns 200 with the ADR-0003 shapes', async () => {
+    seedInfrastructure(setup.state, setup.config);
+    const res = await request(setup.app).get('/api/v1/system').set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    const { cluster, node } = res.body.result;
+    expect(cluster.status.mode).toBe('single_node');
+    expect(cluster.status.member_node_ids).toEqual([setup.config.controller_id]);
+    expect(cluster.spec.display_name).toBe(os.hostname());
+    expect(node.id).toBe(setup.config.controller_id);
+    expect(node.spec.hostname).toBe(os.hostname());
+    expect(node.status.agent_state).toBe('offline');
+  });
+
+  it('GET /capabilities returns the Phase 0 flags, mcp.allow_apply mirrors config (absent → false)', async () => {
+    seedInfrastructure(setup.state, setup.config); // test config has no mcp block
+    const res = await request(setup.app)
+      .get('/api/v1/capabilities')
+      .set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result.ha).toBe('not_enabled');
+    expect(res.body.result.quorum).toBe('not_enabled');
+    expect(res.body.result.witness).toBe('not_enabled');
+    expect(res.body.result['nfs.v3_locking_managed']).toBe(false);
+    expect(res.body.result['nfs.recovery_state_managed']).toBe(false);
+    expect(res.body.result['mcp.allow_apply']).toBe(false);
+  });
+
+  it('re-run is a no-op that preserves operator edits (restart over existing DB)', async () => {
+    seedInfrastructure(setup.state, setup.config);
+    const row = setup.state.kv.get<{ spec: { display_name: string } }>('/xinas/v1/cluster');
+    expect(row).not.toBeNull();
+    const edited = structuredClone(row!.value);
+    edited.spec.display_name = 'operator-named';
+    setup.state.kv.put('/xinas/v1/cluster', edited);
+
+    seedInfrastructure(setup.state, setup.config); // simulated restart
+
+    const after = setup.state.kv.get<{ spec: { display_name: string } }>('/xinas/v1/cluster');
+    expect(after!.value.spec.display_name).toBe('operator-named');
+  });
+
+  it('refreshes ONLY the mcp.allow_apply mirror when the config flag flips', async () => {
+    seedInfrastructure(setup.state, setup.config); // allow_apply false
+    const nodeKey = `/xinas/v1/nodes/${setup.config.controller_id}`;
+    const nodeBefore = setup.state.kv.get(nodeKey);
+
+    seedInfrastructure(setup.state, { ...setup.config, mcp: { allow_apply: true } });
+
+    const cluster = setup.state.kv.get<{
+      spec: { display_name: string };
+      status: { capabilities: Record<string, unknown> };
+    }>('/xinas/v1/cluster');
+    expect(cluster!.value.status.capabilities['mcp.allow_apply']).toBe(true);
+    expect(cluster!.value.spec.display_name).toBe(os.hostname()); // untouched
+    const nodeAfter = setup.state.kv.get(nodeKey);
+    expect(nodeAfter!.revision).toBe(nodeBefore!.revision); // node row not rewritten
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run (from `xiNAS-MCP/`): `npx vitest run src/__tests__/api/bootstrap.test.ts`
+Expected: FAIL — cannot resolve `../../api/bootstrap.js` (module does not exist yet).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `xiNAS-MCP/src/api/bootstrap.ts`:
+
+```typescript
+import os from 'node:os';
+import type { OpenedStateStore } from '../state/index.js';
+import type { ApiConfig } from './config.js';
+
+const CLUSTER_KEY = '/xinas/v1/cluster';
+
+interface ClusterRow {
+  kind: string;
+  id: string;
+  spec: Record<string, unknown>;
+  status: {
+    mode: string;
+    capabilities: Record<string, unknown>;
+    member_node_ids: string[];
+  };
+}
+
+/**
+ * ADR-0016: seed the infrastructure singletons the read routes hard-require
+ * (/xinas/v1/cluster + /xinas/v1/nodes/<controller_id>) so a fresh install —
+ * or a wiped/restored state DB — serves GET /system and /capabilities without
+ * any installer or agent involvement.
+ *
+ * Called from startServer() before any listener binds, so there is exactly
+ * one writer and plain put() (no CAS) is safe. Existing rows are never
+ * overwritten, with one exception: the advertised `mcp.allow_apply`
+ * capability is refreshed to match the current api config (the MCP
+ * dispatcher reads the config directly — this keeps /capabilities truthful,
+ * it is not the gate itself).
+ */
+export function seedInfrastructure(state: OpenedStateStore, config: ApiConfig): void {
+  const allowApply = config.mcp?.allow_apply === true;
+
+  const cluster = state.kv.get<ClusterRow>(CLUSTER_KEY);
+  if (cluster === null) {
+    state.kv.put(CLUSTER_KEY, {
+      kind: 'Cluster',
+      id: 'default',
+      spec: { display_name: os.hostname() },
+      status: {
+        mode: 'single_node',
+        capabilities: {
+          ha: 'not_enabled',
+          quorum: 'not_enabled',
+          witness: 'not_enabled',
+          'nfs.v3_locking_managed': false,
+          'nfs.recovery_state_managed': false,
+          'mcp.allow_apply': allowApply,
+        },
+        member_node_ids: [config.controller_id],
+      },
+    } satisfies ClusterRow);
+  } else if (cluster.value.status.capabilities['mcp.allow_apply'] !== allowApply) {
+    const next = structuredClone(cluster.value);
+    next.status.capabilities['mcp.allow_apply'] = allowApply;
+    state.kv.put(CLUSTER_KEY, next);
+  }
+
+  const nodeKey = `/xinas/v1/nodes/${config.controller_id}`;
+  if (state.kv.get(nodeKey) === null) {
+    state.kv.put(nodeKey, {
+      kind: 'Node',
+      id: config.controller_id,
+      spec: { hostname: os.hostname() },
+      // Static cold default — GET /system surfaces live heartbeat state
+      // under node.status.agent; nothing keeps this flat field current
+      // (ADR-0016 decision 2).
+      status: { agent_state: 'offline', observation_age_seconds: 0 },
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/__tests__/api/bootstrap.test.ts`
+Expected: PASS — 5 tests.
+
+- [ ] **Step 5: Lint + typecheck the new files**
+
+Run: `npm run lint && npm run typecheck`
+Expected: no errors (biome + tsc are strict; fix any complaint before committing).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/bootstrap.ts src/__tests__/api/bootstrap.test.ts
+git commit -m "feat(api): seedInfrastructure() — cluster + node singleton bootstrap (ADR-0016, #32)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Wire into `startServer()` and verify the suite
+
+**Files:**
+- Modify: `xiNAS-MCP/src/api/server.ts` (import block ~line 4-12; call site directly after `state.drainer.start()` at ~line 37)
+
+- [ ] **Step 1: Add the import and the call**
+
+In `xiNAS-MCP/src/api/server.ts`, add to the imports:
+
+```typescript
+import { seedInfrastructure } from './bootstrap.js';
+```
+
+and directly after `state.drainer.start();`:
+
+```typescript
+  // ADR-0016: seed /xinas/v1/cluster + /xinas/v1/nodes/<controller_id>
+  // (create-if-absent; allow_apply mirror refresh) before anything can
+  // serve reads — the routes hard-require both rows.
+  seedInfrastructure(state, config);
+```
+
+- [ ] **Step 2: Run the full unit suite**
+
+Run: `npm test`
+Expected: PASS, no regressions. (Tests build apps via `createApp()` and seed
+manually with `seedCluster()`/`seedNode()`, so they don't hit this path;
+`startServer`-based tests get valid rows seeded, which existing manual seeds
+either match or deliberately overwrite.)
+
+- [ ] **Step 3: Run the e2e suite**
+
+Run: `npm run test:e2e`
+Expected: PASS. If an e2e test fails on cluster/node shape, it means it
+asserted on the unseeded 404 or seeded AFTER `startServer` with a conflicting
+shape — inspect before changing anything; per ADR-0016 the seed must lose to
+explicit test seeds (they overwrite it), so a failure here is a real bug in
+the wiring, not the test.
+
+- [ ] **Step 4: Lint + typecheck**
+
+Run: `npm run lint && npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 5: Commit (with rebuild trailer — this is the behavior-activating commit)**
+
+```bash
+git add src/api/server.ts
+git commit -m "fix(api): self-seed cluster + node at startup — system.get works on fresh install (#32)
+
+Requires-Rebuild: xinas_node_build, xinas_api
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+(`xinas_node_build` rebuilds `dist/` from the changed TS; `xinas_api` restarts
+the service — same precedent as d13fe94.)
+
+---
+
+### Task 3: On-host verification criterion (manual, from phase0-requirements §5)
+
+Not executable in this repo checkout — record for the next install loop:
+
+- [ ] Fresh install → `curl --unix-socket /run/xinas/api.sock http://x/api/v1/system` returns 200 with `mode=single_node` and one node; MCP `system.get` no longer returns "cluster not initialized".
+- [ ] `systemctl stop xinas-api && rm /var/lib/xinas/state/xinas.db* && systemctl start xinas-api` → same 200 (wiped-DB recovery, the ADR-0016 verify criterion).

--- a/xiNAS-MCP/src/__tests__/api/bootstrap.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/bootstrap.test.ts
@@ -1,0 +1,104 @@
+import os from 'node:os';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { seedInfrastructure } from '../../api/bootstrap.js';
+import { ADMIN_TOKEN, buildTestApp } from './_helpers.js';
+
+// ADR-0016: the api self-seeds the infrastructure singletons at startup.
+// These tests run against an UNSEEDED store — the fresh-install state that
+// bug #32 hit — with no seedCluster()/seedNode() helper calls.
+describe('ADR-0016 infrastructure bootstrap', () => {
+  let setup: Awaited<ReturnType<typeof buildTestApp>>;
+
+  beforeEach(async () => {
+    setup = await buildTestApp();
+  });
+
+  afterEach(async () => {
+    await setup.cleanup();
+  });
+
+  it('unseeded store still 404s (pins the pre-bootstrap failure mode)', async () => {
+    const res = await request(setup.app).get('/api/v1/system').set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(404);
+  });
+
+  it('seeds cluster + node so GET /system returns 200 with the ADR-0003 shapes', async () => {
+    seedInfrastructure(setup.state, setup.config);
+    const res = await request(setup.app).get('/api/v1/system').set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    const { cluster, node } = res.body.result;
+    expect(cluster.status.mode).toBe('single_node');
+    expect(cluster.status.member_node_ids).toEqual([setup.config.controller_id]);
+    expect(cluster.spec.display_name).toBe(os.hostname());
+    expect(node.id).toBe(setup.config.controller_id);
+    expect(node.spec.hostname).toBe(os.hostname());
+    expect(node.status.agent_state).toBe('offline');
+  });
+
+  it('GET /capabilities returns the Phase 0 flags, mcp.allow_apply mirrors config (absent → false)', async () => {
+    seedInfrastructure(setup.state, setup.config); // test config has no mcp block
+    const res = await request(setup.app)
+      .get('/api/v1/capabilities')
+      .set('Authorization', ADMIN_TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body.result.ha).toBe('not_enabled');
+    expect(res.body.result.quorum).toBe('not_enabled');
+    expect(res.body.result.witness).toBe('not_enabled');
+    expect(res.body.result['nfs.v3_locking_managed']).toBe(false);
+    expect(res.body.result['nfs.recovery_state_managed']).toBe(false);
+    expect(res.body.result['mcp.allow_apply']).toBe(false);
+  });
+
+  it('re-run is a no-op that preserves operator edits (restart over existing DB)', async () => {
+    seedInfrastructure(setup.state, setup.config);
+    const row = setup.state.kv.get<{ spec: { display_name: string } }>('/xinas/v1/cluster');
+    expect(row).not.toBeNull();
+    const edited = structuredClone(row!.value);
+    edited.spec.display_name = 'operator-named';
+    setup.state.kv.put('/xinas/v1/cluster', edited);
+    const revisionAfterEdit = setup.state.kv.get('/xinas/v1/cluster')!.revision;
+
+    seedInfrastructure(setup.state, setup.config); // simulated restart
+
+    const after = setup.state.kv.get<{ spec: { display_name: string } }>('/xinas/v1/cluster');
+    expect(after!.value.spec.display_name).toBe('operator-named');
+    // Revisions are monotonic per key, so revision-stable === zero writes:
+    // pins the PURE no-op path (an unconditional read-modify-write would
+    // preserve display_name but bump the revision).
+    expect(after!.revision).toBe(revisionAfterEdit);
+  });
+
+  it('refreshes ONLY the mcp.allow_apply mirror when the config flag flips', async () => {
+    seedInfrastructure(setup.state, setup.config); // allow_apply false
+    const nodeKey = `/xinas/v1/nodes/${setup.config.controller_id}`;
+    const nodeBefore = setup.state.kv.get(nodeKey);
+
+    seedInfrastructure(setup.state, { ...setup.config, mcp: { allow_apply: true } });
+
+    const cluster = setup.state.kv.get<{
+      spec: { display_name: string };
+      status: { capabilities: Record<string, unknown> };
+    }>('/xinas/v1/cluster');
+    expect(cluster!.value.status.capabilities['mcp.allow_apply']).toBe(true);
+    expect(cluster!.value.spec.display_name).toBe(os.hostname()); // untouched
+    const nodeAfter = setup.state.kv.get(nodeKey);
+    expect(nodeAfter!.revision).toBe(nodeBefore!.revision); // node row not rewritten
+  });
+
+  it('reseeds a missing node without touching an existing cluster (rule independence)', () => {
+    seedInfrastructure(setup.state, setup.config);
+    const nodeKey = `/xinas/v1/nodes/${setup.config.controller_id}`;
+    const deleted = setup.state.kv.delete(nodeKey);
+    expect(deleted.ok).toBe(true);
+    const clusterBefore = setup.state.kv.get('/xinas/v1/cluster');
+
+    seedInfrastructure(setup.state, setup.config);
+
+    const node = setup.state.kv.get<{ id: string }>(nodeKey);
+    expect(node).not.toBeNull();
+    expect(node!.value.id).toBe(setup.config.controller_id);
+    const clusterAfter = setup.state.kv.get('/xinas/v1/cluster');
+    expect(clusterAfter!.revision).toBe(clusterBefore!.revision); // cluster untouched
+  });
+});

--- a/xiNAS-MCP/src/__tests__/api/server.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/server.test.ts
@@ -32,4 +32,35 @@ describe('startServer', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // ADR-0016 wiring regression (#32): startServer must self-seed the Cluster +
+  // Node singletons on a fresh state DB — GET /system serves 200 without any
+  // installer or test pre-seeding. Fails if the seedInfrastructure() call is
+  // removed from startServer().
+  it('self-seeds cluster + node so GET /system works on a fresh DB', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'xinas-api-server-'));
+    try {
+      const handle = await startServer({
+        inline: {
+          controller_id: '00000000-0000-0000-0000-0000000000ab',
+          listen: { kind: 'tcp', host: '127.0.0.1', port: 0 },
+          tokens: { 'tok-admin': { principal: 'admin:test', role: 'admin' } },
+          state: { databasePath: join(dir, 'xinas.db'), auditJsonlPath: join(dir, 'audit.jsonl') },
+        },
+      });
+      try {
+        const port = (handle.address as { port: number }).port;
+        const res = await fetch(`http://127.0.0.1:${port}/api/v1/system`, {
+          headers: { Authorization: 'Bearer tok-admin' },
+        });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.result.cluster.status.mode).toBe('single_node');
+      } finally {
+        await handle.close();
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/xiNAS-MCP/src/__tests__/e2e/agent-api-roundtrip.test.ts
+++ b/xiNAS-MCP/src/__tests__/e2e/agent-api-roundtrip.test.ts
@@ -190,8 +190,10 @@ describe.sequential('e2e: agent -> api round-trip (fixture probe mode)', () => {
     writeFileSync(controllerIdPath, `${CONTROLLER_ID}\n`);
     writeFileSync(agentTokenPath, `${AGENT_TOKEN}\n`);
 
-    // Pre-seed the DB with the Cluster + Node singletons so GET /api/v1/system
-    // returns 200 (the agent never emits those kinds). Open the store, seed,
+    // Pre-seed the Cluster + Node singletons with fixture values (display_name,
+    // hostname, etc.). Since ADR-0016 startServer self-seeds defaults anyway —
+    // explicit rows here make the assertions deterministic (the self-seed is
+    // create-if-absent, so it leaves these rows alone). Open the store, seed,
     // close — the api process then reopens the same file.
     const seedStore = await openStateStore({
       databasePath: dbPath,

--- a/xiNAS-MCP/src/__tests__/e2e/agent-api-roundtrip.test.ts
+++ b/xiNAS-MCP/src/__tests__/e2e/agent-api-roundtrip.test.ts
@@ -192,9 +192,10 @@ describe.sequential('e2e: agent -> api round-trip (fixture probe mode)', () => {
 
     // Pre-seed the Cluster + Node singletons with fixture values (display_name,
     // hostname, etc.). Since ADR-0016 startServer self-seeds defaults anyway —
-    // explicit rows here make the assertions deterministic (the self-seed is
-    // create-if-absent, so it leaves these rows alone). Open the store, seed,
-    // close — the api process then reopens the same file.
+    // explicit rows here make the assertions deterministic (create-if-absent
+    // leaves them alone; the mirror refresh is a no-op because the fixture
+    // already carries mcp.allow_apply=false, matching the mcp-less config).
+    // Open the store, seed, close — the api process then reopens the same file.
     const seedStore = await openStateStore({
       databasePath: dbPath,
       auditJsonlPath: auditPath,
@@ -204,7 +205,11 @@ describe.sequential('e2e: agent -> api round-trip (fixture probe mode)', () => {
       kind: 'Cluster',
       id: 'default',
       spec: { display_name: 'e2e-cluster' },
-      status: { mode: 'single_node', capabilities: {}, member_node_ids: [CONTROLLER_ID] },
+      status: {
+        mode: 'single_node',
+        capabilities: { 'mcp.allow_apply': false },
+        member_node_ids: [CONTROLLER_ID],
+      },
     });
     seedStore.kv.put(`/xinas/v1/nodes/${CONTROLLER_ID}`, {
       kind: 'Node',

--- a/xiNAS-MCP/src/api/bootstrap.ts
+++ b/xiNAS-MCP/src/api/bootstrap.ts
@@ -1,0 +1,84 @@
+import os from 'node:os';
+import type { OpenedStateStore } from '../state/index.js';
+import type { ApiConfig } from './config.js';
+
+const CLUSTER_KEY = '/xinas/v1/cluster';
+
+/** Origin tag stamped on every bootstrap write (RevisionedValue.source);
+ *  embedMetadata surfaces it in GET /system so operators can see the
+ *  singletons were self-seeded, not installer- or operator-written. */
+const PUT_SOURCE = { source: 'api:bootstrap' } as const;
+
+interface ClusterRow {
+  kind: string;
+  id: string;
+  spec: Record<string, unknown>;
+  status: {
+    mode: string;
+    capabilities: Record<string, unknown>;
+    member_node_ids: string[];
+  };
+}
+
+/**
+ * ADR-0016: seed the infrastructure singletons the read routes hard-require
+ * (/xinas/v1/cluster + /xinas/v1/nodes/<controller_id>) so a fresh install —
+ * or a wiped/restored state DB — serves GET /system and /capabilities without
+ * any installer or agent involvement.
+ *
+ * Called from startServer() before any listener binds, so there is exactly
+ * one writer and plain put() (no CAS) is safe. Existing rows are never
+ * overwritten, with one exception: the advertised `mcp.allow_apply`
+ * capability is refreshed to match the current api config (the MCP
+ * dispatcher reads the config directly — this keeps /capabilities truthful,
+ * it is not the gate itself).
+ */
+export function seedInfrastructure(state: OpenedStateStore, config: ApiConfig): void {
+  const allowApply = config.mcp?.allow_apply === true;
+
+  const cluster = state.kv.get<ClusterRow>(CLUSTER_KEY);
+  if (cluster === null) {
+    state.kv.put(
+      CLUSTER_KEY,
+      {
+        kind: 'Cluster',
+        id: 'default',
+        spec: { display_name: os.hostname() },
+        status: {
+          mode: 'single_node',
+          capabilities: {
+            ha: 'not_enabled',
+            quorum: 'not_enabled',
+            witness: 'not_enabled',
+            'nfs.v3_locking_managed': false,
+            'nfs.recovery_state_managed': false,
+            'mcp.allow_apply': allowApply,
+          },
+          member_node_ids: [config.controller_id],
+        },
+      } satisfies ClusterRow,
+      PUT_SOURCE,
+    );
+  } else if (cluster.value.status.capabilities['mcp.allow_apply'] !== allowApply) {
+    const next = structuredClone(cluster.value);
+    next.status.capabilities['mcp.allow_apply'] = allowApply;
+    state.kv.put(CLUSTER_KEY, next, PUT_SOURCE);
+  }
+
+  const nodeKey = `/xinas/v1/nodes/${config.controller_id}`;
+  if (state.kv.get(nodeKey) === null) {
+    state.kv.put(
+      nodeKey,
+      {
+        kind: 'Node',
+        id: config.controller_id,
+        spec: { hostname: os.hostname() },
+        // Static cold default — GET /system surfaces live heartbeat state
+        // under node.status.agent; nothing keeps this flat field current
+        // (ADR-0016 decision 2).
+        status: { agent_state: 'offline', observation_age_seconds: 0 },
+      },
+      PUT_SOURCE,
+    );
+  }
+}

--- a/xiNAS-MCP/src/api/server.ts
+++ b/xiNAS-MCP/src/api/server.ts
@@ -4,6 +4,7 @@ import type { AddressInfo } from 'node:net';
 import { type OpenedStateStore, openStateStore } from '../state/index.js';
 import { createAgentRpcClient } from './agent-client.js';
 import { createApp } from './app.js';
+import { seedInfrastructure } from './bootstrap.js';
 import { type ApiConfig, loadConfig } from './config.js';
 import type { ApiContext } from './context.js';
 import { HeartbeatTracker, createAgentHealthProbe } from './heartbeat.js';
@@ -35,6 +36,11 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
     ...(config.state.archiveDir !== undefined ? { archiveDir: config.state.archiveDir } : {}),
   });
   state.drainer.start();
+
+  // ADR-0016: seed /xinas/v1/cluster + /xinas/v1/nodes/<controller_id>
+  // (create-if-absent; allow_apply mirror refresh) before anything can
+  // serve reads — the routes hard-require both rows.
+  seedInfrastructure(state, config);
 
   // Compile inbound-observation validators from api-v1.yaml once. Returns null
   // (validation skipped) when the spec isn't shipped — the graceful default.


### PR DESCRIPTION
## Summary
- **Bug #32** (PR #236's documented gap): xinas-api never seeded `/xinas/v1/cluster` + `/xinas/v1/nodes/<controller_id>`, so `GET /system` / MCP `system.get` returned `NOT_FOUND "cluster not initialized"` on every fresh install.
- **ADR-0016** records the decision: the api self-seeds both singletons at startup (create-if-absent + `mcp.allow_apply` capability mirror refresh) — chosen over installer-seeds and agent-registers because the seed derives entirely from api-local facts and self-heals a wiped/restored state DB. phase0-requirements §5 gains the matching requirement.
- `seedInfrastructure()` (`src/api/bootstrap.ts`) wired into `startServer()` before any listener binds (single-writer, no CAS). Existing rows are never value-modified except the advertised `allow_apply` flag; operator edits survive restarts.

## Test Plan
- [x] 6 module tests incl. pinned pre-fix 404, no-op-by-revision-stability, mirror refresh, rule independence (mutation-verified)
- [x] Wiring regression test: `startServer` on fresh DB → `GET /system` 200 (fails if the seed call is removed — verified by mutation)
- [x] Full suites: 1280 unit / 65 e2e / typecheck clean (3 pre-existing agent timing flakes unrelated to diff, spun off separately)
- [ ] On-host (next install loop): fresh install → `system.get` returns `mode=single_node`; wipe `/var/lib/xinas/state/xinas.db` + restart → same 200

Carries `Requires-Rebuild: xinas_node_build, xinas_api` on the activating commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)