### PR TITLE
fix(client): multi-IP NFS mount broken by `local` outside a function

### DIFF
--- a/client_repo/client_setup.sh
+++ b/client_repo/client_setup.sh
@@ -4403,7 +4403,9 @@ case "${1:-}" in
         # Add trunking for multi-IP configurations (kernel >= 6.x only)
         trunk_opts=""
         if [[ $num_ips -gt 1 ]]; then
-            local kmajor
+            # NOTE: this --mount case runs at top level (case "${1:-}"), NOT in a
+            # function, so `local` here aborts under `set -euo pipefail` and kills
+            # the mount before it runs. Use a plain assignment.
             kmajor=$(uname -r | cut -d. -f1)
             if [[ "$kmajor" -ge 6 ]]; then
                 trunk_opts=",trunkdiscovery"


### PR DESCRIPTION
## What

Found while installing the xiNAS client on a real node and mounting shares over RDMA.

`client_setup.sh --mount SERVER1,SERVER2:/share MP [tcp|rdma]` — the **multi-IP trunking** path — aborts immediately:

```
client_setup.sh: line 4406: local: can only be used in a function
```

## Why

The `--mount` handler lives in the **top-level** `case "${1:-}"` argument parser, not inside a function, so `local kmajor` is invalid there. The script runs under `set -euo pipefail`, so the non-zero `local` **aborts before any mount runs**. Every trunked mount (2/4/8/16 IPs — the `nconnect` + `trunkdiscovery` performance feature) is dead on arrival. Single-IP mounts are unaffected (the `num_ips > 1` branch is skipped).

## Fix

Drop `local`; the next line already assigns `kmajor`.

## Verified on a real node

- Before: `xinas-client --mount 10.10.10.57,10.10.10.58:/mnt/data/share1 /mnt/multi rdma` → `EXIT=1`, 0 mounts.
- After: same command mounts both connections over **NFSv4.2 / RDMA** with `nconnect=8` + `trunkdiscovery`.

Note: the client one-shot installer (`install_client.sh`) pulls `client_repo` from **`main`**, so this is targeted at `main` to reach real clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
