### PR TITLE
fix(support-bundle): dir perms + no lease leak on staging failure

### DIFF
--- a/collection/roles/xinas_api/templates/xinas-api-tmpfiles.conf.j2
+++ b/collection/roles/xinas_api/templates/xinas-api-tmpfiles.conf.j2
@@ -29,6 +29,15 @@ d /run/xinas             1731 root xinas-api -
 d /var/lib/xinas         0755 root root          -
 d {{ xinas_api_state_dir }}   0750 {{ xinas_api_user }} {{ xinas_api_socket_group }} -
 d {{ xinas_api_log_dir }}     0750 {{ xinas_api_user }} {{ xinas_api_socket_group }} -
+# support-bundle staging dir — written by BOTH the api (owner xinas-api: stages
+# <task>.api.json) AND the agent (group xinas-admin: creates work-<task>/ +
+# <task>.tar.gz). The agent runs as root but its sandbox drops CAP_DAC_OVERRIDE,
+# so root does NOT bypass mode bits — the dir must be group-writable for the
+# agent, like /run/xinas. Mode 0770 (NOT setgid 2770): a setgid bit propagates
+# into the collected work tree and the executor's tar verify then fails with
+# "Cannot change mode to rwxr-sr-x: Operation not permitted" (sandboxed root
+# lacks CAP_FSETID to restore setgid on dirs it isn't the group-owner of).
+d {{ xinas_api_log_dir }}/bundles 0770 {{ xinas_api_user }} {{ xinas_api_socket_group }} -
 # config-history store (xinas_history DEFAULT_STORE_PATH). Created here — by the
 # api role, which runs BEFORE xinas_agent and at every boot — so the agent's
 # ReadWritePaths carve-out for it resolves at namespace-setup time. The

--- a/collection/roles/xinas_menu/tasks/main.yml
+++ b/collection/roles/xinas_menu/tasks/main.yml
@@ -170,8 +170,15 @@
   ansible.builtin.file:
     path: "{{ xinas_log_dir }}"
     state: directory
-    owner: root
-    group: root
+    # MUST match the xinas_api role's tmpfiles ownership (xinas-api:xinas-admin).
+    # This role runs AFTER xinas_api, so owning /var/log/xinas as root:root here
+    # CLOBBERS the api's ownership: the unprivileged api can then no longer create
+    # entries in its own log dir — support.bundle fails with EACCES mkdir
+    # /var/log/xinas/bundles, and a plain api restart would EACCES on audit.jsonl
+    # (only the api unit's ExecStartPre tmpfiles re-assert masks that). The menu's
+    # own healthcheck writes run as root and work fine inside an api-owned dir.
+    owner: xinas-api
+    group: xinas-admin
     mode: '0750'
   tags: [xinas_menu, logs]
 

--- a/xiNAS-MCP/src/api/routes/support.ts
+++ b/xiNAS-MCP/src/api/routes/support.ts
@@ -120,23 +120,42 @@ export function supportRouter(ctx: ApiContext): Router {
         return;
       }
 
-      // Stage the DB-owned half BEFORE dispatch so the collect stage
-      // finds it; the dispatch spec carries the apply task_id.
-      await stageApiHalf(ctx, bundleDir, task.task_id);
+      // Stage the DB-owned half BEFORE dispatch so the collect stage finds it;
+      // the dispatch spec carries the apply task_id. The task is already
+      // 'queued' holding the SupportBundle lease at this point, so if staging or
+      // dispatch throws we MUST release that lease — otherwise the queued task is
+      // orphaned and every later support-bundle fails CONFLICT 'resource is
+      // locked by another task' until an operator manually cancels it. Cancel a
+      // queued task releases its lease (engine.cancel → revertDesired). Cleanup
+      // is best-effort and must never mask the original failure.
+      try {
+        await stageApiHalf(ctx, bundleDir, task.task_id);
 
-      const dispatchSpec = {
-        ...(persisted.spec as Record<string, unknown>),
-        task_id: task.task_id,
-      };
-      const dispatched = await tasks.taskEngine.admitAndDispatch({
-        task,
-        agentClient: tasks.agentClient,
-        spec: dispatchSpec,
-        plan: applyPlan,
-      });
+        const dispatchSpec = {
+          ...(persisted.spec as Record<string, unknown>),
+          task_id: task.task_id,
+        };
+        const dispatched = await tasks.taskEngine.admitAndDispatch({
+          task,
+          agentClient: tasks.agentClient,
+          spec: dispatchSpec,
+          plan: applyPlan,
+        });
 
-      res.status(202);
-      sendOk(req, res, taskEnvelope(dispatched), [dispatched.state_revision_at_apply ?? 0]);
+        res.status(202);
+        sendOk(req, res, taskEnvelope(dispatched), [dispatched.state_revision_at_apply ?? 0]);
+      } catch (stageErr) {
+        try {
+          await tasks.taskEngine.cancel({
+            taskId: task.task_id,
+            agentClient: tasks.agentClient,
+            trackerOffline: false,
+          });
+        } catch {
+          /* best-effort lease release; surface the original failure below */
+        }
+        throw stageErr;
+      }
     } catch (err) {
       next(err);
     }


### PR DESCRIPTION
## What

Found by **test-driving all ~60 MCP tools on a real 24-NVMe node**. The `support.bundle` tool failed end-to-end for **three compounding reasons**, all invisible to the fixture-backed test suite.

## Fixes

**1. `/var/log/xinas` re-owned to `root:root`** (`collection/roles/xinas_menu`) — the "Ensure log directory exists" task runs *after* `xinas_api` and chowned the dir to `root:root`, clobbering the api's `xinas-api:xinas-admin` ownership. The unprivileged api then couldn't `mkdir /var/log/xinas/bundles` → `EACCES`. (It also silently armed an api restart-loop, masked only by the unit's ExecStartPre tmpfiles re-assert.) → own it `xinas-api:xinas-admin`.

**2. bundles dir not group-writable for the agent** (`xinas_api` tmpfiles) — both the api (owner) *and* the agent write `bundles/` (the agent creates `work-<task>/` + `<task>.tar.gz`). The agent runs as root but its sandbox drops `CAP_DAC_OVERRIDE`, so it needs group write. → pre-create `/var/log/xinas/bundles 0770 xinas-api:xinas-admin`. Plain `0770`, **not** setgid `2770` — a setgid bit propagates into the collected tree and the executor's tar-verify then fails `cannot change mode to rwxr-sr-x` (sandboxed root lacks `CAP_FSETID`).

**3. lease leak on api-half staging failure** (`api/routes/support.ts`) — the route admits the task (queued, holding the `SupportBundle` lease) *before* staging the api half; if staging/dispatch threw, the queued task + lease were orphaned and every later bundle failed `CONFLICT: resource is locked` until an operator manually cancelled it. → wrap staging+dispatch and cancel the queued task (releases the lease) on failure, best-effort, before re-raising.

## Verified on-node

- support.bundle completes `success` — all 7 stages (snapshot_before → preflight → collect → archive → verify → prune → snapshot_after), archive produced.
- Induced staging failure now leaves **0 leases**, and the next bundle succeeds with **no manual cancel**.
- Part of a full MCP-tool sweep: **all ~60 tools exercised and passing** (reads, plan/apply mutations, direct tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
