### PR TITLE
fix(raid_fs): default install aborts — preset wipes raid_create_min_free_mb

### DIFF
--- a/collection/roles/raid_fs/tasks/create_array.yml
+++ b/collection/roles/raid_fs/tasks/create_array.yml
@@ -32,11 +32,11 @@
   ansible.builtin.fail:
     msg: >-
       Only {{ _mem_avail_kb.stdout | int // 1024 }} MiB free after reclaim, but
-      creating array '{{ item.name }}' needs >= {{ raid_create_min_free_mb }} MiB
+      creating array '{{ item.name }}' needs >= {{ raid_create_min_free_mb | default(2560) }} MiB
       for the xiRAID mempool (memory_prealloc). Proceeding would fail with a
       kernel '__get_free_pages() failed … RAID creation failed' error. Add RAM,
       reduce the disk count for this array, or lower its memory_prealloc_mb.
-  when: (_mem_avail_kb.stdout | int // 1024) < (raid_create_min_free_mb | int)
+  when: (_mem_avail_kb.stdout | int // 1024) < (raid_create_min_free_mb | default(2560) | int)
   tags: [raid_fs, raid]
 
 - name: Create array {{ item.name }}

--- a/presets/default/raid_fs.yml
+++ b/presets/default/raid_fs.yml
@@ -33,3 +33,9 @@ nvme_raid_log_level: 10       # RAID 10 for small namespaces (log array)
 
 # Note: xiraid_arrays and xfs_filesystems are generated automatically
 # by nvme_namespace role when nvme_auto_namespace: true
+# Minimum free memory (MiB) required before creating each array. xiRAID
+# preallocates a per-array kernel mempool (~memory_prealloc, ~2 GB) via
+# __get_free_pages(); creation fails cryptically below this floor. Defined here
+# because this preset REPLACES the raid_fs role's defaults/main.yml, so any
+# default the role adds must be mirrored here or it is lost at preset-apply.
+raid_create_min_free_mb: 2560

--- a/presets/xinnorVM/raid_fs.yml
+++ b/presets/xinnorVM/raid_fs.yml
@@ -9,3 +9,9 @@ xiraid_force_metadata: true
 
 # When true, always format XFS filesystems even if the label already exists
 xfs_force_mkfs: true
+# Minimum free memory (MiB) required before creating each array. xiRAID
+# preallocates a per-array kernel mempool (~memory_prealloc, ~2 GB) via
+# __get_free_pages(); creation fails cryptically below this floor. Defined here
+# because this preset REPLACES the raid_fs role's defaults/main.yml, so any
+# default the role adds must be mirrored here or it is lost at preset-apply.
+raid_create_min_free_mb: 2560


### PR DESCRIPTION
## What

Installing the **v3.1.1 release** (`curl … install.sh | sudo bash` → `autoinstall.sh --preset default`) **fails at array creation on every host**:

```
raid_fs/tasks/create_array.yml:31 — 'raid_create_min_free_mb' is undefined
→ ansible-playbook failed (exit 2)
```

## Root cause — preset-apply clobber

`autoinstall.sh` applies a preset by **copying `presets/<name>/raid_fs.yml` over `roles/raid_fs/defaults/main.yml`** (the install log shows `main.yml <- presets/default/raid_fs.yml`). Commit #23 added `raid_create_min_free_mb: 2560` to the *role defaults*, but **neither preset was updated to carry it**, so the wholesale replace deletes the variable. The guard task's `when:` then evaluates an undefined var and aborts. (The role defaults still define it — which is why this only reproduces through a preset, not in unit tests.)

## Fix

- Add `raid_create_min_free_mb: 2560` to **both** presets that replace the raid_fs defaults (`default`, `xinnorVM`), with a comment explaining the mirroring requirement.
- Make the guard **defensive**: `raid_create_min_free_mb | default(2560)` in the message and the `when:` — so a preset that forgets it can never hard-fail the whole install again.

## Verified on a real 24-NVMe node

Reproduced the exact `exit 2` on a clean v3.1.1 install; after this fix the default-preset install gets past array creation and completes (MemAvailable ~234 GiB, well above the 2560 MiB floor, so the guard correctly passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
