### PR TITLE
fix(mcp/agent/api/install): real on-node observation, MCP apply, cluster init & install ordering

### DIFF
--- a/collection/roles/raid_fs/tasks/create_array.yml
+++ b/collection/roles/raid_fs/tasks/create_array.yml
@@ -32,11 +32,11 @@
   ansible.builtin.fail:
     msg: >-
       Only {{ _mem_avail_kb.stdout | int // 1024 }} MiB free after reclaim, but
-      creating array '{{ item.name }}' needs >= {{ raid_create_min_free_mb }} MiB
+      creating array '{{ item.name }}' needs >= {{ raid_create_min_free_mb | default(2560) }} MiB
       for the xiRAID mempool (memory_prealloc). Proceeding would fail with a
       kernel '__get_free_pages() failed … RAID creation failed' error. Add RAM,
       reduce the disk count for this array, or lower its memory_prealloc_mb.
-  when: (_mem_avail_kb.stdout | int // 1024) < (raid_create_min_free_mb | int)
+  when: (_mem_avail_kb.stdout | int // 1024) < (raid_create_min_free_mb | default(2560) | int)
   tags: [raid_fs, raid]
 
 - name: Create array {{ item.name }}

--- a/collection/roles/xinas_api/templates/xinas-api-tmpfiles.conf.j2
+++ b/collection/roles/xinas_api/templates/xinas-api-tmpfiles.conf.j2
@@ -29,4 +29,10 @@ d /run/xinas             1731 root xinas-api -
 d /var/lib/xinas         0755 root root          -
 d {{ xinas_api_state_dir }}   0750 {{ xinas_api_user }} {{ xinas_api_socket_group }} -
 d {{ xinas_api_log_dir }}     0750 {{ xinas_api_user }} {{ xinas_api_socket_group }} -
+# config-history store (xinas_history DEFAULT_STORE_PATH). Created here — by the
+# api role, which runs BEFORE xinas_agent and at every boot — so the agent's
+# ReadWritePaths carve-out for it resolves at namespace-setup time. The
+# xinas_history role (later) populates baseline/snapshots/state subdirs; root
+# 0700 matches how that role owns the tree (the agent runs as root).
+d /var/lib/xinas/config-history 0700 root root      -
 d /etc/xinas-agent       0755 root root          -

--- a/collection/roles/xinas_nfs_helper/handlers/main.yml
+++ b/collection/roles/xinas_nfs_helper/handlers/main.yml
@@ -1,0 +1,19 @@
+---
+# The xinas-agent role runs BEFORE this one, so at the agent's first boot the
+# NFS helper socket (/run/xinas-nfs-helper.sock) does not exist yet. The agent's
+# NfsSession collector fails its initial sweep with ENOENT and CACHES that error
+# for the process lifetime, which leaves agent.health = degraded and the
+# `agent.connectivity` health check degraded on every fresh install until a
+# manual restart. Once this role has deployed and started the helper, bounce the
+# agent so its collectors re-sweep with the socket present. Handlers run at the
+# END of the play (after every role, so all other agent deps are up too), and
+# only when notified (i.e. the helper actually changed), so idempotent re-runs
+# do not needlessly churn the agent.
+- name: Restart xinas-agent to re-sweep NFS collectors
+  ansible.builtin.systemd:
+    name: xinas-agent
+    state: restarted
+  # Never let a re-sweep restart fail the whole install: the agent recovers on
+  # its own next start regardless, and the socket is already serving.
+  failed_when: false
+  tags: [xinas_nfs_helper, service]

--- a/collection/roles/xinas_nfs_helper/tasks/main.yml
+++ b/collection/roles/xinas_nfs_helper/tasks/main.yml
@@ -49,4 +49,8 @@
     daemon_reload: true
     enabled: true
     state: "{{ 'restarted' if (_nfs_helper_src is changed or _nfs_helper_unit is changed) else 'started' }}"
+  # Bounce xinas-agent at play-end so its NfsSession collector re-sweeps now that
+  # this helper's socket exists (the agent role ran before this one — see
+  # handlers/main.yml). Only fires when the helper actually (re)started.
+  notify: Restart xinas-agent to re-sweep NFS collectors
   tags: [xinas_nfs_helper, service]

--- a/xiNAS-MCP/src/agent/publisher.ts
+++ b/xiNAS-MCP/src/agent/publisher.ts
@@ -180,8 +180,24 @@ export class Publisher {
           return;
         }
 
-        // 4xx: don't retry — payload is structurally wrong.
+        // 4xx: don't retry — payload is structurally wrong. But DO log it: the
+        // observed endpoint fail-closes the whole batch on one bad delta, so a
+        // silent 4xx here means an ENTIRE kind vanished from observed state with
+        // no trace (this masked a real schema-mismatch bug for the Disk,
+        // Filesystem and XiraidArray kinds on real hardware). Never swallow it.
         if (result.status >= 400 && result.status < 500) {
+          process.stderr.write(
+            `${JSON.stringify({
+              time: new Date().toISOString(),
+              level: 'error',
+              subsystem: 'publisher',
+              event: 'observed_post_rejected',
+              status: result.status,
+              kinds: [...kindsInBatch],
+              complete_snapshots: completeSnapshots,
+              delta_count: batch.length,
+            })}\n`,
+          );
           return;
         }
 

--- a/xiNAS-MCP/src/agent/xiraid/client.ts
+++ b/xiNAS-MCP/src/agent/xiraid/client.ts
@@ -140,6 +140,21 @@ export class XiraidClient {
 }
 
 /**
+ * Normalize a daemon list payload to an array. The xiRAID daemon returns
+ * raid_show / pool_show as a NAME-KEYED MAP (e.g. `{ data: {...}, log: {...} }`,
+ * as `xicli ... --format json` also emits), whereas every downstream parser
+ * (parseRaidShow, readPools) expects an array of per-entry objects and returns
+ * empty on a non-array. Accept either shape: pass arrays through, spread a
+ * map's values, and treat anything else (incl. an empty `{}` = no entries) as
+ * an empty list.
+ */
+function toArrayPayload(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) return payload;
+  if (payload !== null && typeof payload === 'object') return Object.values(payload);
+  return [];
+}
+
+/**
  * The real transport: lazy gRPC channel from /etc/xraid/net.conf via the
  * existing client pool. raid_show returns the parsed JSON payload.
  */
@@ -151,7 +166,13 @@ export function createGrpcTransport(): XiraidTransport {
       // "13 INTERNAL: Unsupported unit: None" on an unset unit (finding #17),
       // which otherwise fails every array observation sweep.
       const res = await raidShow(client, { units: 'g' });
-      return res.data ?? [];
+      // The live daemon returns a NAME-KEYED MAP ({ data: {...}, log: {...} }),
+      // matching `xicli raid show --format json`, but the collector/parser
+      // contract (and this method's JSDoc) is "an array of per-array objects".
+      // parseRaidShow() bails with `if (!Array.isArray(payload)) return []`, so
+      // returning the raw map silently observed ZERO arrays on real hardware
+      // (only the fake transport ever emitted an array). Normalize to an array.
+      return toArrayPayload(res.data);
     },
     async raidCreate(req: RaidCreateRequest): Promise<void> {
       const client = await getClient();
@@ -193,7 +214,9 @@ export function createGrpcTransport(): XiraidTransport {
       const client = await getClient();
       // units:'g' — same daemon "Unsupported unit: None" crash as raidShow (#17).
       const res = await poolShow(client, { units: 'g' });
-      return res.data ?? [];
+      // Same name-keyed-map vs array mismatch as raidShow: readPools() bails on
+      // a non-array, so spare-pool membership was never joined. Normalize.
+      return toArrayPayload(res.data);
     },
     async raidImportShow(): Promise<unknown> {
       // No drives filter: scan all (confirm exact daemon semantics for an

--- a/xiNAS-MCP/src/api/observed-schemas.ts
+++ b/xiNAS-MCP/src/api/observed-schemas.ts
@@ -113,6 +113,38 @@ function stripRequired(node: unknown): void {
 }
 
 /**
+ * Recursively delete every `enum` array anywhere in a JSON Schema object graph
+ * (mirrors stripRequired).
+ *
+ * WHY: inbound observation validation is documented as TYPE-ONLY (see
+ * loadObservedSchemas), but `enum` is a VALUE constraint, not a type check, and
+ * survived stripRequired. Real observed values legitimately fall outside a
+ * public read-schema's enum — e.g. a Filesystem's `mount_unit_state` carries
+ * whatever `systemctl is-enabled` prints (`generated`, `transient`, …) which is
+ * not in the closed read-schema enum, and an observed row's own `kind` fails
+ * the FLAT ConfigSnapshot/Pool `kind` enum. Because the observed endpoint
+ * fail-closes the WHOLE batch on one bad delta, a single out-of-enum value
+ * silently dropped an entire kind (Filesystem never observed on real hardware).
+ * Enum correctness belongs to the public READ schemas (what clients GET back),
+ * not to the inbound garbage-net. Stripping `enum` keeps the type checks while
+ * letting real-world values through; this also subsumes the FLAT_SCHEMA_KINDS
+ * workaround for enum-bearing `kind` fields.
+ *
+ * Only deletes `enum` when it is the JSON-Schema keyword (an array); a property
+ * literally NAMED "enum" whose value is a subschema object is left alone.
+ */
+function stripEnum(node: unknown): void {
+  if (Array.isArray(node)) {
+    for (const item of node) stripEnum(item);
+    return;
+  }
+  if (node === null || typeof node !== 'object') return;
+  const obj = node as Record<string, unknown>;
+  if (Array.isArray(obj['enum'])) delete obj['enum'];
+  for (const value of Object.values(obj)) stripEnum(value);
+}
+
+/**
  * Compile per-kind inbound-observation validators from api-v1.yaml.
  *
  * Returns `{ schemas, ajv }` where `schemas` is keyed by observed kind name
@@ -174,7 +206,13 @@ export function loadObservedSchemas(): {
     // are all type-only. We register the STRIPPED doc (not the original) so a
     // ref from Disk → Metadata also lands on the required-stripped Metadata.
     const strippedDoc = structuredClone(doc) as typeof doc;
-    if (strippedDoc.components?.schemas) stripRequired(strippedDoc.components.schemas);
+    if (strippedDoc.components?.schemas) {
+      stripRequired(strippedDoc.components.schemas);
+      // Also strip `enum` so inbound validation is truly TYPE-ONLY (see
+      // stripEnum): a real observed value outside a read-schema enum must not
+      // fail-close the whole batch.
+      stripEnum(strippedDoc.components.schemas);
+    }
     // Register the stripped spec so internal `$ref` pointers resolve to the
     // required-stripped subschemas when each kind schema is compiled.
     ajv.addSchema(strippedDoc, 'api-v1.yaml');

--- a/xiNAS-MCP/src/api/server.ts
+++ b/xiNAS-MCP/src/api/server.ts
@@ -1,6 +1,7 @@
 import { chmodSync, chownSync, existsSync, unlinkSync } from 'node:fs';
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
+import { hostname as osHostname } from 'node:os';
 import { type OpenedStateStore, openStateStore } from '../state/index.js';
 import { createAgentRpcClient } from './agent-client.js';
 import { createApp } from './app.js';
@@ -24,6 +25,60 @@ export interface ServerHandle {
   close(): Promise<void>;
 }
 
+/**
+ * Seed the singleton Cluster and this node's Node record if they don't exist
+ * yet (finding #32). Shapes match what GET /system + GET /capabilities read
+ * (src/api/routes/system.ts): the cluster carries status.capabilities and
+ * member_node_ids; the node carries spec.hostname + status.agent_state. The
+ * heartbeat tracker updates the node's live agent_state afterwards; this only
+ * establishes the row so the system-family reads stop 404ing on a clean host.
+ */
+function seedClusterIfAbsent(state: OpenedStateStore, config: ApiConfig): void {
+  try {
+    if (state.kv.get('/xinas/v1/cluster') === null) {
+      state.kv.put('/xinas/v1/cluster', {
+        kind: 'Cluster',
+        id: 'default',
+        spec: { display_name: osHostname() },
+        status: {
+          mode: 'single_node',
+          capabilities: {
+            ha: 'not_enabled',
+            quorum: 'not_enabled',
+            witness: 'not_enabled',
+            'nfs.v3_locking_managed': false,
+            'nfs.recovery_state_managed': false,
+            'mcp.allow_apply': config.mcp?.allow_apply === true,
+          },
+          member_node_ids: [config.controller_id],
+        },
+      });
+    }
+    const nodeKey = `/xinas/v1/nodes/${config.controller_id}`;
+    if (state.kv.get(nodeKey) === null) {
+      state.kv.put(nodeKey, {
+        kind: 'Node',
+        id: config.controller_id,
+        spec: { hostname: osHostname() },
+        status: { agent_state: 'offline', observation_age_seconds: 0 },
+      });
+    }
+  } catch (err) {
+    // Non-fatal: a seed failure must not stop the api from starting. The
+    // system-family reads will 404 until the next successful start, exactly the
+    // pre-fix behavior — everything else (shares, arrays, health) is unaffected.
+    process.stderr.write(
+      `${JSON.stringify({
+        time: new Date().toISOString(),
+        level: 'error',
+        subsystem: 'bootstrap',
+        event: 'cluster_seed_failed',
+        error: err instanceof Error ? err.message : String(err),
+      })}\n`,
+    );
+  }
+}
+
 export async function startServer(opts: StartServerOptions = {}): Promise<ServerHandle> {
   const config = loadConfig(opts);
   // Conditional spread — exactOptionalPropertyTypes refuses
@@ -35,6 +90,15 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
     ...(config.state.archiveDir !== undefined ? { archiveDir: config.state.archiveDir } : {}),
   });
   state.drainer.start();
+
+  // First-boot cluster/node bootstrap (finding #32). Nothing in the shipped
+  // product ever seeded /xinas/v1/cluster or /xinas/v1/nodes/<id> — only test
+  // fixtures did — so on a real install GET /system and GET /capabilities
+  // permanently returned NOT_FOUND 'cluster not initialized'. Per ADR-0002 the
+  // api is the SOLE SQLite writer, so ansible/agent cannot seed it; the api
+  // must self-seed on first start. Idempotent: only writes when absent, so a
+  // human-managed cluster record (future multi-node) is never clobbered.
+  seedClusterIfAbsent(state, config);
 
   // Compile inbound-observation validators from api-v1.yaml once. Returns null
   // (validation skipped) when the spec isn't shipped — the graceful default.

--- a/xiNAS-MCP/src/lib/parse/disk.ts
+++ b/xiNAS-MCP/src/lib/parse/disk.ts
@@ -77,10 +77,18 @@ export function parseLsblkOutput(raw: string): ObservedDisk[] {
         status: {
           name: d.name,
           device_path: `/dev/${d.name}`,
-          ...(d.model !== undefined ? { model: d.model } : {}),
-          ...(d.serial !== undefined ? { serial: d.serial } : {}),
-          ...(d.tran !== undefined ? { transport: d.tran } : {}),
-          ...(d.wwn !== undefined ? { wwn: d.wwn } : {}),
+          // lsblk emits `null` (not omitted) for these on virtual block
+          // devices — e.g. xiRAID volumes /dev/xi_data, /dev/xi_log have no
+          // model/serial/transport/wwn. The api Disk schema types them as
+          // `string`, and inbound validation strips `required` but still checks
+          // TYPE, so a JSON `null` fails "must be string" and — because the
+          // observed endpoint fail-closes the WHOLE batch on one bad delta —
+          // silently dropped EVERY disk on real hardware. Guard on `string`
+          // (not `!== undefined`, which lets `null` through).
+          ...(typeof d.model === 'string' ? { model: d.model } : {}),
+          ...(typeof d.serial === 'string' ? { serial: d.serial } : {}),
+          ...(typeof d.tran === 'string' ? { transport: d.tran } : {}),
+          ...(typeof d.wwn === 'string' ? { wwn: d.wwn } : {}),
           ...(sizeText !== undefined ? { size_text: sizeText } : {}),
           ...(capacityBytes !== undefined ? { capacity_bytes: capacityBytes } : {}),
           system_disk: systemDisk,

--- a/xiNAS-MCP/src/lib/parse/nfs.ts
+++ b/xiNAS-MCP/src/lib/parse/nfs.ts
@@ -54,7 +54,10 @@ function parseJson(raw: string, caller: string): unknown {
 }
 
 interface RawClient {
-  host_pattern: string;
+  // The live xinas-nfs-helper emits `host`; older/assumed shapes used
+  // `host_pattern`. Accept both (see parseListExports).
+  host_pattern?: string;
+  host?: string;
   options?: string[];
 }
 
@@ -64,12 +67,18 @@ interface RawExport {
 }
 
 interface RawListExports {
+  // The live helper wraps its payload in a `{ ok, result: [...] }` envelope
+  // (callHelper returns the WHOLE line, unwrapped). Earlier this parser only
+  // read `exports`, so on real hardware it always saw undefined → [] and NO
+  // NFS export was ever observed (health then reported false drift for every
+  // managed share). Accept `result` (real), `exports` (legacy), or a bare array.
+  result?: RawExport[];
   exports?: RawExport[];
 }
 
 export function parseListExports(raw: string): ObservedExportRule[] {
-  const data = parseJson(raw, 'parseListExports') as RawListExports;
-  const exports_ = data.exports ?? [];
+  const data = parseJson(raw, 'parseListExports') as RawListExports | RawExport[];
+  const exports_ = Array.isArray(data) ? data : (data.result ?? data.exports ?? []);
   const rules: ObservedExportRule[] = [];
 
   for (const exp of exports_) {
@@ -81,7 +90,7 @@ export function parseListExports(raw: string): ObservedExportRule[] {
       const anon_gid = extractAnonId(opts, 'anon_gid');
       rules.push({
         export_path: exp.path,
-        host_pattern: client.host_pattern,
+        host_pattern: client.host_pattern ?? client.host ?? '*',
         options: opts,
         ...(squash_mode !== undefined ? { squash_mode } : {}),
         ...(anon_uid !== undefined ? { anon_uid } : {}),
@@ -102,12 +111,14 @@ interface RawSession {
 }
 
 interface RawListSessions {
+  // Same envelope as list_exports: the live helper returns `{ ok, result }`.
+  result?: RawSession[];
   sessions?: RawSession[];
 }
 
 export function parseListSessions(raw: string): ObservedNfsSession[] {
-  const data = parseJson(raw, 'parseListSessions') as RawListSessions;
-  const sessions = data.sessions ?? [];
+  const data = parseJson(raw, 'parseListSessions') as RawListSessions | RawSession[];
+  const sessions = Array.isArray(data) ? data : (data.result ?? data.sessions ?? []);
 
   return sessions.map<ObservedNfsSession>((s) => ({
     kind: 'NfsSession',

--- a/xiNAS-MCP/xinas-agent.service
+++ b/xiNAS-MCP/xinas-agent.service
@@ -58,7 +58,25 @@ ProtectHome=true
 # Finding #29: /run/netplan (and /etc/netplan on netplan-less hosts) may not
 # exist; a non-optional ReadWritePaths entry fails namespace setup with
 # 226/NAMESPACE and the agent restart-loops. '-' makes them optional.
-ReadWritePaths=/run/xinas /var/log/xinas /etc/systemd/system -/etc/netplan -/run/netplan /run/systemd
+#   /var/lib/xinas/config-history — the task executors' snapshot_before /
+#                          snapshot_after stages shell out to `xinas_history`,
+#                          which writes config snapshots under
+#                          /var/lib/xinas/config-history (store.py DEFAULT_STORE_PATH).
+#                          /var/lib/xinas is ReadOnlyPaths below (the api owns the
+#                          SQLite state), so WITHOUT this RW carve-out every
+#                          mutating task (share/fs/network create) threw EROFS at
+#                          stage 0 and — because task.begin fires the runner
+#                          fire-and-forget — hung stuck-'running' with no trace.
+#                          A ReadWritePaths subpath overrides a ReadOnlyPaths
+#                          parent. The dir is created by the xinas_api role's
+#                          tmpfiles.d (runs BEFORE this role, and at every boot),
+#                          so it exists at namespace-setup time. The leading '-'
+#                          keeps it OPTIONAL: if it is ever absent the agent still
+#                          starts (a non-optional missing RW path fails namespace
+#                          setup with 226/NAMESPACE — the exact trap a `+mkdir`
+#                          ExecStartPre can't escape, since ExecStartPre also runs
+#                          inside the mount namespace).
+ReadWritePaths=/run/xinas /var/log/xinas /etc/systemd/system -/var/lib/xinas/config-history -/etc/netplan -/run/netplan /run/systemd
 #   /etc/netplan         — S6 network executors (ADR-0008 §Sandbox): the
 #                          full-file 99-xinas.yaml render + the audited
 #                          cleanup of managed-iface stanzas in foreign files.

--- a/xiNAS-MCP/xinas-api.service
+++ b/xiNAS-MCP/xinas-api.service
@@ -29,6 +29,15 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+# Re-assert the tmpfiles.d ownership/mode of the writable dirs on EVERY start.
+# systemd-tmpfiles-setup runs these only at boot; a plain `systemctl restart`
+# does not. If /var/log/xinas or /var/lib/xinas/state ever drift from
+# `xinas-api:xinas-admin` (e.g. recreated as root by a partial reinstall, or a
+# log-rotation misstep), the unprivileged api can no longer open audit.jsonl /
+# the SQLite db and restart-loops with EACCES until someone manually re-runs
+# tmpfiles. The `+` prefix runs this as root (before the sandbox), so it can
+# chown; it is idempotent and cheap. This makes restart self-healing.
+ExecStartPre=+/usr/bin/systemd-tmpfiles --create /usr/lib/tmpfiles.d/xinas-api.conf
 ExecStart=/usr/bin/node /opt/xiNAS/xiNAS-MCP/dist/api-server.js
 Environment=XINAS_API_CONFIG=/etc/xinas-api/config.json
 Restart=on-failure


### PR DESCRIPTION
## What

Nine real defects found while running an **end-to-end unattended install + MCP share lifecycle on a live 24-NVMe node** (Ubuntu 24.04, kernel 6.8). Every one passed the existing test suite (which uses fakes/fixtures) but broke on real hardware. All fixes verified on-node after a clean `uninstall` → `autoinstall --preset default` (17/17 roles ok, clean log).

## Fixes

**Observation pipeline** — each caused an *entire kind* to be silently dropped on real hardware (the `/internal/v1/observed` endpoint fail-closes the whole batch on one bad delta, and a 4xx was swallowed):
- `agent/xiraid/client.ts` — live daemon returns `raid_show`/`pool_show` as a **name-keyed map**; parsers expected an array → **0 XiraidArray/Pool**. Added `toArrayPayload()`.
- `lib/parse/disk.ts` — `lsblk` emits `null` model/serial/tran/wwn for virtual volumes (`xi_data`/`xi_log`); string-typed schema rejected `null` → **0 disks**. Guard on `typeof === 'string'`.
- `api/observed-schemas.ts` — inbound validation kept `enum` constraints though it's meant to be type-only; a real out-of-enum value fail-closed the batch → **0 Filesystem**. Added `stripEnum()`.
- `lib/parse/nfs.ts` — live nfs-helper returns `{result:[{clients:[{host}]}]}`, parser read `{exports}`/`host_pattern` → **0 ExportRule** (false NFS drift). Accept both envelopes.
- `agent/publisher.ts` — a 4xx from the observed endpoint was swallowed silently, masking all of the above. Now logs `observed_post_rejected`.

**Cluster init (#32)** — `api/server.ts`: production never seeded `/xinas/v1/cluster` or the Node record, so `GET /system` + `/capabilities` permanently 404'd *"cluster not initialized"*. Per ADR-0002 only the api may write SQLite, so it self-seeds on first start (idempotent `seedClusterIfAbsent()`).

**Service robustness + install ordering**
- `xinas-api.service` — re-assert tmpfiles ownership via `ExecStartPre` so a plain restart self-heals if `/var/log/xinas` or the state dir drift to `root` (otherwise EACCES restart-loop).
- `xinas-agent.service` — carve `/var/lib/xinas/config-history` into `ReadWritePaths` (optional `-`) so the executors' `snapshot_before` stage can write it; without it **every mutating MCP/API task hit EROFS and hung `running` forever**. Dir is created by the api role's tmpfiles.d. (A `+mkdir` ExecStartPre does *not* escape the mount namespace — it 226/NAMESPACEs.)
- `xinas_api` tmpfiles.d — create `/var/lib/xinas/config-history`.
- `xinas_nfs_helper` role — restart `xinas-agent` (handler, at play-end) once the helper socket exists; the agent role runs first, so its `NfsSession` collector otherwise caches `ENOENT` and leaves `agent.connectivity` degraded on every fresh install until a manual restart.

**RAID create (#231)** — `raid_fs/tasks/create_array.yml`: `default(2560)` on `raid_create_min_free_mb` so the mempool-floor check survives the preset-clobber that overwrites role defaults.

## Validation on real node

- Clean install: **17/17 roles ok**, 0 real failures in `install.log`, all 4 services active/enabled (restarts=0), all artifacts present.
- Observation: arrays=2, disks=48, filesystems=1, ExportRule observed; agent `healthy` with **0 errored collectors** after the ordering fix.
- `#32`: `system get` returns the cluster with no manual patch.
- MCP end-to-end: transport up; apply gate returns `MCP_APPLY_DISABLED` when off; share **created via MCP plan/apply**, visible via API+MCP+`exportfs`+observed, **loopback-mounted R/W/delete**, **deleted via MCP**; audit is MCP-originated, terminal-success, no duplicate frames, hash-chain intact.

Closes #32. Closes #231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
