### PR TITLE
fix(agent): arrays invisible in API/TUI — parseRaidShow rejects real daemon shape

### DIFF
--- a/xiNAS-MCP/src/__tests__/lib/parse/raid.test.ts
+++ b/xiNAS-MCP/src/__tests__/lib/parse/raid.test.ts
@@ -136,4 +136,43 @@ describe('parseRaidShow', () => {
     );
     expect(noPayload[0]?.spec.spare_disk_ids).toEqual([]);
   });
+
+  it('normalizes the real xiRAID daemon shape (object keyed by name, tuple devices)', () => {
+    // The live xiRAID 4.3.x daemon returns raid_show as an object keyed by
+    // array name ({"data":{...},"log":{...}}) with devices as
+    // [index, path, [states]] tuples — NOT the flat array of string-device
+    // objects the fake transport emits. Both must parse.
+    const arrays = parseRaidShow(
+      {
+        data: {
+          level: '5',
+          devices: [
+            [0, '/dev/nvme1n1', ['online']],
+            [1, '/dev/nvme2n1', ['online']],
+          ],
+          state: ['online', 'initing'],
+          init_progress: 30,
+        },
+        log: {
+          level: '10',
+          devices: [[0, '/dev/nvme3n1', ['online']]],
+          state: ['online'],
+        },
+      },
+      DISK_IDS,
+    );
+    expect(arrays).toHaveLength(2);
+    const byId = Object.fromEntries(arrays.map((a) => [a.id, a]));
+    // the map key becomes the array name; tuple devices resolve to disk ids
+    expect(byId.data).toMatchObject({
+      id: 'data',
+      spec: { name: 'data', level: 'raid5', member_disk_ids: ['disk-1', 'disk-2'] },
+      status: { state: 'rebuilding', rebuild_progress_pct: 30 },
+    });
+    expect(byId.log).toMatchObject({
+      id: 'log',
+      spec: { name: 'log', level: 'raid10', member_disk_ids: ['disk-3'] },
+      status: { state: 'optimal' },
+    });
+  });
 });

--- a/xiNAS-MCP/src/lib/parse/raid.ts
+++ b/xiNAS-MCP/src/lib/parse/raid.ts
@@ -100,11 +100,7 @@ export function parseRaidShow(
     const devices = Array.isArray(o.devices)
       ? o.devices
           .map((d): string | null =>
-            typeof d === 'string'
-              ? d
-              : Array.isArray(d) && typeof d[1] === 'string'
-                ? d[1]
-                : null,
+            typeof d === 'string' ? d : Array.isArray(d) && typeof d[1] === 'string' ? d[1] : null,
           )
           .filter((d): d is string => d !== null)
       : [];

--- a/xiNAS-MCP/src/lib/parse/raid.ts
+++ b/xiNAS-MCP/src/lib/parse/raid.ts
@@ -70,16 +70,43 @@ export function parseRaidShow(
   diskIdByPath: ReadonlyMap<string, string>,
   pools?: unknown,
 ): ObservedXiraidArray[] {
-  if (!Array.isArray(payload)) return [];
+  // xiRAID's raid_show returns EITHER a JSON array of per-array objects OR an
+  // object keyed by array name ({"data":{...},"log":{...}}) — the latter on the
+  // real xiRAID 4.3.x daemon (the fake transport emits an array). Normalize both
+  // to a list, injecting the map key as `name` when a keyed value lacks one;
+  // otherwise real arrays are silently dropped and the API/TUI shows "no arrays".
+  let entries: unknown[];
+  if (Array.isArray(payload)) {
+    entries = payload;
+  } else if (payload !== null && typeof payload === 'object') {
+    entries = Object.entries(payload as Record<string, unknown>).map(([name, info]) =>
+      info !== null && typeof info === 'object' && !Array.isArray(info)
+        ? { name, ...(info as Record<string, unknown>) }
+        : info,
+    );
+  } else {
+    return [];
+  }
   const poolDrives = readPools(pools);
   const out: ObservedXiraidArray[] = [];
-  for (const entry of payload) {
+  for (const entry of entries) {
     if (typeof entry !== 'object' || entry === null) continue;
     const o = entry as Record<string, unknown>;
     if (typeof o.name !== 'string' || o.name.length === 0) continue;
 
+    // devices is either ["/dev/..."] (fake transport) or, on the real xiRAID
+    // daemon, [[index, "/dev/...", [states]], ...] tuples — extract the path
+    // from both shapes so member_disk_ids is populated.
     const devices = Array.isArray(o.devices)
-      ? o.devices.filter((d): d is string => typeof d === 'string')
+      ? o.devices
+          .map((d): string | null =>
+            typeof d === 'string'
+              ? d
+              : Array.isArray(d) && typeof d[1] === 'string'
+                ? d[1]
+                : null,
+          )
+          .filter((d): d is string => d !== null)
       : [];
     const states = normalizeStates(o.state);
     const reconProgress = numberOrNull(o.recon_progress) ?? numberOrNull(o.init_progress);


### PR DESCRIPTION
## Symptom

On a real node the xiNAS TUI (and MCP `arrays.list`) shows **"no arrays"** — even though `xicli raid show` lists them, the volumes are online, and `/mnt/data` is mounted.

## Root cause

The xiRAID observation collector calls `parseRaidShow()` on the daemon's `raid_show` payload. The parser was written against the **fake transport's** shape and rejects what the **real xiRAID 4.3.x daemon** returns:

1. **Payload is an object keyed by array name** — `{"data":{…},"log":{…}}` — not a JSON array. The parser did `if (!Array.isArray(payload)) return []` and dropped every array → **0 observed → API/TUI shows none**.
2. **`devices` are `[index, "/dev/…", [states]]` tuples**, not bare path strings, so even once visible, `member_disk_ids` came out empty.

Unit tests passed because they exercised the fake-transport (array) shape, not the daemon's.

## Fix

Both changes live in the tolerant parser, where daemon-shape variance already belongs:
- Normalize an object-keyed payload to a list, injecting the map key as `name` when a value lacks one — arrays *and* keyed objects parse.
- Extract the device path from either a string or a `[idx, path, states]` tuple.

## Verified on a 24-NVMe node

- `arrays.list` now returns both arrays: **data** (raid5, rebuilding, 22 members) and **log** (raid10, optimal, 22 members); agent healthy.
- Added a regression test for the real object-keyed / tuple-device shape — **9/9 parser tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
