### PR TITLE
fix(history/agent): unique snapshot IDs + never wedge a task on snapshot failure

### DIFF
--- a/xiNAS-MCP/src/agent/task/runner.ts
+++ b/xiNAS-MCP/src/agent/task/runner.ts
@@ -134,8 +134,24 @@ export class TaskRunner {
       // 1. accepted (seq 1).
       await emit('accepted');
 
-      // 2. snapshot_before — real xinas_history capture.
-      const before = await this.#bridge.snapshotCreate(begin.operation_kind, 'api');
+      // 2. snapshot_before — real xinas_history capture. A capture failure here
+      //    must NOT wedge the task: task.begin fires run() fire-and-forget and
+      //    swallows a thrown promise, so an uncaught throw would leave the task
+      //    stuck 'running' with NO terminal event (the api only settles a task on
+      //    a terminal). No change has been applied yet, so report a clean failure.
+      let before: { snapshot_id: string };
+      try {
+        before = await this.#bridge.snapshotCreate(begin.operation_kind, 'api');
+      } catch (err) {
+        await emit('stage_failed', {
+          stage_index: nextStageIndex(),
+          stage_name: 'snapshot_before',
+          status: 'failed',
+          error_message: err instanceof Error ? err.message : String(err),
+        });
+        await emit('terminal', { status: 'failed', error_code: 'FAILED_BEFORE_CHANGE' });
+        return;
+      }
       await emit('stage_succeeded', {
         stage_index: nextStageIndex(),
         stage_name: 'snapshot_before',
@@ -193,15 +209,37 @@ export class TaskRunner {
         });
       }
 
-      // 4. All stages ok → snapshot_after + terminal(success).
-      const after = await this.#bridge.snapshotCreate(begin.operation_kind, 'api');
-      await emit('stage_succeeded', {
-        stage_index: nextStageIndex(),
-        stage_name: 'snapshot_after',
-        status: 'succeeded',
-        snapshot_id: after.snapshot_id,
+      // 4. All stages ok → snapshot_after + terminal(success). snapshot_after is
+      //    a POST-change capture (a rollback reference); the operation's real
+      //    work already succeeded, so a capture failure here must neither fail
+      //    the task nor wedge it in 'running'. Best-effort: log to the journal and
+      //    still terminate success, just without an after-snapshot id.
+      let after: { snapshot_id: string } | null = null;
+      try {
+        after = await this.#bridge.snapshotCreate(begin.operation_kind, 'api');
+      } catch (err) {
+        process.stderr.write(
+          `${JSON.stringify({
+            level: 'error',
+            subsystem: 'task-runner',
+            event: 'snapshot_after_failed',
+            task_id: begin.task_id,
+            error: err instanceof Error ? err.message : String(err),
+          })}\n`,
+        );
+      }
+      if (after !== null) {
+        await emit('stage_succeeded', {
+          stage_index: nextStageIndex(),
+          stage_name: 'snapshot_after',
+          status: 'succeeded',
+          snapshot_id: after.snapshot_id,
+        });
+      }
+      await emit('terminal', {
+        status: 'success',
+        ...(after !== null ? { snapshot_id: after.snapshot_id } : {}),
       });
-      await emit('terminal', { status: 'success', snapshot_id: after.snapshot_id });
     } finally {
       this.#inflight.delete(begin.task_id);
     }

--- a/xinas_history/models.py
+++ b/xinas_history/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import uuid
 from dataclasses import dataclass, field
 from enum import Enum
 
@@ -313,17 +314,31 @@ class DiffResult:
 
 
 def generate_snapshot_id(operation: str) -> str:
-    """Generate a snapshot ID from the current UTC time and operation name.
+    """Generate a UNIQUE snapshot ID from the current UTC time and operation.
 
-    Format: ``YYYYMMDDTHHMMSSZ-<operation>`` where *operation* has
-    underscores replaced with hyphens for readability.
+    Format: ``YYYYMMDDTHHMMSSZ-<operation>-<rand>`` where *operation* has
+    underscores replaced with hyphens for readability and *rand* is a short
+    random hex suffix.
+
+    The random suffix is REQUIRED for correctness, not decoration: the timestamp
+    has one-second granularity, so two snapshots created in the same wall-clock
+    second for the same operation would otherwise derive the IDENTICAL id. That
+    happens routinely when two task executors run concurrently (each captures a
+    ``snapshot_before`` + ``snapshot_after``) — e.g. creating two NFS shares at
+    once. On collision the second snapshot's atomic ``.tmp-<id>`` → ``<id>``
+    store rename fails with ``[Errno 39] Directory not empty``; the bridge throws,
+    and the agent runner's snapshot capture had no terminal path, leaving the
+    whole task wedged in ``running`` forever (share never materialized). The id
+    is opaque everywhere — listings sort by the manifest ``timestamp`` field and
+    nothing parses the id string — so the suffix is safe to add.
 
     Examples::
 
-        generate_snapshot_id("raid_create")   -> "20260316T145500Z-raid-create"
-        generate_snapshot_id("install")       -> "20260316T145500Z-install"
+        generate_snapshot_id("raid_create")   -> "20260316T145500Z-raid-create-3f2a9c1b"
+        generate_snapshot_id("install")       -> "20260316T145500Z-install-a17b02de"
     """
     now = datetime.datetime.utcnow()
     ts = now.strftime("%Y%m%dT%H%M%SZ")
     slug = operation.replace("_", "-")
-    return f"{ts}-{slug}"
+    suffix = uuid.uuid4().hex[:8]
+    return f"{ts}-{slug}-{suffix}"


### PR DESCRIPTION
## What

Two concurrency bugs found on a real node while creating **two NFS shares via MCP at the same time**: share A materialized, share B did not, and **both task rows stuck `running` forever**.

## Root causes

**1. Same-second snapshot ID collision** (`xinas_history/models.py`)
`generate_snapshot_id()` used a **one-second-granularity** UTC timestamp: `YYYYMMDDTHHMMSSZ-<operation>`. Two `share.create` executors running concurrently each capture `snapshot_before`/`snapshot_after`, so two snapshots of the same operation in the same second compute the **identical id**. The loser's atomic `.tmp-<id>` → `<id>` store rename fails with `[Errno 39] Directory not empty`. Fix: append a short random hex suffix. The id is **opaque everywhere** (listings sort by the manifest `timestamp` field; nothing parses the id), so it's safe.

**2. A snapshot capture failure wedges the task** (`agent/task/runner.ts`)
The runner's `snapshot_before`/`snapshot_after` calls were unguarded. When `snapshotCreate` threw (bug 1), it propagated out of `run()` — which `task.begin` invokes fire-and-forget with a bare `.catch(()=>{})` — so **no terminal event was emitted** and the api left the task `running` indefinitely. Fixes:
- `snapshot_before` failure → `stage_failed` + `terminal(failed, FAILED_BEFORE_CHANGE)` (no change applied; clean failure).
- `snapshot_after` failure → the operation's real work already succeeded, so log to the journal and still `terminal(success)` (without an after-snapshot id) rather than failing or wedging the task.

## Verified on-node

Reproduced the deadlock (two concurrent `snapshot create` → one `Directory not empty`, both tasks wedged `running`). After the fix:
- Two shares created **concurrently** via MCP → **both reach terminal `success`**, both export (`exportfs` shows both), both **mount over loopback** with R/W/delete, both observed as `ExportRule`.
- The api reconciler settles any pre-existing wedged task to `requires_manual_recovery` on restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
