### PR TITLE
feat(tui): Back navigation for Add Share, Edit Share, and Create Array wizards

### DIFF
--- a/docs/Storage/fs-shares-management-spec.md
+++ b/docs/Storage/fs-shares-management-spec.md
@@ -263,31 +263,46 @@ Every write goes through the helper socket, including the `idmapd` step (which i
 
 This is the closest the TUI comes to a dashboard — it's the screen most operators see most often.
 
-### 4.3 The shared 5-step access-control wizard (`_access_wizard`)
+### 4.3 Wizard navigation model
 
-Add and Edit both call into `_access_wizard()` with `step_offset` and `total_steps` parameters so the title chrome reads `Step N/7` consistently. The wizard collects five fields:
+Both share wizards (Add, Edit) — and, by the same pattern, the RAID Create-Array wizard covered in [Storage/raid-management-spec.md §4](raid-management-spec.md#4-create-array-wizard) — run on a generic **Back-navigable driver**: [xinas_menu/widgets/wizard.py](../../xinas_menu/widgets/wizard.py).
 
-| Step | Field | Choices |
-|---|---|---|
-| 1 | `host` | `Everyone` (→ `*`), `Specific network` (→ free-form CIDR), `Single host` (→ free-form IP) |
-| 2 | `access` | `rw` or `ro` |
-| 3 | `root_squash` | `no_root_squash` ("full admin", recommended) or `root_squash` ("limited", more secure) |
-| 4 | `sync_mode` | `sync` (safer) or `async` (faster) |
-| 5 | `sec` | `sys`, `krb5`, `krb5i`, `krb5p` |
+- **`WizardStep`** — a dataclass of `key` (the answers-dict key the step's result is stored under), an async `run(answers, allow_back, step_no)` callable, and an optional `applies(answers)` predicate (default: always applicable). A step whose `applies()` returns `False` is skipped in both directions and its stale key (if any) is pruned from `answers` when skipped.
+- **`BACK` / `CANCEL`** — two distinct sentinel objects (not `None`, not any real string/bool). A step's `run()` returns one of these instead of a value to signal "go to the previous applicable step" or "abort the whole wizard."
+- **`run_wizard(steps, initial=None)`** — the driver loop. It owns the current index and the accumulated `answers` dict (seeded from `initial`, used by Edit to pre-load the selected share's current values). For each applicable step it computes `allow_back` (`True` once any earlier step is applicable — `False` on the wizard's first step) and `step_no` (the 1-based position **counting only applicable steps**, so a skipped step doesn't leave a gap in the numbering). It calls `step.run(answers, allow_back, step_no)`; on `CANCEL` the whole call returns `None`; on `BACK` it rewinds to the previous applicable index; otherwise it stores `answers[step.key] = result` and advances. Returns the final `answers` dict once every step has been passed, or `None` if any step cancelled.
+- **Answers are retained across Back.** Since `answers` is one dict shared by the whole run, backing up and coming forward again shows the step's previously-entered value pre-filled rather than blank — see the dialog pre-fill params below.
 
-When called from Edit (`current=` set), every prompt is annotated with `(Current: …)` so the operator can see what they're about to change before they change it.
+**Dialog support.** The four dialogs used by these wizards — `SelectDialog`, `InputDialog`, `ConfirmDialog` ([xinas_menu/widgets/](../../xinas_menu/widgets/)), and `DrivePickerScreen` (RAID only, see the RAID spec) — all accept a keyword-only `allow_back: bool = False`. When `True`, the dialog renders a **Back** button and dismisses with the `BACK` sentinel when it's pressed. `Esc` always still dismisses as **Cancel** (`None`), never Back — that binding is unconditional in every dialog. `SelectDialog` and `ConfirmDialog` additionally bind the `left` arrow key to Back (a no-op if `allow_back` is `False`); `InputDialog` exposes Back only via the button (arrow-left would collide with in-field cursor movement); `DrivePickerScreen` binds `b` to Back in addition to its button, since arrow keys and most single letters are already claimed by the picker's own navigation/filter/sort bindings.
 
-The wizard returns the dict `{host, access, root_squash, sync_mode, sec}` or `None` on cancel. Each step also accepts cancel — bailing on step 3 doesn't mutate state.
+Pre-fill on re-entry is dialog-specific: `SelectDialog.selected` pre-highlights an option, `InputDialog.default` pre-fills the text field, and `DrivePickerScreen.preselected` pre-checks a drive set — each wizard step reads its current value out of `answers` and passes it back in on every entry, so what the operator sees after backing up matches what they last chose.
 
-### 4.4 Add Share (7 steps)
+### 4.4 The shared 5-step access-control steps (`_access_steps`)
+
+Add and Edit both call `NFSScreen._access_steps(prefix, total)`, which builds and returns the five shared `WizardStep`s (it no longer runs the steps itself — the caller concatenates them into its own step list and hands the whole thing to `run_wizard`). `prefix` (`"Add Share"` or `"Edit Share"`) and `total` (currently always `7`) feed a shared `title(step_no)` closure so every dialog in the wizard reads `<prefix> — Step <step_no>/<total>`, with `step_no` computed by the driver.
+
+| Step | Key | Field | Choices |
+|---|---|---|---|
+| 1 | `host` | `host` | `Everyone` (→ `*`), `Specific network` (→ free-form CIDR), `Single host` (→ free-form IP) |
+| 2 | `access` | `access` | `rw` or `ro` |
+| 3 | `root_squash` | `root_squash` | `no_root_squash` ("full admin", recommended) or `root_squash` ("limited", more secure) |
+| 4 | `sync_mode` | `sync_mode` | `sync` (safer) or `async` (faster) |
+| 5 | `sec` | `sec` | `sys`, `krb5`, `krb5i`, `krb5p` |
+
+Every step reads its **working value** out of the running `answers` dict (`answers.get("host", "*")`, etc.) to compute the `SelectDialog.selected` pre-fill — so re-entering a step after Back shows what was picked last, not the original default. Separately, when `answers` carries an `_orig` snapshot — which only Edit seeds (see §4.6) — each prompt appends a `(Current: …)` hint describing the share's value *before this edit run started*, so the operator can see both "what I'm about to pick" (pre-selected) and "what it was originally" (the hint) at once.
+
+The host step (step 1) is a nested sub-flow: the top-level `SelectDialog` offers the three radio choices; picking "Specific network" or "Single host" pushes a follow-up `InputDialog` (always `allow_back=True`) for the CIDR/IP. Backing out of that sub-input returns to the host `SelectDialog` (an internal `continue`, not a `BACK` to the driver); an **empty** value at that sub-input re-prompts the same way, with a `"Host/network must not be empty."` notification — it no longer aborts the wizard as older behavior did.
+
+Each step returns `CANCEL` if its dialog is dismissed with `None`, `BACK` if the dialog returns the `BACK` sentinel, or the resolved field value.
+
+### 4.5 Add Share (7 steps)
 
 **Step 1 — pick an export path.**
 
-The wizard scans `findmnt -t xfs -n -o TARGET` to list existing XFS mounts. The list is prepended with a `Custom path…` option so an operator can export a subdirectory under an existing mount (e.g. `/mnt/data/share1`). Either choice ends up as an absolute path; the wizard rejects anything that doesn't start with `/`.
+The wizard scans `findmnt -t xfs -n -o TARGET` to list existing XFS mounts. The list is prepended with a `Custom path…` option so an operator can export a subdirectory under an existing mount (e.g. `/mnt/data/share1`). Either choice ends up as an absolute path; the wizard rejects anything that doesn't start with `/`. This is the wizard's first step, so its dialogs never render a Back button (`allow_back` is `False` here — there's no earlier step to return to); every step after it does.
 
-**Steps 2–6.** `_access_wizard("Add Share", step_offset=2, total_steps=7)`.
+**Steps 2–6.** `self._access_steps("Add Share", total=7)` — see §4.4. A Back button is available on all five.
 
-**Step 7 — confirmation.** The options list is built deterministically:
+**Step 7 — confirmation.** `allow_back=True`, so the operator can back up from the summary to revise any earlier answer before committing. The options list is built deterministically:
 
 ```
 options = [access, sync_mode, "no_subtree_check", root_squash]
@@ -318,21 +333,22 @@ This is the canonical internal representation. The helper serialises it to the s
 
 On success: `audit.log("nfs.add_export", path, "OK")` + `snapshots.record("share_create", diff_summary=…)` + Show is refreshed.
 
-### 4.5 Edit Share — preserve unknown options
+### 4.6 Edit Share — preserve unknown options
 
-**Step 1.** `nfs.list_exports()` → `SelectDialog` over current paths.
+**Step 1 — select export.** `SelectDialog` over current paths, `selected=answers.get("path")` (so re-entering after Back re-highlights whichever share was already chosen). The step's `run()` only **reseeds** the working answers when the operator picks a **different** path than the one already recorded (`if choice != answers.get("path")`): it looks up the export, calls `_parse_current_export(export)`, stores the snapshot under `answers["_orig"]`, the export's id under `answers["share_id"]`, and copies the five wizard fields (`host`, `access`, `root_squash`, `sync_mode`, `sec`) from that snapshot into `answers`. If the operator backs into this step and re-confirms the **same** path, none of that reseeding happens — any in-flight edits made on the later access steps during this run are left untouched rather than being clobbered back to the share's on-disk values. If the looked-up share has no id, the step shows a "Share not found." dialog and returns `CANCEL`.
 
 **Parse current values.** `_parse_current_export(export)` extracts the five wizard-managed fields and **everything else** (`extra_opts`). Unknown options are anything not in `_WIZARD_MANAGED_OPTS = {"rw", "ro", "root_squash", "no_root_squash", "sync", "async"}` and not a `sec=…` line.
 
-**Steps 2–6.** `_access_wizard(..., current=current)` — every step shows the current value.
+**Steps 2–6.** `self._access_steps("Edit Share", total=7)` — the same shared steps Add uses (§4.4). Because `answers["_orig"]` was seeded in step 1, every prompt shows the `(Current: …)` hint alongside the pre-selected working value.
 
-**Step 7 — confirmation.** The new options list rebuilds the wizard-managed knobs **plus** appends the preserved `extra_opts`:
+**Step 7 — confirmation.** `allow_back=True`. The new options list rebuilds the wizard-managed knobs **plus** appends the preserved `extra_opts` (read from `answers["_orig"]["extra_opts"]`):
 
 ```python
+extra = answers["_orig"]["extra_opts"]
 options = [access, sync_mode, root_squash]
 if sec != "sys":
     options.append(f"sec={sec}")
-options.extend(current["extra_opts"])
+options.extend(extra)
 ```
 
 So if the original export had `insecure,no_wdelay,fsid=0` (the appliance baseline from [Installer/fs-exports-spec.md §2.3](../Installer/fs-exports-spec.md#23-decoding-the-default-options)), those three options survive a wizard run unchanged. Note: `no_subtree_check` is *not* in `_WIZARD_MANAGED_OPTS`, so it counts as an extra and is preserved through edits — but unlike Add, Edit doesn't force-add it.
@@ -341,7 +357,7 @@ So if the original export had `insecure,no_wdelay,fsid=0` (the appliance baselin
 
 On success: `audit.log("nfs.update_export", path, "OK")` + `snapshots.record("share_modify", diff_summary=…)` + Show is refreshed.
 
-### 4.6 Remove Share
+### 4.7 Remove Share
 
 Simple two-prompt flow:
 
@@ -352,13 +368,13 @@ Then `nfs.remove_export(path)`. On success: `audit.log("nfs.remove_export", path
 
 The export's directory on disk is **not** removed. Anything the share was rooted at stays put.
 
-### 4.7 Active Sessions
+### 4.8 Active Sessions
 
 `nfs.list_sessions()` reads `/proc/fs/nfsd/clients/*/info` on the server side, returning a list of `{client_ip, nfs_version, export_path, active_locks}` dicts. The screen prints `client → export_path` per row. The fallback path (when `/proc/fs/nfsd/clients` is empty — older kernels or v3-only servers) parses `/proc/net/rpc/auth.unix.ip`.
 
 Per-export filtering is available via `nfs.get_sessions(path)`, but the screen always asks for the global list. Use the MCP tool surface for per-path queries.
 
-### 4.8 Configure idmapd Domain
+### 4.9 Configure idmapd Domain
 
 The only NFS-screen action that **does not** go through the helper socket. NFSv4 ID mapping (`/etc/idmapd.conf`) is a one-time / rare-edit configuration; rather than adding a `set_idmapd_domain` op to the helper, the screen edits the file directly in an executor:
 
@@ -405,8 +421,8 @@ FilesystemScreen._create_filesystem_wizard()
 ```
 NFSScreen._add_share_wizard()
   ├─ findmnt -t xfs -n -o TARGET                — list candidate paths
-  ├─ SelectDialog (path) or InputDialog (custom)
-  ├─ _access_wizard(...)                        — 5 nested dialogs
+  ├─ run_wizard([path_step] + _access_steps(...) + [confirm_step])
+  │    ├─ path (mount SelectDialog or custom InputDialog; Back-enabled from step 2 on)
   │    ├─ host (Everyone/Network/Single)
   │    ├─ access (rw/ro)
   │    ├─ root_squash (no_root_squash/root_squash)

--- a/docs/Storage/raid-management-spec.md
+++ b/docs/Storage/raid-management-spec.md
@@ -210,20 +210,25 @@ State → icon/colour mapping (from `_state_icon` / `_state_color`):
 
 ## 4. Create Array wizard
 
-`_create_array_wizard()` runs as a Textual `@work(exclusive=True)` async worker so the UI stays responsive. Steps:
+`_create_array_wizard()` runs as a Textual `@work(exclusive=True)` async worker so the UI stays responsive. Like the NFS share wizards ([Storage/fs-shares-management-spec.md §4.3](fs-shares-management-spec.md#43-wizard-navigation-model)), it is built on the generic [xinas_menu/widgets/wizard.py](../../xinas_menu/widgets/wizard.py) driver: a flat list of `WizardStep`s (`name`, `level`, `drives`, `strip`, `group_size`, `spare`, `confirmed`) handed to `run_wizard()`, with `group_size` and `spare` marked conditional via an `applies=` predicate. `run_wizard` computes `allow_back` and `step_no` per step; **every step after the first (`name`) renders a Back button**, and `Back` returns the operator to the previous *applicable* step — skipping `group_size` when the level isn't 50/60, and skipping `spare` when no pools exist — with that step's prior answer pre-filled. Titles are driver-computed `f"Create Array — Step {step_no}"` (no `/N` denominator, unlike the NFS wizards) so a RAID-5 array (no `group_size` step) numbers its steps 1..6 contiguously, with no gap where step 5 would otherwise have been.
 
-### Step 1 — name
+**Disks and pools are fetched up front**, before the wizard's step list is even built — this is what lets the `group_size`/`spare` `applies=` predicates and the drives step see their data on every entry, including after a Back:
+
+1. `_list_api_disks(self.app.control)` (`GET /api/v1/disks`, cross-referenced against the arrays list to exclude already-claimed drives) enumerates NVMe drives. **If zero NVMe drives are available, the wizard aborts immediately with a "No available NVMe drives found." dialog — this check now runs before the name prompt is ever shown**, not after Step 3 as in the pre-Back-navigation flow.
+2. `GET /api/v1/pools` (via `self.app.control.result`) lists spare pools. A failure here is swallowed (`pools = {}`) rather than aborting the wizard — it just means the `spare` step's `applies=lambda a: bool(pools)` predicate stays `False` and the step is skipped.
+
+### Step — name
 
 `InputDialog` with validation:
 
 - 1 ≤ length ≤ 64.
 - Matches `_ARRAY_NAME_RE = ^[a-zA-Z0-9_-]+$`.
 
-A failed validation re-prompts via the `while True:` loop until the user enters a valid name or cancels.
+A failed validation re-prompts via the `while True:` loop until the user enters a valid name or cancels. This is the wizard's first step, so its dialog never renders a Back button.
 
-### Step 2 — RAID level
+### Step — RAID level
 
-`SelectDialog` over `_RAID_LEVELS = ["0", "1", "5", "6", "10", "50", "60"]`. xiRAID Classic accepts all seven; the TUI passes the string through to `RaidCreate.level`.
+`SelectDialog` over `_RAID_LEVELS = ["0", "1", "5", "6", "10", "50", "60"]`, pre-selecting the previously-chosen level on re-entry. xiRAID Classic accepts all seven; the TUI passes the string through to the array-create spec's `level` field.
 
 **Engine-enforced minimum drive counts (finding #20).** xiRAID Classic enforces higher minimums than textbook RAID math, and `xicli raid create --help` does not document the numbers — an under-count is rejected with e.g. `Error: To create RAID level '5', a minimum of '4' disks are required.`:
 
@@ -238,47 +243,52 @@ A failed validation re-prompts via the `while True:` loop until the user enters 
 
 (Minimums per the installer-feedback observations; the RAID-5 value is the engine's own rejection message. They could not be re-probed live here because the engine validates device existence before drive count and no free devices were available.)
 
-The Create wizard does **not** pre-validate drive count against the chosen level — an under-count is caught by the engine only *after* the confirmation step and surfaced through `grpc_short_error` (§4, "Confirmation + dispatch", failure step 4). Pre-checking count-vs-level in Step 3 before dispatch (so the operator gets an immediate, actionable message) is a tracked follow-up.
+The Create wizard does **not** pre-validate drive count against the chosen level — an under-count is caught by the engine only *after* the confirmation step and surfaced as a failure dialog. Pre-checking count-vs-level in the drives step before dispatch (so the operator gets an immediate, actionable message) is a tracked follow-up.
 
-### Step 3 — drives
+Changing the level on a Back visit can flip whether `group_size` applies going forward — e.g. going from `50` back to `5` — in which case the driver prunes the now-inapplicable `group_size` answer and the wizard skips straight past it on the next advance.
 
-`_get_drive_groups()` enumerates NVMe drives via `grpc.disk_list()` (which itself is `lsblk` enriched with RAID membership from `raid_show(extended=True)` — see §5) and bins them by NUMA node and size category. Threshold for "small" vs "large" is `1 GB` (`SMALL_THRESHOLD = 1_000_000_000`). The split is what lets the wizard offer separate "log" (small `n1` namespaces) and "data" (large `n2` namespaces) groups out of the box.
+### Step — drives
 
-The user picks a **drive group**:
+Drive groups are precomputed from the up-front disk fetch and binned by NUMA node and size category. Threshold for "small" vs "large" is `1 GB` (`SMALL_THRESHOLD = 1_000_000_000`). The split is what lets the wizard offer separate "log" (small `n1` namespaces) and "data" (large `n2` namespaces) groups out of the box.
 
-- `All small NVMe, NUMA 0` (etc.) — pre-selected list, opens the `DrivePickerScreen` with `preselected=` so the operator can review.
+**First entry** (no prior `drives` answer in this run): the user picks a **drive group** via a `SelectDialog`:
+
+- `All small NVMe, NUMA 0` (etc.) — opens `DrivePickerScreen` pre-filtered to that group, with `preselected=` set to the whole group so the operator can review/deselect.
 - `Pick individual drives` — opens `DrivePickerScreen` with all unassigned NVMe drives and no preselection.
 
-`DrivePickerScreen` ([widgets/drive_picker.py](../../xinas_menu/widgets/drive_picker.py)) is the full-screen modal: filter by text/NUMA/size, sort by name/size/model/NUMA, multi-select with Space, `a` to select-all-visible, `d` for the detail dialog.
+Backing out of either picker (`allow_back=True` is hardcoded on both, since they're a sub-step of `drives`) returns to the group-select `SelectDialog`, not out of the `drives` step itself; a Back from the group-select is what returns `BACK` to the driver. Picking zero drives shows a "No drives selected." dialog and re-prompts the group select.
+
+**Re-entry** (the operator already completed this step once and has now navigated Back into it from a later step, e.g. `strip`): the group-select `SelectDialog` is **skipped entirely** — the wizard jumps straight to `DrivePickerScreen` over all NVMe drives with the prior selection **pre-checked** (`preselected=prior`), so revising a drive pick doesn't force re-choosing a group.
+
+`DrivePickerScreen` ([widgets/drive_picker.py](../../xinas_menu/widgets/drive_picker.py)) is the full-screen modal: filter by text/NUMA/size, sort by name/size/model/NUMA, multi-select with Space, `a` to select-all-visible, `d` for the detail dialog, and (when `allow_back` is set) `b` for Back — `Esc` always still cancels the whole wizard, never just this step.
 
 Filters that exclude a drive from the picker:
 
-- `system: True` (any OS-mounted partition on it — see `_get_os_drives()` in `grpc_client.py`)
-- `raid_name` set (already a member of some RAID array)
+- `system: True` (any OS-mounted partition on it)
+- already a member of some RAID array, or already assigned to a spare pool
 - `nvme` not in the name (anything that isn't NVMe — the wizard is NVMe-only)
 
-If zero drives are available, the wizard aborts with a "No available NVMe drives found." dialog.
+### Step — strip size
 
-### Step 4 — strip size
+`SelectDialog` over `_STRIP_SIZES = ["16", "32", "64", "128", "256"]` (KB), pre-selecting `"64"` (`selected=answers.get("strip", "64")`) so Enter on first entry still yields the historical default. **`Esc` now cancels the whole wizard**, the same as every other plain-`SelectDialog` step — there is no special-cased "dismiss without choosing silently defaults to 64" behavior anymore; the pre-selection is what makes the common case ("just press Enter") still land on 64.
 
-`SelectDialog` over `_STRIP_SIZES = ["16", "32", "64", "128", "256"]` (KB). Default if the user dismisses without choosing: `64`.
+### Step — group size (RAID 50/60 only, conditional)
 
-### Step 5 — group size (RAID 50/60 only)
+`applies=lambda a: a.get("level") in ("50", "60")`. For levels `50` and `60` the wizard prompts for `group_size` as a positive integer; the validation loop re-prompts on bad input. For any other level this step is skipped in both directions — advancing past `strip` goes straight to `spare`/`confirmed`, and Back from a later step lands on `strip`, not on a hidden `group_size` prompt.
 
-For levels `50` and `60` the wizard prompts for `group_size` as a positive integer. The validation loop re-prompts on bad input.
+### Step — spare pool (conditional on pools existing)
 
-### Step 6 — spare pool
-
-`grpc.pool_show()` lists existing pools. If any exist, a `SelectDialog` offers `(none)` + the sorted pool names. If no pools exist, the step is skipped silently (no spare pool assigned).
+`applies=lambda a: bool(pools)`. If any spare pools exist, a `SelectDialog` offers `(none)` + the sorted pool names, pre-selecting the prior choice on re-entry. If no pools exist at all, the step is skipped silently (no spare pool assigned) — same as before, just expressed as an `applies=` predicate now instead of an inline `if` in a hand-rolled step sequence.
 
 ### Confirmation + dispatch
 
-The summary dialog renders all selections. On confirm:
+The summary dialog (title `"Confirm Create"`, `allow_back=True`) renders all selections, so the operator can Back up from the summary to revise any earlier answer before creating. On confirm:
 
-1. Drive names are normalised to `/dev/<name>` (the picker returns bare names).
-2. `grpc.raid_create(name, level, drives, **kwargs)` is invoked.
+1. The spec is assembled from the collected `answers`: `name`, `level` (as `"raid<N>"`), `member_disk_ids` (drive names mapped to disk ids via the up-front disk fetch), `strip_size_kib`, plus `group_size` and `spare_disk_ids` when applicable.
+2. `POST /api/v1/arrays` is submitted via `self.app.control.plan_apply_wait(...)`, with progress and cancellation surfaced through a `TaskWaitDialog`.
 3. On success: `audit.log("raid.create", "<name> RAID-<level> (<n> drives)", "OK")` + `snapshots.record("raid_create", …)` + Quick Overview is refreshed.
-4. On failure: a `ConfirmDialog` shows `grpc_short_error(err)`.
+4. On cancellation: a "Create cancelled — partial work rolled back." dialog is shown.
+5. On failure: a `ConfirmDialog` shows the create error.
 
 ---
 
@@ -439,16 +449,20 @@ No write operations — no RPCs are sent. The screen is the canonical "what does
 
 ```
 RAIDScreen._create_array_wizard()
-  ├─ InputDialog (name)                 — TUI only
-  ├─ SelectDialog (level)               — TUI only
-  ├─ _get_drive_groups()
-  │    └─ grpc.disk_list()              → lsblk + raid_show(extended=True)
-  │         └─ grpc raid_show RPC       → xRAID daemon → xicli raid show -f json
-  ├─ DrivePickerScreen                  — TUI only
-  ├─ SelectDialog (strip size)          — TUI only
-  ├─ ConfirmDialog (summary)            — TUI only
-  ├─ grpc.raid_create(name, level, drives, strip_size, [sparepool])
-  │    └─ gRPC raid_create RPC          → xRAID daemon → xicli raid create
+  ├─ _list_api_disks(control)           — GET /api/v1/disks (up front; aborts here if no NVMe)
+  ├─ GET /api/v1/pools                  — up front (failure ⇒ spare step just skipped)
+  ├─ run_wizard([name, level, drives, strip, group_size?, spare?, confirmed])
+  │    ├─ InputDialog (name)                 — TUI only, no Back (first step)
+  │    ├─ SelectDialog (level)               — TUI only, Back-enabled
+  │    ├─ drives: SelectDialog (group) → DrivePickerScreen
+  │    │       — first entry only; re-entry after Back jumps straight to
+  │    │         DrivePickerScreen with the prior selection preselected
+  │    ├─ SelectDialog (strip size, pre-selects 64)
+  │    ├─ InputDialog (group size)           — only if level in {50, 60}
+  │    ├─ SelectDialog (spare pool)          — only if pools exist
+  │    └─ ConfirmDialog (summary, Back-enabled)
+  ├─ POST /api/v1/arrays (name, level, member_disk_ids, strip_size_kib, [group_size], [spare_disk_ids])
+  │    └─ plan_apply_wait → control-path API → xiRAID
   ├─ audit.log("raid.create", …, "OK")  — write /var/log/xinas/audit.log
   ├─ snapshots.record("raid_create", …) — xinas_history snapshot
   └─ _show_quick()                      → refresh Quick Overview

--- a/docs/Storage/raid-management-spec.md
+++ b/docs/Storage/raid-management-spec.md
@@ -293,6 +293,8 @@ Steps:
 3. **Per-parameter prompt** — see §5.1.
 4. **Confirm + dispatch.** Value is coerced to the declared `vtype` (`int` for the integer knobs, `str` for the rest). `grpc.raid_modify(name, **{key: value})` is invoked. On success: audit (`raid.modify`) + snapshot (`raid_modify`) + Quick Overview refresh.
 
+Step 1 guards the empty case: if the array listing fails or returns no arrays, the flow aborts on an **OK-only** dialog ("No RAID arrays configured." / "No arrays available."). Delete Array (§6) guards the same way. This is one instance of the screen-wide dialog convention — see §12.
+
 ### 5.1 CPU Affinity dialog (special case)
 
 CPU affinity is the only knob with a multi-mode UI. The current value is read from the array dict (`arr["cpu_allowed"]`, defaulting to `"all"`). Three modes:

--- a/docs/plans/2026-07-03-wizard-back-navigation-design.md
+++ b/docs/plans/2026-07-03-wizard-back-navigation-design.md
@@ -1,0 +1,213 @@
+# Wizard Back navigation — design
+
+**Date:** 2026-07-03
+**Status:** Approved (brainstorming), pending implementation plan
+**Area specs updated by this work:**
+[docs/Storage/fs-shares-management-spec.md](../Storage/fs-shares-management-spec.md) §4.3/§4.4 + Edit,
+[docs/Storage/raid-management-spec.md](../Storage/raid-management-spec.md) §4.
+
+## Problem
+
+The day-2 management wizards in the Textual TUI are strictly forward-only.
+Each step is a blocking `await self.app.push_screen_wait(dialog)` that returns
+a value or `None` (cancel = abort the whole wizard). A user who mis-answers an
+early step — e.g. picks the wrong access mode on "Add Share — Step 3/7" — has
+no way back; they must cancel and restart from step 1. The user asked for a
+**Back button**.
+
+Three wizards are in scope:
+
+| Wizard | Driver | Steps |
+|---|---|---|
+| Add Share | `NFSScreen._add_share_wizard` + shared `_access_wizard` | 7 (path → 5 access → confirm) |
+| Edit Share | `NFSScreen._edit_share` + shared `_access_wizard` | 6 (5 access → confirm) |
+| Create Array | `RAIDScreen._create_array_wizard` (self-contained) | 5–7 (name, level, drives, strip, *group size for RAID 50/60*, *spare pool if pools exist*, confirm) |
+
+The shared `_access_wizard` (the 5 middle access-control steps) is used by both
+NFS wizards, so covering it covers Add and Edit for one effort. The RAID wizard
+is a separate driver with extra complexity: a custom `DrivePickerScreen` modal,
+two conditional steps, and inline validation re-prompt loops.
+
+## Goals
+
+- A **Back** button on every wizard step except the first, in all three wizards.
+- Back returns to the **previous applicable step** with the user's earlier
+  answer **remembered** (pre-selected / pre-filled). Advancing again keeps later
+  answers unless the user changes something.
+- Cancel (Esc) semantics unchanged — still aborts the whole wizard.
+- No regression to the forward path, validation, sub-branches, or dispatch.
+
+## Non-goals
+
+- No Ansible / role behavior change ⇒ **no `Requires-Rebuild:` trailer**
+  (Python-TUI-only change).
+- No change to `TaskWaitDialog`, the post-confirm API dispatch, audit, or
+  snapshot recording.
+- No new Textual pilot test harness — the repo tests TUI logic through headless
+  helpers, and this design keeps to that convention.
+
+## Approach
+
+A **generic wizard driver** plus a small set of dialog changes. Rejected
+alternatives: (2) per-wizard hand-rolled index loops — duplicates back/cancel/
+retain logic three times and forces the shared `_access_wizard` to leak its
+internal index so Back can cross into the path step; (3) Back only *within* each
+sub-section — can't return to step 1, i.e. half the feature.
+
+### New module: `xinas_menu/widgets/wizard.py`
+
+```python
+class _Sentinel:
+    def __init__(self, name): self._name = name
+    def __repr__(self): return self._name
+
+BACK = _Sentinel("BACK")      # step wants the previous step
+CANCEL = _Sentinel("CANCEL")  # step wants to abort the wizard
+
+@dataclass
+class WizardStep:
+    key: str
+    run: Callable[[dict, bool, int], Awaitable[Any]]  # (answers, allow_back, step_no)
+    applies: Callable[[dict], bool] = lambda a: True
+
+async def run_wizard(steps, initial=None) -> dict | None:
+    answers = dict(initial or {})
+    idx = 0
+    while idx < len(steps):
+        step = steps[idx]
+        if not step.applies(answers):
+            idx += 1
+            continue
+        allow_back = _has_prior_applicable(steps, idx, answers)
+        step_no = _display_number(steps, idx, answers)
+        result = await step.run(answers, allow_back, step_no)
+        if result is CANCEL:
+            return None
+        if result is BACK:
+            idx = _prev_applicable(steps, idx, answers)  # stays put at idx 0
+            continue
+        answers[step.key] = result
+        idx += 1
+    return answers
+```
+
+- **Advance:** store `answers[key]`, move to the next index; the loop skips
+  inapplicable steps.
+- **Back:** jump to the previous *applicable* step (skips e.g. group-size when
+  the level isn't 50/60, in both directions).
+- **Cancel:** return `None` (unchanged abort semantics).
+- **`allow_back`** is false on the first applicable step ⇒ that dialog renders
+  no Back button.
+- **`step_no`** is the driver-computed 1-based number among applicable steps,
+  fed into the dialog title so numbering stays correct across conditional steps.
+
+`run_wizard`, `_prev_applicable`, `_display_number`, and
+`_has_prior_applicable` are **pure/headless** — unit-tested with fake steps, no
+Textual app required.
+
+### Dialog changes
+
+Add `allow_back: bool = False` to `SelectDialog`, `InputDialog`,
+`ConfirmDialog`, and `DrivePickerScreen`. When true:
+
+- Render a **Back** button in the button row.
+- Dismiss with the `BACK` sentinel when Back is pressed.
+- `SelectDialog` and `ConfirmDialog` also bind `left` → Back (arrow-left is
+  unused by the vertical `OptionList` and by yes/no confirms). `Esc` stays
+  Cancel everywhere.
+- `InputDialog` and `DrivePickerScreen` keep the button as the primary
+  affordance (their keyboards are busy with typing / multi-select); the button
+  is reachable via Tab-focus.
+
+Return-type widening: the three shared dialogs become
+`ModalScreen[str | _Sentinel | None]` / `ModalScreen[bool | _Sentinel]`. The
+`BACK` sentinel is a distinct object, so it never collides with a real string,
+bool, or `None`.
+
+**State pre-fill:**
+- `SelectDialog` gains `selected: str | None` — pre-highlights / scrolls to the
+  remembered option.
+- `InputDialog.default` and `DrivePickerScreen.preselected` already exist and
+  carry the remembered value.
+
+### Wizard rewrites
+
+**NFS (`nfs.py`).** Extract the 5 shared access steps into
+`_access_steps(prefix, current=None) -> list[WizardStep]` (closures that pre-fill
+from `answers`/`current`). Then:
+
+- `_add_share_wizard`: `steps = [path_step] + _access_steps("Add Share") + [confirm_step]`, then `run_wizard(steps)`.
+- `_edit_share`: `steps = _access_steps("Edit Share", current) + [confirm_step]`, then `run_wizard(steps, initial=current)`.
+
+Cross-boundary Back (access-step-1 → path) now falls out naturally — it is one
+flat step list, no nested loop to unwind.
+
+**RAID (`raid.py`).** `_create_array_wizard` becomes:
+
+```
+steps = [name, level, drives, strip, group_size, spare_pool, confirm]
+group_size.applies  = lambda a: a["level"] in {"50", "60"}
+spare_pool.applies  = lambda a: bool(available_pools)   # captured from the pools query
+```
+
+Titles switch from the current hardcoded/fuzzy strings ("Create Array — Step 5",
+"Create Array — Spare Pool") to driver-computed `Create Array — Step {step_no}`,
+so a RAID-5 array (no group-size step) numbers 1..N contiguously.
+
+**Sub-branches and validation loops stay inside their step closure:**
+- *Path step* (Add Share): `SelectDialog(mounts + ["Custom path…"])`; if custom,
+  an `InputDialog`. Back from the custom input returns to the mount select; Back
+  from the mount select (when `allow_back`) returns `BACK` to the driver. On
+  re-entry, if the stored path matches a mount it's pre-selected, else "Custom
+  path…" is pre-selected and the input pre-filled with the stored path.
+- *Host step* (access wizard): `SelectDialog(Everyone / Specific network /
+  Single host)`; the latter two show a follow-up `InputDialog` for the CIDR/IP.
+  Same internal Back handling and best-effort pre-fill from the stored host
+  (`*` → Everyone; CIDR → Specific network; bare IP → Single host).
+- *Drives step* (RAID): group `SelectDialog` → `DrivePickerScreen`. Back from
+  the picker returns to the group select; Back from the group select returns
+  `BACK` to the driver. Remembered drive list flows back via `preselected=`.
+- *Validation loops* (name, group size): the `while True:` re-prompt stays
+  inside the closure; invalid input re-prompts, Back/Cancel exit the loop by
+  returning the sentinel.
+
+Confirm step gains `allow_back=True` so the user can revise before create.
+
+### State retention semantics
+
+`run_wizard` holds all answers in one dict across back/forward. Changing an
+early answer does **not** auto-invalidate later answers — they keep their prior
+values and are shown pre-filled when revisited. This is safe because every step's
+option set is static (fixed choice lists, or free-form text the user re-confirms);
+the only dynamic inputs (path mount list, drive list, pool list) are queried once
+at wizard start and reused.
+
+## Testing (headless, matching repo convention)
+
+TDD the driver and pure helpers — no Textual pilot:
+
+- `run_wizard` forward accumulation returns the full answers dict.
+- Back retention: answer step 3, Back to step 2, forward again → step 3's stored
+  answer is still present.
+- Back on the first applicable step is impossible (`allow_back` false) — and if a
+  step returns `BACK` at index 0 anyway, the driver stays put (no underflow).
+- Cancel at any step returns `None`.
+- Conditional skip: with `level` not in {50,60}, forward skips group-size and
+  Back from spare-pool lands on strip; toggling `level` to 50 makes it applicable.
+- `_display_number` numbers only applicable steps contiguously.
+- Pure pre-fill/parse helpers (path→mount-vs-custom, host→radio+input) tested
+  directly.
+
+The dialog `allow_back` rendering + `BACK`-on-press is thin Textual glue over the
+above and is left to the same "thin glue, untested" treatment the repo already
+applies to screen workers.
+
+## Files touched
+
+- **New:** `xinas_menu/widgets/wizard.py`, `tests/test_wizard_driver.py`.
+- **Edit:** `xinas_menu/widgets/select_dialog.py`, `input_dialog.py`,
+  `confirm_dialog.py`, `xinas_menu/widgets/drive_picker.py`,
+  `xinas_menu/screens/nfs.py`, `xinas_menu/screens/raid.py`.
+- **Specs:** `docs/Storage/fs-shares-management-spec.md`,
+  `docs/Storage/raid-management-spec.md` (+ short shared "wizard navigation
+  model" note describing `BACK`/`CANCEL` and the driver).

--- a/docs/plans/2026-07-03-wizard-back-navigation-plan.md
+++ b/docs/plans/2026-07-03-wizard-back-navigation-plan.md
@@ -1,0 +1,1474 @@
+# Wizard Back Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a state-preserving **Back** button to the three day-2 management wizards (Add Share, Edit Share, Create Array) in the Textual TUI.
+
+**Architecture:** A new headless `run_wizard` driver runs an ordered list of `WizardStep`s, owning the index, back navigation, and accumulated answers. The four wizard dialogs gain an `allow_back` flag (renders a Back button, dismisses with a distinct `BACK` sentinel) and pre-selection. Each wizard method builds a step list and delegates to the driver; the dispatch (API call, audit, snapshot) runs after the driver returns a confirmed answers dict.
+
+**Tech Stack:** Python 3, Textual (`textual>=0.71`), pytest (async tested via `asyncio.run`).
+
+**Design doc:** [docs/plans/2026-07-03-wizard-back-navigation-design.md](2026-07-03-wizard-back-navigation-design.md)
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `xinas_menu/widgets/wizard.py` | `BACK`/`CANCEL` sentinels, `WizardStep`, `run_wizard`, pure index helpers | **Create** |
+| `tests/test_wizard_driver.py` | Headless driver coverage | **Create** |
+| `xinas_menu/widgets/select_dialog.py` | `allow_back` + `selected` pre-highlight | Modify |
+| `xinas_menu/widgets/input_dialog.py` | `allow_back` | Modify |
+| `xinas_menu/widgets/confirm_dialog.py` | `allow_back` | Modify |
+| `xinas_menu/widgets/drive_picker.py` | `allow_back` | Modify |
+| `tests/test_wizard_dialogs.py` | Constructor smoke tests for the 4 dialogs' `allow_back` | **Create** |
+| `xinas_menu/screens/nfs.py` | `_access_steps`, rewritten `_add_share_wizard`/`_edit_share`, pure prefill helpers | Modify |
+| `tests/test_nfs_wizard_helpers.py` | Pure prefill/parse helper coverage | **Create** |
+| `xinas_menu/screens/raid.py` | Rewritten `_create_array_wizard` | Modify |
+| `docs/Storage/fs-shares-management-spec.md` | Wizard-navigation model + Add/Edit sections | Modify |
+| `docs/Storage/raid-management-spec.md` | Create-array wizard section | Modify |
+
+Convention notes (verified in-repo): async code is tested with `asyncio.run(...)` (no pytest-asyncio); TUI screen workers are thin glue over headless-tested helpers and are **not** pilot-tested — this plan keeps to that, testing the driver and pure helpers headless and treating dialog rendering as glue.
+
+---
+
+## Task 1: Wizard driver module
+
+**Files:**
+- Create: `xinas_menu/widgets/wizard.py`
+- Test: `tests/test_wizard_driver.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_wizard_driver.py
+"""Headless coverage for the generic wizard driver (run_wizard)."""
+
+from __future__ import annotations
+
+import asyncio
+
+from xinas_menu.widgets.wizard import BACK, CANCEL, WizardStep, run_wizard
+
+
+def _script_step(key, script, applies=lambda a: True):
+    """A step whose run() pops the next scripted outcome each time it is entered.
+
+    `script` is a list of outcomes. Each outcome is either a callable
+    `fn(answers, allow_back, step_no) -> value|BACK|CANCEL` or a plain value.
+    Records the (allow_back, step_no) it was called with in `calls`.
+    """
+    calls = []
+    it = iter(script)
+
+    async def run(answers, allow_back, step_no):
+        calls.append((allow_back, step_no))
+        nxt = next(it)
+        return nxt(answers, allow_back, step_no) if callable(nxt) else nxt
+
+    step = WizardStep(key=key, run=run, applies=applies)
+    step.calls = calls  # type: ignore[attr-defined]
+    return step
+
+
+def test_forward_accumulates_all_answers():
+    steps = [
+        _script_step("a", ["A"]),
+        _script_step("b", ["B"]),
+        _script_step("c", ["C"]),
+    ]
+    result = asyncio.run(run_wizard(steps))
+    assert result == {"a": "A", "b": "B", "c": "C"}
+
+
+def test_cancel_returns_none():
+    steps = [_script_step("a", ["A"]), _script_step("b", [CANCEL])]
+    assert asyncio.run(run_wizard(steps)) is None
+
+
+def test_back_retains_earlier_and_later_answers():
+    # a="A", b enters -> BACK, a re-enters -> keeps "A" (prefill visible via answers),
+    # a returns "A2", b returns "B".
+    a = _script_step("a", ["A", "A2"])
+    b = _script_step("b", [BACK, "B"])
+    result = asyncio.run(run_wizard([a, b]))
+    assert result == {"a": "A2", "b": "B"}
+    # a was entered twice, b twice; a saw allow_back False both times (first step).
+    assert a.calls == [(False, 1), (False, 1)]
+    assert b.calls[0] == (True, 2)
+
+
+def test_back_on_first_step_is_noop():
+    # A misbehaving first step that returns BACK must not underflow.
+    a = _script_step("a", [BACK, "A"])
+    b = _script_step("b", ["B"])
+    result = asyncio.run(run_wizard([a, b]))
+    assert result == {"a": "A", "b": "B"}
+
+
+def test_conditional_step_skipped_forward_and_back():
+    # b applies only when a == "yes". With a == "no", forward skips b; Back from
+    # c lands on a, not b.
+    a = _script_step("a", ["no", "no"])
+    b = _script_step("b", ["Bshould", "not", "run"], applies=lambda ans: ans.get("a") == "yes")
+    c = _script_step("c", [BACK, "C"])
+    result = asyncio.run(run_wizard([a, b, c]))
+    assert result == {"a": "no", "c": "C"}
+    assert b.calls == []  # never entered
+    # c enters, backs to a (skipping b), a re-runs, c re-runs.
+    assert a.calls == [(False, 1), (False, 1)]
+
+
+def test_display_number_counts_only_applicable():
+    seen = {}
+
+    def rec(key):
+        def fn(answers, allow_back, step_no):
+            seen[key] = step_no
+            return key.upper()
+        return fn
+
+    a = _script_step("a", [rec("a")])
+    b = _script_step("b", [rec("b")], applies=lambda ans: False)
+    c = _script_step("c", [rec("c")])
+    asyncio.run(run_wizard([a, b, c]))
+    assert seen == {"a": 1, "c": 2}  # b skipped, c numbered 2 not 3
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/sergeyplatonov/Documents/GitHub/xiNAS/.claude/worktrees/wonderful-heyrovsky-f81608 && python -m pytest tests/test_wizard_driver.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'xinas_menu.widgets.wizard'`.
+
+- [ ] **Step 3: Write the driver module**
+
+```python
+# xinas_menu/widgets/wizard.py
+"""Generic back-navigable wizard driver for the Textual management wizards.
+
+A wizard is an ordered list of :class:`WizardStep`. Each step's ``run``
+coroutine drives one logical step (which may internally show more than one
+dialog) and returns the step's answer value, or one of the sentinels
+:data:`BACK` / :data:`CANCEL`.
+
+``run_wizard`` owns the current index, back navigation, and the accumulated
+answers dict. It has no Textual dependency, so it is unit-tested headless with
+fake steps.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class _Sentinel:
+    __slots__ = ("_name",)
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return self._name
+
+
+#: Returned by a step's ``run`` to go back to the previous applicable step.
+BACK = _Sentinel("BACK")
+#: Returned by a step's ``run`` to abort the whole wizard.
+CANCEL = _Sentinel("CANCEL")
+
+#: ``run(answers, allow_back, step_no) -> value | BACK | CANCEL``
+StepRun = Callable[[dict, bool, int], Awaitable[Any]]
+
+
+@dataclass
+class WizardStep:
+    key: str
+    run: StepRun
+    applies: Callable[[dict], bool] = field(default=lambda answers: True)
+
+
+def _applicable(steps: list[WizardStep], answers: dict) -> list[int]:
+    return [i for i, s in enumerate(steps) if s.applies(answers)]
+
+
+def _has_prior_applicable(steps: list[WizardStep], idx: int, answers: dict) -> bool:
+    return any(i < idx for i in _applicable(steps, answers))
+
+
+def _prev_applicable(steps: list[WizardStep], idx: int, answers: dict) -> int:
+    prior = [i for i in _applicable(steps, answers) if i < idx]
+    return prior[-1] if prior else idx  # stay put if nothing earlier applies
+
+
+def _display_number(steps: list[WizardStep], idx: int, answers: dict) -> int:
+    return sum(1 for i in _applicable(steps, answers) if i <= idx)
+
+
+async def run_wizard(steps: list[WizardStep], initial: dict | None = None) -> dict | None:
+    """Drive ``steps`` with Back/Cancel navigation.
+
+    Returns the accumulated answers dict when the user advances past the last
+    step, or ``None`` if any step returns :data:`CANCEL`. ``initial`` seeds the
+    answers dict (used by Edit to pre-fill from the current share).
+    """
+    answers: dict = dict(initial or {})
+    idx = 0
+    while idx < len(steps):
+        step = steps[idx]
+        if not step.applies(answers):
+            idx += 1
+            continue
+        allow_back = _has_prior_applicable(steps, idx, answers)
+        step_no = _display_number(steps, idx, answers)
+        result = await step.run(answers, allow_back, step_no)
+        if result is CANCEL:
+            return None
+        if result is BACK:
+            idx = _prev_applicable(steps, idx, answers)
+            continue
+        answers[step.key] = result
+        idx += 1
+    return answers
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_wizard_driver.py -q`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Lint**
+
+Run: `ruff check xinas_menu/widgets/wizard.py tests/test_wizard_driver.py && ruff format --check xinas_menu/widgets/wizard.py tests/test_wizard_driver.py`
+Expected: no errors (run `ruff format` if the check fails, then re-check).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add xinas_menu/widgets/wizard.py tests/test_wizard_driver.py
+git commit -m "feat(tui): headless wizard driver with Back/Cancel navigation"
+```
+
+---
+
+## Task 2: `allow_back` on the wizard dialogs
+
+Adds a Back button (dismisses with `BACK`) to the four dialogs, plus `selected` pre-highlight on `SelectDialog`. `Esc` stays Cancel. `SelectDialog`/`ConfirmDialog` also bind `left` → Back.
+
+**Files:**
+- Modify: `xinas_menu/widgets/select_dialog.py`, `input_dialog.py`, `confirm_dialog.py`, `xinas_menu/widgets/drive_picker.py`
+- Test: `tests/test_wizard_dialogs.py`
+
+- [ ] **Step 1: Write the failing smoke tests**
+
+```python
+# tests/test_wizard_dialogs.py
+"""Constructor smoke tests: the four wizard dialogs accept allow_back and the
+BACK sentinel is a distinct object (headless — no Textual app mounted)."""
+
+from __future__ import annotations
+
+from xinas_menu.widgets.confirm_dialog import ConfirmDialog
+from xinas_menu.widgets.drive_picker import DrivePickerScreen
+from xinas_menu.widgets.input_dialog import InputDialog
+from xinas_menu.widgets.select_dialog import SelectDialog
+from xinas_menu.widgets.wizard import BACK
+
+
+def test_back_sentinel_is_distinct():
+    assert BACK is not None and BACK is not True and BACK is not False and BACK != ""
+
+
+def test_select_dialog_accepts_allow_back_and_selected():
+    d = SelectDialog(["a", "b"], title="t", prompt="p", selected="b", allow_back=True)
+    assert d._allow_back is True
+    assert d._selected == "b"
+
+
+def test_input_dialog_accepts_allow_back():
+    d = InputDialog("prompt", "title", default="x", allow_back=True)
+    assert d._allow_back is True
+
+
+def test_confirm_dialog_accepts_allow_back():
+    d = ConfirmDialog("msg", "title", allow_back=True)
+    assert d._allow_back is True
+
+
+def test_drive_picker_accepts_allow_back():
+    d = DrivePickerScreen([], title="t", allow_back=True)
+    assert d._allow_back is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_wizard_dialogs.py -q`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'allow_back'`.
+
+- [ ] **Step 3: Modify `select_dialog.py`**
+
+Replace the class body from the `BINDINGS` line through `action_cancel` with:
+
+```python
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel", show=False),
+        Binding("left", "back", "Back", show=False),
+    ]
+
+    def __init__(
+        self,
+        items: list[str],
+        title: str = "Select",
+        prompt: str = "",
+        *,
+        selected: str | None = None,
+        allow_back: bool = False,
+    ) -> None:
+        super().__init__()
+        self._items = items
+        self._title = title
+        self._prompt = prompt
+        self._selected = selected
+        self._allow_back = allow_back
+
+    def compose(self) -> ComposeResult:
+        from textual.containers import Horizontal, Vertical
+
+        with Vertical(id="dialog-container"):
+            yield Label(self._title, id="dialog-title")
+            if self._prompt:
+                yield Label(self._prompt, id="dialog-body")
+            yield OptionList(
+                *[Option(item, id=f"opt-{i}") for i, item in enumerate(self._items)],
+                id="dialog-select",
+            )
+            with Horizontal(id="dialog-buttons"):
+                if self._allow_back:
+                    yield Button("Back [←]", variant="default", id="btn-back")
+                yield Button("Cancel [Esc]", variant="default", id="btn-cancel")
+
+    def on_mount(self) -> None:
+        if self._selected is not None and self._selected in self._items:
+            option_list = self.query_one("#dialog-select", OptionList)
+            option_list.highlighted = self._items.index(self._selected)
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        self.dismiss(str(event.option.prompt))
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-back":
+            self.action_back()
+        else:
+            self.dismiss(None)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def action_back(self) -> None:
+        if self._allow_back:
+            from xinas_menu.widgets.wizard import BACK
+
+            self.dismiss(BACK)
+```
+
+Update the class declaration and imports at the top of the file:
+
+```python
+from textual.widgets import Button, Label, OptionList
+from textual.widgets.option_list import Option
+
+from xinas_menu.widgets.wizard import BACK as _BACK  # noqa: F401  (re-exported for typing)
+
+
+class SelectDialog(ModalScreen["str | object | None"]):
+```
+
+(The `object` in the type parameter covers the `BACK` sentinel. The local
+import inside `action_back` avoids a circular import at module load; the
+top-level `_BACK` alias is only for readers — delete it if ruff flags F401 and
+keep the inline import.)
+
+- [ ] **Step 4: Modify `input_dialog.py`**
+
+```python
+    def __init__(
+        self,
+        prompt: str,
+        title: str = "Input",
+        default: str = "",
+        password: bool = False,
+        placeholder: str = "",
+        *,
+        allow_back: bool = False,
+    ) -> None:
+        super().__init__()
+        self._prompt = prompt
+        self._title = title
+        self._default = default
+        self._password = password
+        self._placeholder = placeholder
+        self._allow_back = allow_back
+
+    def compose(self) -> ComposeResult:
+        from textual.containers import Horizontal, Vertical
+
+        with Vertical(id="dialog-container"):
+            yield Label(self._title, id="dialog-title")
+            yield Label(self._prompt, id="dialog-body")
+            yield Input(
+                value=self._default,
+                placeholder=self._placeholder,
+                password=self._password,
+                id="dialog-input",
+            )
+            with Horizontal(id="dialog-buttons"):
+                yield Button("OK [Enter]", variant="primary", id="btn-ok")
+                if self._allow_back:
+                    yield Button("Back", variant="default", id="btn-back")
+                yield Button("Cancel [Esc]", variant="default", id="btn-cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-ok":
+            inp = self.query_one("#dialog-input", Input)
+            self.dismiss(inp.value)
+        elif event.button.id == "btn-back":
+            self._dismiss_back()
+        else:
+            self.dismiss(None)
+
+    def on_input_submitted(self, _event: Input.Submitted) -> None:
+        inp = self.query_one("#dialog-input", Input)
+        self.dismiss(inp.value)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def _dismiss_back(self) -> None:
+        if self._allow_back:
+            from xinas_menu.widgets.wizard import BACK
+
+            self.dismiss(BACK)
+```
+
+Change the class declaration to `class InputDialog(ModalScreen["str | object | None"]):`.
+
+- [ ] **Step 5: Modify `confirm_dialog.py`**
+
+Add to `BINDINGS`: `Binding("left", "back", "Back", show=False),`. Add `allow_back: bool = False` as a keyword-only param in `__init__` and store `self._allow_back = allow_back`. In `compose`, inside the `dialog-buttons` `Horizontal`, before the Yes/No/OK buttons add:
+
+```python
+                if self._allow_back:
+                    yield Button("Back [←]", variant="default", id="btn-back", classes="dialog-btn")
+```
+
+In `on_button_pressed`, handle Back first:
+
+```python
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-back":
+            self.action_back()
+        elif event.button.id == "btn-ok":
+            self.dismiss(True)
+        else:
+            self.dismiss(event.button.id == "btn-yes")
+```
+
+Add the action:
+
+```python
+    def action_back(self) -> None:
+        if self._allow_back:
+            from xinas_menu.widgets.wizard import BACK
+
+            self.dismiss(BACK)
+```
+
+Change the class declaration to `class ConfirmDialog(ModalScreen["bool | object"]):`.
+
+- [ ] **Step 6: Modify `drive_picker.py`**
+
+Add `allow_back: bool = False` as a keyword-only param to `__init__` and store `self._allow_back = allow_back`. Add to `BINDINGS`: `Binding("b", "back", "Back", show=True),`. In `compose`, inside `#picker-buttons`, before the Cancel button add:
+
+```python
+                if self._allow_back:
+                    yield Button("Back [b]", variant="default", id="btn-back")
+```
+
+Add the action and Back handling in `on_button_pressed`:
+
+```python
+    def action_back(self) -> None:
+        if self._allow_back:
+            from xinas_menu.widgets.wizard import BACK
+
+            self.dismiss(BACK)
+```
+
+In `on_button_pressed`, add a branch `if event.button.id == "btn-back": self.action_back(); return` before the existing OK/Cancel handling. Change the class declaration to `class DrivePickerScreen(ModalScreen["list[str] | object | None"]):`.
+
+- [ ] **Step 7: Run smoke tests**
+
+Run: `python -m pytest tests/test_wizard_dialogs.py -q`
+Expected: PASS (6 passed).
+
+- [ ] **Step 8: Lint**
+
+Run: `ruff check xinas_menu/widgets/ tests/test_wizard_dialogs.py && ruff format --check xinas_menu/widgets/`
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add xinas_menu/widgets/select_dialog.py xinas_menu/widgets/input_dialog.py \
+        xinas_menu/widgets/confirm_dialog.py xinas_menu/widgets/drive_picker.py \
+        tests/test_wizard_dialogs.py
+git commit -m "feat(tui): allow_back + pre-selection on wizard dialogs"
+```
+
+---
+
+## Task 3: NFS pure prefill/parse helpers
+
+Extract the "which radio + input default" logic for the host step and the "mount vs custom" logic for the path step into pure module-level functions so they are headless-testable and reused by the step closures.
+
+**Files:**
+- Modify: `xinas_menu/screens/nfs.py` (add module-level helpers near the other module functions)
+- Test: `tests/test_nfs_wizard_helpers.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_nfs_wizard_helpers.py
+"""Pure prefill helpers for the NFS share wizard."""
+
+from __future__ import annotations
+
+from xinas_menu.screens.nfs import _host_prefill, _path_prefill
+
+_HOST_CHOICES = [
+    "Everyone (any host on the network)",
+    "Specific network (e.g., 192.168.1.0/24)",
+    "Single host (by IP address)",
+]
+
+
+def test_host_prefill_everyone():
+    sel, hint = _host_prefill("*")
+    assert sel == _HOST_CHOICES[0]
+    assert hint == "Everyone"
+
+
+def test_host_prefill_network():
+    sel, hint = _host_prefill("192.168.1.0/24")
+    assert sel == _HOST_CHOICES[1]
+    assert hint == "Network 192.168.1.0/24"
+
+
+def test_host_prefill_single():
+    sel, hint = _host_prefill("10.0.0.5")
+    assert sel == _HOST_CHOICES[2]
+    assert hint == "Host 10.0.0.5"
+
+
+def test_path_prefill_matches_mount():
+    sel, default = _path_prefill("/mnt/data", ["/mnt/data", "/mnt/log"])
+    assert sel == "/mnt/data"
+    assert default == "/mnt/data/"  # custom default is unused when a mount matches
+
+
+def test_path_prefill_custom_when_no_match():
+    sel, default = _path_prefill("/mnt/data/share1", ["/mnt/data"])
+    assert sel == "Custom path…"
+    assert default == "/mnt/data/share1"
+
+
+def test_path_prefill_empty():
+    sel, default = _path_prefill("", ["/mnt/data"])
+    assert sel is None
+    assert default == "/mnt/data/"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_nfs_wizard_helpers.py -q`
+Expected: FAIL — `ImportError: cannot import name '_host_prefill'`.
+
+- [ ] **Step 3: Add the helpers to `nfs.py`**
+
+Add near the top-level helper functions (e.g. just below the imports block, before `class NFSScreen`). Also define the shared choice list constants there:
+
+```python
+_HOST_CHOICES = [
+    "Everyone (any host on the network)",
+    "Specific network (e.g., 192.168.1.0/24)",
+    "Single host (by IP address)",
+]
+_CUSTOM_PATH = "Custom path…"
+
+
+def _host_prefill(host: str) -> tuple[str, str]:
+    """Map a stored export host to (selected radio label, "(Current:)" hint)."""
+    if host == "*":
+        return _HOST_CHOICES[0], "Everyone"
+    if "/" in host:
+        return _HOST_CHOICES[1], f"Network {host}"
+    return _HOST_CHOICES[2], f"Host {host}"
+
+
+def _path_prefill(stored: str, mount_points: list[str]) -> tuple[str | None, str]:
+    """Map a stored path to (SelectDialog pre-selection, custom-input default).
+
+    Returns ``(mount, "/mnt/data/")`` when *stored* is one of *mount_points*,
+    ``("Custom path…", stored)`` when it is a non-empty non-mount path, and
+    ``(None, "/mnt/data/")`` when *stored* is empty (first entry).
+    """
+    if not stored:
+        return None, "/mnt/data/"
+    if stored in mount_points:
+        return stored, "/mnt/data/"
+    return _CUSTOM_PATH, stored
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_nfs_wizard_helpers.py -q`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add xinas_menu/screens/nfs.py tests/test_nfs_wizard_helpers.py
+git commit -m "refactor(tui): extract pure NFS wizard prefill helpers"
+```
+
+---
+
+## Task 4: Rewrite the NFS wizards on the driver
+
+Replace `_access_wizard` with `_access_steps` (returns 5 `WizardStep`s) and rewrite `_add_share_wizard`/`_edit_share` to assemble a step list, call `run_wizard`, then dispatch. Behavior parity plus: Back navigation, remembered answers, and an empty host sub-input now returns to the host select instead of aborting.
+
+**Files:**
+- Modify: `xinas_menu/screens/nfs.py:118-544` (replace `_access_wizard`, `_add_share_wizard`, `_edit_share`)
+
+- [ ] **Step 1: Add the wizard import**
+
+At the top of `nfs.py`, with the other `xinas_menu.widgets` imports, add:
+
+```python
+from xinas_menu.widgets.wizard import BACK, CANCEL, WizardStep, run_wizard
+```
+
+- [ ] **Step 2: Replace `_access_wizard` (lines 120-297) with `_access_steps`**
+
+```python
+    # ── Shared access-control steps (host / perms / admin / sync / security) ──
+
+    def _access_steps(self, prefix: str, total: int) -> list[WizardStep]:
+        """Build the 5 shared access-control steps.
+
+        Each step reads its working value from ``answers`` (retained across
+        Back) and, when ``answers`` carries an ``_orig`` snapshot (Edit),
+        annotates the prompt with the share's original value.
+        """
+
+        def title(step_no: int) -> str:
+            return f"{prefix} — Step {step_no}/{total}"
+
+        def orig(answers: dict) -> dict | None:
+            return answers.get("_orig")
+
+        async def host_step(answers, allow_back, step_no):
+            while True:
+                cur_host = answers.get("host", "*")
+                selected, _ = _host_prefill(cur_host)
+                prompt = "Who should be able to connect?"
+                o = orig(answers)
+                if o is not None:
+                    _, hint = _host_prefill(o.get("host", "*"))
+                    prompt += f"\n(Current: {hint})"
+                who = await self.app.push_screen_wait(
+                    SelectDialog(
+                        _HOST_CHOICES,
+                        title=title(step_no),
+                        prompt=prompt,
+                        selected=selected,
+                        allow_back=allow_back,
+                    )
+                )
+                if who is None:
+                    return CANCEL
+                if who is BACK:
+                    return BACK
+                if who.startswith("Everyone"):
+                    return "*"
+                if who.startswith("Specific"):
+                    default = cur_host if "/" in cur_host else "192.168.1.0/24"
+                    sub = await self.app.push_screen_wait(
+                        InputDialog(
+                            "Network address:",
+                            title(step_no),
+                            default=default,
+                            placeholder="192.168.1.0/24",
+                            allow_back=True,
+                        )
+                    )
+                else:
+                    default = cur_host if (cur_host != "*" and "/" not in cur_host) else ""
+                    sub = await self.app.push_screen_wait(
+                        InputDialog(
+                            "Host IP address:",
+                            title(step_no),
+                            default=default,
+                            placeholder="192.168.1.100",
+                            allow_back=True,
+                        )
+                    )
+                if sub is None:
+                    return CANCEL
+                if sub is BACK or not sub:
+                    continue  # back to (or empty at) the who-select
+                return sub
+
+        access_choices = [
+            "Read & Write (can add, edit, delete files)",
+            "Read Only (can only view files)",
+        ]
+        admin_choices = [
+            "Yes - Full admin access (recommended)",
+            "No - Limited access (more secure)",
+        ]
+        sync_choices = [
+            "Sync - confirm after writing to disk (safer, recommended)",
+            "Async - confirm immediately (faster, risk of data loss on crash)",
+        ]
+        sec_choices = [
+            "Standard UID/GID (default)",
+            "Kerberos authentication",
+            "Kerberos + integrity",
+            "Kerberos + encryption",
+        ]
+        _SEC_MAP = {
+            "Standard": "sys",
+            "Kerberos authentication": "krb5",
+            "Kerberos + integrity": "krb5i",
+            "Kerberos + encryption": "krb5p",
+        }
+        _SEC_LABELS = {
+            "sys": "Standard UID/GID",
+            "krb5": "Kerberos",
+            "krb5i": "Kerberos + integrity",
+            "krb5p": "Kerberos + encryption",
+        }
+
+        def _sec_value(choice: str) -> str:
+            for key, val in _SEC_MAP.items():
+                if choice.startswith(key):
+                    return val
+            return "sys"
+
+        steps: list[WizardStep] = [WizardStep(key="host", run=host_step)]
+
+        async def access_run_fn(answers, allow_back, step_no):
+            cur = answers.get("access", "rw")
+            selected = access_choices[0] if cur == "rw" else access_choices[1]
+            prompt = "What can connected hosts do?"
+            o = orig(answers)
+            if o is not None:
+                prompt += "\n(Current: %s)" % (
+                    "Read & Write" if o.get("access") == "rw" else "Read Only"
+                )
+            pick = await self.app.push_screen_wait(
+                SelectDialog(access_choices, title=title(step_no), prompt=prompt,
+                             selected=selected, allow_back=allow_back)
+            )
+            if pick is None:
+                return CANCEL
+            if pick is BACK:
+                return BACK
+            return "rw" if pick.startswith("Read & Write") else "ro"
+
+        async def admin_run_fn(answers, allow_back, step_no):
+            cur = answers.get("root_squash", "no_root_squash")
+            selected = admin_choices[0] if cur == "no_root_squash" else admin_choices[1]
+            prompt = "Allow full administrator access?"
+            o = orig(answers)
+            if o is not None:
+                prompt += "\n(Current: %s)" % (
+                    "Yes" if o.get("root_squash") == "no_root_squash" else "No"
+                )
+            pick = await self.app.push_screen_wait(
+                SelectDialog(admin_choices, title=title(step_no), prompt=prompt,
+                             selected=selected, allow_back=allow_back)
+            )
+            if pick is None:
+                return CANCEL
+            if pick is BACK:
+                return BACK
+            return "no_root_squash" if pick.startswith("Yes") else "root_squash"
+
+        async def sync_run_fn(answers, allow_back, step_no):
+            cur = answers.get("sync_mode", "sync")
+            selected = sync_choices[0] if cur == "sync" else sync_choices[1]
+            prompt = "When should the server confirm writes?"
+            o = orig(answers)
+            if o is not None:
+                prompt += "\n(Current: %s)" % (
+                    "Sync (safer)" if o.get("sync_mode") == "sync" else "Async (faster)"
+                )
+            pick = await self.app.push_screen_wait(
+                SelectDialog(sync_choices, title=title(step_no), prompt=prompt,
+                             selected=selected, allow_back=allow_back)
+            )
+            if pick is None:
+                return CANCEL
+            if pick is BACK:
+                return BACK
+            return "sync" if pick.startswith("Sync") else "async"
+
+        async def sec_run_fn(answers, allow_back, step_no):
+            cur = answers.get("sec", "sys")
+            selected = next((c for c in sec_choices if _sec_value(c) == cur), sec_choices[0])
+            prompt = "Select authentication mode:"
+            o = orig(answers)
+            if o is not None:
+                prompt += f"\n(Current: {_SEC_LABELS.get(o.get('sec'), o.get('sec'))})"
+            pick = await self.app.push_screen_wait(
+                SelectDialog(sec_choices, title=title(step_no), prompt=prompt,
+                             selected=selected, allow_back=allow_back)
+            )
+            if pick is None:
+                return CANCEL
+            if pick is BACK:
+                return BACK
+            return _sec_value(pick)
+
+        steps.append(WizardStep(key="access", run=access_run_fn))
+        steps.append(WizardStep(key="root_squash", run=admin_run_fn))
+        steps.append(WizardStep(key="sync_mode", run=sync_run_fn))
+        steps.append(WizardStep(key="sec", run=sec_run_fn))
+        return steps
+```
+
+- [ ] **Step 3: Rewrite `_add_share_wizard`**
+
+```python
+    @work(exclusive=True)
+    async def _add_share_wizard(self) -> None:
+        """7-step share creation wizard with Back navigation."""
+        from xinas_menu.utils.xfs_helpers import run_async_cmd
+
+        mount_points: list[str] = []
+        ok, out, _ = await run_async_cmd("findmnt", "-t", "xfs", "-n", "-o", "TARGET", timeout=10)
+        if ok and out:
+            mount_points = [line.strip() for line in out.splitlines() if line.strip()]
+
+        async def path_step(answers, allow_back, step_no):
+            stored = answers.get("path", "")
+            title = f"Add Share — Step {step_no}/7"
+            while True:
+                if mount_points:
+                    selected, custom_default = _path_prefill(stored, mount_points)
+                    choice = await self.app.push_screen_wait(
+                        SelectDialog(
+                            mount_points + [_CUSTOM_PATH],
+                            title=title,
+                            prompt="Select filesystem to export (or choose custom for a subfolder):",
+                            selected=selected,
+                            allow_back=allow_back,
+                        )
+                    )
+                    if choice is None:
+                        return CANCEL
+                    if choice is BACK:
+                        return BACK
+                    if choice == _CUSTOM_PATH:
+                        sub = await self.app.push_screen_wait(
+                            InputDialog(
+                                "Export path:",
+                                title,
+                                default=custom_default,
+                                placeholder="/mnt/data/share1",
+                                allow_back=True,
+                            )
+                        )
+                        if sub is None:
+                            return CANCEL
+                        if sub is BACK:
+                            continue
+                        path = sub
+                    else:
+                        path = choice
+                else:
+                    sub = await self.app.push_screen_wait(
+                        InputDialog(
+                            "Export path:",
+                            title,
+                            default=stored or "/mnt/data/",
+                            placeholder="/mnt/data/share1",
+                            allow_back=allow_back,
+                        )
+                    )
+                    if sub is None:
+                        return CANCEL
+                    if sub is BACK:
+                        return BACK
+                    path = sub
+                if not path.startswith("/"):
+                    self.app.notify("Export path must start with '/'.", severity="error")
+                    continue
+                return path.rstrip("/") or "/"
+
+        async def confirm_step(answers, allow_back, step_no):
+            host = answers["host"]
+            access = answers["access"]
+            root_squash = answers["root_squash"]
+            sync_mode = answers["sync_mode"]
+            sec = answers["sec"]
+            options = [access, sync_mode, "no_subtree_check", root_squash]
+            if sec != "sys":
+                options.append(f"sec={sec}")
+            summary = _share_summary(answers["path"], host, access, root_squash, sync_mode, sec, options)
+            result = await self.app.push_screen_wait(
+                ConfirmDialog(
+                    f"Create this export?\n\n{summary}",
+                    f"Add Share — Step {step_no}/7",
+                    allow_back=allow_back,
+                )
+            )
+            if result is BACK:
+                return BACK
+            return True if result is True else CANCEL
+
+        steps = (
+            [WizardStep(key="path", run=path_step)]
+            + self._access_steps("Add Share", total=7)
+            + [WizardStep(key="confirmed", run=confirm_step)]
+        )
+        answers = await run_wizard(steps)
+        if answers is None:
+            return
+
+        path = answers["path"]
+        host = answers["host"]
+        access = answers["access"]
+        root_squash = answers["root_squash"]
+        sync_mode = answers["sync_mode"]
+        sec = answers["sec"]
+
+        loop = asyncio.get_running_loop()
+        try:
+            await loop.run_in_executor(None, lambda: os.makedirs(path, exist_ok=True))
+        except OSError as exc:
+            await self.app.push_screen_wait(ConfirmDialog(f"Cannot create directory:\n{exc}", "Error"))
+            return
+
+        used: set[int] = set()
+        for row in await self._get_exports():
+            fsid = row.get("fsid")
+            if isinstance(fsid, int):
+                used.add(fsid)
+            elif isinstance(fsid, str) and fsid.strip().lstrip("-").isdigit():
+                used.add(int(fsid))
+        spec: dict[str, Any] = {
+            "path": path,
+            "fsid": max(used, default=0) + 1,
+            "clients": [{"pattern": host, "options": [access, root_squash, "no_subtree_check"]}],
+            "sync": sync_mode,
+        }
+        if sec != "sys":
+            spec["security_mode"] = sec
+        try:
+            await asyncio.to_thread(
+                self.app.control.plan_apply_wait,
+                "POST",
+                "/api/v1/shares",
+                spec,
+                on_progress=self._task_progress("Add Share"),
+            )
+        except ControlPathError as exc:
+            await self.app.push_screen_wait(ConfirmDialog(f"Failed: {exc}", "Error"))
+            return
+        self.app.audit.log("nfs.add_export", path, "OK")
+        await self.app.snapshots.record("share_create", diff_summary=f"Added NFS share {path}")
+        self._load_exports()
+```
+
+- [ ] **Step 4: Add the shared summary helper near the module helpers**
+
+```python
+def _share_summary(path, host, access, root_squash, sync_mode, sec, options) -> str:
+    access_label = "Read & Write" if access == "rw" else "Read Only"
+    admin_label = "Yes (no_root_squash)" if root_squash == "no_root_squash" else "No (root_squash)"
+    sync_label = "Sync (safer)" if sync_mode == "sync" else "Async (faster)"
+    sec_labels = {
+        "sys": "Standard UID/GID",
+        "krb5": "Kerberos",
+        "krb5i": "Kerberos + integrity",
+        "krb5p": "Kerberos + encryption",
+    }
+    return (
+        f"Path:       {path}\n"
+        f"Access:     {host}\n"
+        f"Permission: {access_label}\n"
+        f"Admin:      {admin_label}\n"
+        f"Sync:       {sync_label}\n"
+        f"Security:   {sec_labels.get(sec, sec)}\n"
+        f"Options:    {','.join(options)}"
+    )
+```
+
+- [ ] **Step 5: Rewrite `_edit_share`**
+
+```python
+    @work(exclusive=True)
+    async def _edit_share(self) -> None:
+        """7-step edit share wizard with Back navigation."""
+        exports = await self._get_exports()
+        if not exports:
+            await self.app.push_screen_wait(ConfirmDialog("No shares configured.", "Edit Share"))
+            return
+        paths = [e["path"] for e in exports]
+
+        async def select_step(answers, allow_back, step_no):
+            choice = await self.app.push_screen_wait(
+                SelectDialog(
+                    paths,
+                    title=f"Edit Share — Step {step_no}/7",
+                    prompt="Select export to edit:",
+                    selected=answers.get("path"),
+                    allow_back=allow_back,
+                )
+            )
+            if choice is None:
+                return CANCEL
+            if choice is BACK:
+                return BACK
+            if choice != answers.get("path"):
+                export = next((e for e in exports if e["path"] == choice), {})
+                share_id = str(export.get("id", ""))
+                if not share_id:
+                    await self.app.push_screen_wait(ConfirmDialog("Share not found.", "Edit Share"))
+                    return CANCEL
+                current = _parse_current_export(export)
+                answers["_orig"] = current
+                answers["share_id"] = share_id
+                for k in ("host", "access", "root_squash", "sync_mode", "sec"):
+                    answers[k] = current[k]
+            return choice
+
+        async def confirm_step(answers, allow_back, step_no):
+            host = answers["host"]
+            access = answers["access"]
+            root_squash = answers["root_squash"]
+            sync_mode = answers["sync_mode"]
+            sec = answers["sec"]
+            extra = answers["_orig"]["extra_opts"]
+            options = [access, sync_mode, root_squash]
+            if sec != "sys":
+                options.append(f"sec={sec}")
+            options.extend(extra)
+            summary = _share_summary(answers["path"], host, access, root_squash, sync_mode, sec, options)
+            result = await self.app.push_screen_wait(
+                ConfirmDialog(
+                    f"Update this export?\n\n{summary}",
+                    f"Edit Share — Step {step_no}/7",
+                    allow_back=allow_back,
+                )
+            )
+            if result is BACK:
+                return BACK
+            return True if result is True else CANCEL
+
+        steps = (
+            [WizardStep(key="path", run=select_step)]
+            + self._access_steps("Edit Share", total=7)
+            + [WizardStep(key="confirmed", run=confirm_step)]
+        )
+        answers = await run_wizard(steps)
+        if answers is None:
+            return
+
+        host = answers["host"]
+        access = answers["access"]
+        root_squash = answers["root_squash"]
+        sync_mode = answers["sync_mode"]
+        sec = answers["sec"]
+        share_id = answers["share_id"]
+        extra = answers["_orig"]["extra_opts"]
+
+        patch: dict[str, Any] = {
+            "clients": [{"pattern": host, "options": [access, root_squash, *extra]}],
+            "sync": sync_mode,
+            "security_mode": sec,
+        }
+        try:
+            await asyncio.to_thread(
+                self.app.control.plan_apply_wait,
+                "PATCH",
+                f"/api/v1/shares/{share_id}",
+                patch,
+                on_progress=self._task_progress("Edit Share"),
+            )
+        except ControlPathError as exc:
+            await self.app.push_screen_wait(ConfirmDialog(f"Failed: {exc}", "Error"))
+            return
+        self.app.audit.log("nfs.update_export", answers["path"], "OK")
+        await self.app.snapshots.record("share_modify", diff_summary=f"Updated NFS share {answers['path']}")
+        self._load_exports()
+```
+
+- [ ] **Step 6: Run the full suite + lint**
+
+Run: `python -m pytest tests/ -q && ruff check xinas_menu/screens/nfs.py && ruff format --check xinas_menu/screens/nfs.py`
+Expected: all pass; no lint errors. (Existing tests `test_render_nfs_profile.py` must still pass.)
+
+- [ ] **Step 7: Manual smoke (headless import)**
+
+Run: `python -c "import xinas_menu.screens.nfs"`
+Expected: no error (guards against a syntax/NameError in the rewrite).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add xinas_menu/screens/nfs.py
+git commit -m "feat(tui): Back navigation for Add/Edit Share wizards"
+```
+
+---
+
+## Task 5: Rewrite the Create Array wizard on the driver
+
+Rewrite `_create_array_wizard` to fetch disks/pools up front, build a step list (with `applies` predicates for group-size and spare-pool), call `run_wizard`, then assemble the spec and dispatch. RAID titles switch to driver-computed `Create Array — Step N`. Two benign, documented behavior changes: the "no NVMe drives" check now runs before the name prompt, and `Esc` on the strip step cancels (as every other step) instead of silently defaulting to 64 — the strip dialog pre-selects `64` so Enter still yields 64.
+
+**Files:**
+- Modify: `xinas_menu/screens/raid.py:396-609` (`_create_array_wizard`) and imports.
+
+- [ ] **Step 1: Add the wizard import**
+
+With the other `xinas_menu.widgets` imports in `raid.py`:
+
+```python
+from xinas_menu.widgets.wizard import BACK, CANCEL, WizardStep, run_wizard
+```
+
+- [ ] **Step 2: Replace `_create_array_wizard` (lines 396-609)**
+
+```python
+    @work(exclusive=True)
+    async def _create_array_wizard(self) -> None:
+        """Create-array wizard with Back navigation."""
+        # Fetch disks up front so the drive + spare steps and their applies()
+        # predicates have their data; fail fast if there are no NVMe drives.
+        try:
+            disk_rows = await _list_api_disks(self.app.control)
+        except ControlPathError as exc:
+            await self.app.push_screen_wait(ConfirmDialog(f"Could not list disks.\n{exc}", "Error"))
+            return
+        groups, nvme = _drive_groups(disk_rows)
+        if not nvme:
+            await self.app.push_screen_wait(ConfirmDialog("No available NVMe drives found.", "Error"))
+            return
+        name_to_id = {d["name"]: d["id"] for d in nvme}
+
+        _NONE_POOL = "(none)"
+        try:
+            p_rows = await asyncio.to_thread(self.app.control.result, "/api/v1/pools")
+        except ControlPathError:
+            p_rows = []
+        pools = _pools_by_name(p_rows)
+
+        async def name_step(answers, allow_back, step_no):
+            default = answers.get("name", "")
+            while True:
+                name = await self.app.push_screen_wait(
+                    InputDialog(
+                        "Array name:",
+                        f"Create Array — Step {step_no}",
+                        default=default,
+                        placeholder="data0",
+                        allow_back=allow_back,
+                    )
+                )
+                if name is None:
+                    return CANCEL
+                if name is BACK:
+                    return BACK
+                if len(name) > 64:
+                    self.app.notify("Array name must be 64 characters or fewer.", severity="error")
+                    default = name
+                    continue
+                if not _ARRAY_NAME_RE.match(name):
+                    self.app.notify(
+                        "Array name must contain only letters, digits, hyphens, and underscores.",
+                        severity="error",
+                    )
+                    default = name
+                    continue
+                return name
+
+        async def level_step(answers, allow_back, step_no):
+            pick = await self.app.push_screen_wait(
+                SelectDialog(
+                    _RAID_LEVELS,
+                    title=f"Create Array — Step {step_no}",
+                    prompt="Select RAID level:",
+                    selected=answers.get("level"),
+                    allow_back=allow_back,
+                )
+            )
+            if pick is None:
+                return CANCEL
+            if pick is BACK:
+                return BACK
+            return pick
+
+        async def drives_step(answers, allow_back, step_no):
+            prior = answers.get("drives")
+            if prior:
+                # Re-entry: jump straight to the picker with the prior selection.
+                selected = await self.app.push_screen_wait(
+                    DrivePickerScreen(
+                        nvme, title="Create Array — Select Drives",
+                        preselected=prior, allow_back=allow_back,
+                    )
+                )
+                if selected is None:
+                    return CANCEL
+                if selected is BACK:
+                    return BACK
+                return selected
+            while True:
+                choices = list(groups.keys()) + ["Pick individual drives"]
+                group_choice = await self.app.push_screen_wait(
+                    SelectDialog(
+                        choices, title=f"Create Array — Step {step_no}",
+                        prompt="Select drive group:", allow_back=allow_back,
+                    )
+                )
+                if group_choice is None:
+                    return CANCEL
+                if group_choice is BACK:
+                    return BACK
+                if group_choice == "Pick individual drives":
+                    selected = await self.app.push_screen_wait(
+                        DrivePickerScreen(nvme, title="Create Array — Select Drives", allow_back=True)
+                    )
+                else:
+                    group_drives = groups.get(group_choice, [])
+                    group_names = {d if isinstance(d, str) else d.get("name", "") for d in group_drives}
+                    group_drive_info: list[dict[str, Any]] = [
+                        d for d in nvme if d.get("name") in group_names
+                    ] or group_drives  # pyright: ignore[reportAssignmentType]
+                    selected = await self.app.push_screen_wait(
+                        DrivePickerScreen(
+                            group_drive_info, title=f"Review — {group_choice}",
+                            preselected=group_names, allow_back=True,
+                        )
+                    )
+                if selected is None:
+                    return CANCEL
+                if selected is BACK:
+                    continue  # back to the group select
+                if not selected:
+                    await self.app.push_screen_wait(ConfirmDialog("No drives selected.", "Error"))
+                    continue
+                return selected
+
+        async def strip_step(answers, allow_back, step_no):
+            pick = await self.app.push_screen_wait(
+                SelectDialog(
+                    _STRIP_SIZES,
+                    title=f"Create Array — Step {step_no}",
+                    prompt="Strip size (KB), default 64:",
+                    selected=answers.get("strip", "64"),
+                    allow_back=allow_back,
+                )
+            )
+            if pick is None:
+                return CANCEL
+            if pick is BACK:
+                return BACK
+            return pick
+
+        async def group_size_step(answers, allow_back, step_no):
+            default = str(answers.get("group_size", ""))
+            while True:
+                value = await self.app.push_screen_wait(
+                    InputDialog(
+                        "Group size (required for RAID 50/60):",
+                        f"Create Array — Step {step_no}",
+                        default=default,
+                        placeholder="4",
+                        allow_back=allow_back,
+                    )
+                )
+                if value is None:
+                    return CANCEL
+                if value is BACK:
+                    return BACK
+                try:
+                    gs = int(value)
+                    if gs <= 0:
+                        raise ValueError
+                except ValueError:
+                    self.app.notify("Group size must be a positive integer.", severity="error")
+                    default = value
+                    continue
+                return gs
+
+        async def spare_step(answers, allow_back, step_no):
+            pool_choices = [_NONE_POOL] + sorted(pools.keys())
+            pick = await self.app.push_screen_wait(
+                SelectDialog(
+                    pool_choices,
+                    title=f"Create Array — Step {step_no}",
+                    prompt="Select spare pool (or none):",
+                    selected=answers.get("spare", _NONE_POOL),
+                    allow_back=allow_back,
+                )
+            )
+            if pick is None:
+                return CANCEL
+            if pick is BACK:
+                return BACK
+            return pick
+
+        async def confirm_step(answers, allow_back, step_no):
+            summary = (
+                f"Name:       {answers['name']}\n"
+                f"Level:      RAID-{answers['level']}\n"
+                f"Drives:     {', '.join(answers['drives'])}\n"
+                f"Strip Size: {answers['strip']} KB"
+            )
+            if answers["level"] in ("50", "60"):
+                summary += f"\nGroup Size: {answers.get('group_size')}"
+            spare = answers.get("spare", _NONE_POOL)
+            if spare != _NONE_POOL:
+                summary += f"\nSpare Pool: {spare}"
+            result = await self.app.push_screen_wait(
+                ConfirmDialog(f"Create this RAID array?\n\n{summary}", "Confirm Create", allow_back=allow_back)
+            )
+            if result is BACK:
+                return BACK
+            return True if result is True else CANCEL
+
+        steps = [
+            WizardStep(key="name", run=name_step),
+            WizardStep(key="level", run=level_step),
+            WizardStep(key="drives", run=drives_step),
+            WizardStep(key="strip", run=strip_step),
+            WizardStep(
+                key="group_size", run=group_size_step,
+                applies=lambda a: a.get("level") in ("50", "60"),
+            ),
+            WizardStep(key="spare", run=spare_step, applies=lambda a: bool(pools)),
+            WizardStep(key="confirmed", run=confirm_step),
+        ]
+        answers = await run_wizard(steps)
+        if answers is None:
+            return
+
+        # Assemble the API spec from the collected answers.
+        drives = answers["drives"]
+        spec: dict[str, Any] = {
+            "name": answers["name"],
+            "level": f"raid{answers['level']}",
+            "member_disk_ids": [name_to_id.get(n, n) for n in drives],
+            "strip_size_kib": int(answers["strip"]),
+        }
+        if answers["level"] in ("50", "60"):
+            spec["group_size"] = int(answers["group_size"])
+        spare = answers.get("spare", _NONE_POOL)
+        if spare != _NONE_POOL:
+            path_to_id = {d["device_path"]: d["id"] for d in disk_rows}
+            spare_ids = [
+                path_to_id.get(p, p.rsplit("/", 1)[-1])
+                for p in _pool_drive_paths(pools.get(spare, {}))
+            ]
+            if spare_ids:
+                spec["spare_disk_ids"] = spare_ids
+            else:
+                self.app.notify(
+                    f"Pool '{spare}' has no drives — skipping spare assignment.",
+                    severity="warning",
+                )
+
+        dialog = TaskWaitDialog(f"Creating RAID array '{answers['name']}'…", "Create Array")
+        self.app.push_screen(dialog)
+        cancelled = False
+        error: ControlPathError | None = None
+        try:
+            await asyncio.to_thread(
+                self.app.control.plan_apply_wait,
+                "POST",
+                "/api/v1/arrays",
+                spec,
+                on_progress=dialog.progress_from_thread(self.app),
+                cancel_check=dialog.cancel_requested,
+            )
+        except TaskCancelled:
+            cancelled = True
+        except ControlPathError as exc:
+            error = exc
+        finally:
+            dialog.dismiss(None)
+        if cancelled:
+            await self.app.push_screen_wait(
+                ConfirmDialog("Create cancelled — partial work rolled back.", "Cancelled", ok_only=True)
+            )
+            return
+        if error is not None:
+            await self.app.push_screen_wait(ConfirmDialog(f"Create failed.\n{error}", "Error"))
+            return
+        self.app.audit.log(
+            "raid.create", f"{answers['name']} RAID-{answers['level']} ({len(drives)} drives)", "OK"
+        )
+        await self.app.snapshots.record(
+            "raid_create",
+            diff_summary=f"Created RAID-{answers['level']} array '{answers['name']}' with {len(drives)} drives",
+        )
+        self._show_quick()
+```
+
+- [ ] **Step 3: Run the full suite + lint + import smoke**
+
+Run: `python -m pytest tests/ -q && ruff check xinas_menu/screens/raid.py && ruff format --check xinas_menu/screens/raid.py && python -c "import xinas_menu.screens.raid"`
+Expected: all pass; no lint errors; import clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add xinas_menu/screens/raid.py
+git commit -m "feat(tui): Back navigation for Create Array wizard"
+```
+
+---
+
+## Task 6: Update the specs
+
+**Files:**
+- Modify: `docs/Storage/fs-shares-management-spec.md`, `docs/Storage/raid-management-spec.md`
+
+- [ ] **Step 1: fs-shares spec** — Add a "Wizard navigation model" subsection (before §4.3) describing: the `run_wizard` driver (`xinas_menu/widgets/wizard.py`), the `BACK`/`CANCEL` sentinels, `allow_back` on the dialogs, `selected` pre-selection, and that answers are retained across Back. Update §4.3 to describe `_access_steps` (replacing `_access_wizard`) returning a `list[WizardStep]` reused by Add and Edit, reading prefill from `answers` and the "(Current:)" hint from `answers["_orig"]`. Update §4.4 to note the path step is step 1, the Back button appears on steps 2–7, the confirm step can Back, and the empty-host-input-returns-to-select behavior.
+
+- [ ] **Step 2: raid spec** — Update §4 to describe: disks and pools fetched up front (the "no NVMe drives" check now precedes the name prompt); driver-computed `Create Array — Step N` titles; group-size and spare-pool as conditional steps (`applies` predicates) that Back skips in both directions; the drives step re-entry opening the picker directly with `preselected`; and `Esc` on strip now cancelling (dialog pre-selects `64`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/Storage/fs-shares-management-spec.md docs/Storage/raid-management-spec.md
+git commit -m "docs(storage): spec Back navigation for share and RAID wizards"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** driver (Task 1) ✓; dialog Back + pre-select (Task 2) ✓; state retention (driver + `selected`/`default`/`preselected`) ✓; NFS Add/Edit rewrite incl. cross-boundary Back (Task 4) ✓; RAID rewrite incl. conditional steps (Task 5) ✓; spec updates (Task 6) ✓; no `Requires-Rebuild` (Python-only) ✓.
+
+**Placeholder scan:** none — every code step carries full, runnable code; no TBD/TODO/"handle edge cases" prose.
+
+**Type consistency:** `run_wizard`, `WizardStep`, `BACK`, `CANCEL` are used identically across Tasks 1/4/5. Dialog params `allow_back` (kw-only bool) and `SelectDialog.selected` match between Task 2 definitions and Task 4/5 call sites. Helper names `_host_prefill`/`_path_prefill`/`_share_summary`/`_HOST_CHOICES`/`_CUSTOM_PATH` are defined in Task 3/4 and used consistently. `_parse_current_export` keys (`host`,`access`,`root_squash`,`sync_mode`,`sec`,`extra_opts`) match the seeding in `select_step` and the dispatch reads.
+</content>

--- a/tests/test_nfs_wizard_helpers.py
+++ b/tests/test_nfs_wizard_helpers.py
@@ -1,0 +1,47 @@
+"""Pure prefill helpers for the NFS share wizard."""
+
+from __future__ import annotations
+
+from xinas_menu.screens.nfs import _host_prefill, _path_prefill
+
+_HOST_CHOICES = [
+    "Everyone (any host on the network)",
+    "Specific network (e.g., 192.168.1.0/24)",
+    "Single host (by IP address)",
+]
+
+
+def test_host_prefill_everyone():
+    sel, hint = _host_prefill("*")
+    assert sel == _HOST_CHOICES[0]
+    assert hint == "Everyone"
+
+
+def test_host_prefill_network():
+    sel, hint = _host_prefill("192.168.1.0/24")
+    assert sel == _HOST_CHOICES[1]
+    assert hint == "Network 192.168.1.0/24"
+
+
+def test_host_prefill_single():
+    sel, hint = _host_prefill("10.0.0.5")
+    assert sel == _HOST_CHOICES[2]
+    assert hint == "Host 10.0.0.5"
+
+
+def test_path_prefill_matches_mount():
+    sel, default = _path_prefill("/mnt/data", ["/mnt/data", "/mnt/log"])
+    assert sel == "/mnt/data"
+    assert default == "/mnt/data/"  # custom default is unused when a mount matches
+
+
+def test_path_prefill_custom_when_no_match():
+    sel, default = _path_prefill("/mnt/data/share1", ["/mnt/data"])
+    assert sel == "Custom path…"
+    assert default == "/mnt/data/share1"
+
+
+def test_path_prefill_empty():
+    sel, default = _path_prefill("", ["/mnt/data"])
+    assert sel is None
+    assert default == "/mnt/data/"

--- a/tests/test_wizard_dialogs.py
+++ b/tests/test_wizard_dialogs.py
@@ -1,0 +1,36 @@
+# tests/test_wizard_dialogs.py
+"""Constructor smoke tests: the four wizard dialogs accept allow_back and the
+BACK sentinel is a distinct object (headless — no Textual app mounted)."""
+
+from __future__ import annotations
+
+from xinas_menu.widgets.confirm_dialog import ConfirmDialog
+from xinas_menu.widgets.drive_picker import DrivePickerScreen
+from xinas_menu.widgets.input_dialog import InputDialog
+from xinas_menu.widgets.select_dialog import SelectDialog
+from xinas_menu.widgets.wizard import BACK
+
+
+def test_back_sentinel_is_distinct():
+    assert BACK is not None and BACK is not True and BACK is not False and BACK != ""
+
+
+def test_select_dialog_accepts_allow_back_and_selected():
+    d = SelectDialog(["a", "b"], title="t", prompt="p", selected="b", allow_back=True)
+    assert d._allow_back is True
+    assert d._selected == "b"
+
+
+def test_input_dialog_accepts_allow_back():
+    d = InputDialog("prompt", "title", default="x", allow_back=True)
+    assert d._allow_back is True
+
+
+def test_confirm_dialog_accepts_allow_back():
+    d = ConfirmDialog("msg", "title", allow_back=True)
+    assert d._allow_back is True
+
+
+def test_drive_picker_accepts_allow_back():
+    d = DrivePickerScreen([], title="t", allow_back=True)
+    assert d._allow_back is True

--- a/tests/test_wizard_driver.py
+++ b/tests/test_wizard_driver.py
@@ -91,3 +91,20 @@ def test_display_number_counts_only_applicable():
     c = _script_step("c", [rec("c")])
     asyncio.run(run_wizard([a, b, c]))
     assert seen == {"a": 1, "c": 2}  # b skipped, c numbered 2 not 3
+
+
+def test_back_then_invalidate_drops_stale_answer():
+    # a="yes" -> b applies, returns "B"; c backs to b, b backs to a, a changes to
+    # "no" -> b is now skipped, so its stale answer must be dropped from the result.
+    a = _script_step("a", ["yes", "no"])
+    b = _script_step("b", ["B", BACK], applies=lambda ans: ans.get("a") == "yes")
+    c = _script_step("c", [BACK, "C"])
+    result = asyncio.run(run_wizard([a, b, c]))
+    assert result == {"a": "no", "c": "C"}  # no "b" key
+    assert "b" not in result
+
+
+def test_initial_seeds_answers():
+    a = _script_step("a", ["A"])
+    result = asyncio.run(run_wizard([a], initial={"x": 1}))
+    assert result == {"x": 1, "a": "A"}

--- a/tests/test_wizard_driver.py
+++ b/tests/test_wizard_driver.py
@@ -1,0 +1,93 @@
+# tests/test_wizard_driver.py
+"""Headless coverage for the generic wizard driver (run_wizard)."""
+
+from __future__ import annotations
+
+import asyncio
+
+from xinas_menu.widgets.wizard import BACK, CANCEL, WizardStep, run_wizard
+
+
+def _script_step(key, script, applies=lambda a: True):
+    """A step whose run() pops the next scripted outcome each time it is entered.
+
+    `script` is a list of outcomes. Each outcome is either a callable
+    `fn(answers, allow_back, step_no) -> value|BACK|CANCEL` or a plain value.
+    Records the (allow_back, step_no) it was called with in `calls`.
+    """
+    calls = []
+    it = iter(script)
+
+    async def run(answers, allow_back, step_no):
+        calls.append((allow_back, step_no))
+        nxt = next(it)
+        return nxt(answers, allow_back, step_no) if callable(nxt) else nxt
+
+    step = WizardStep(key=key, run=run, applies=applies)
+    step.calls = calls  # type: ignore[attr-defined]
+    return step
+
+
+def test_forward_accumulates_all_answers():
+    steps = [
+        _script_step("a", ["A"]),
+        _script_step("b", ["B"]),
+        _script_step("c", ["C"]),
+    ]
+    result = asyncio.run(run_wizard(steps))
+    assert result == {"a": "A", "b": "B", "c": "C"}
+
+
+def test_cancel_returns_none():
+    steps = [_script_step("a", ["A"]), _script_step("b", [CANCEL])]
+    assert asyncio.run(run_wizard(steps)) is None
+
+
+def test_back_retains_earlier_and_later_answers():
+    # a="A", b enters -> BACK, a re-enters -> keeps "A" (prefill visible via answers),
+    # a returns "A2", b returns "B".
+    a = _script_step("a", ["A", "A2"])
+    b = _script_step("b", [BACK, "B"])
+    result = asyncio.run(run_wizard([a, b]))
+    assert result == {"a": "A2", "b": "B"}
+    # a was entered twice, b twice; a saw allow_back False both times (first step).
+    assert a.calls == [(False, 1), (False, 1)]
+    assert b.calls[0] == (True, 2)
+
+
+def test_back_on_first_step_is_noop():
+    # A misbehaving first step that returns BACK must not underflow.
+    a = _script_step("a", [BACK, "A"])
+    b = _script_step("b", ["B"])
+    result = asyncio.run(run_wizard([a, b]))
+    assert result == {"a": "A", "b": "B"}
+
+
+def test_conditional_step_skipped_forward_and_back():
+    # b applies only when a == "yes". With a == "no", forward skips b; Back from
+    # c lands on a, not b.
+    a = _script_step("a", ["no", "no"])
+    b = _script_step("b", ["Bshould", "not", "run"], applies=lambda ans: ans.get("a") == "yes")
+    c = _script_step("c", [BACK, "C"])
+    result = asyncio.run(run_wizard([a, b, c]))
+    assert result == {"a": "no", "c": "C"}
+    assert b.calls == []  # never entered
+    # c enters, backs to a (skipping b), a re-runs, c re-runs.
+    assert a.calls == [(False, 1), (False, 1)]
+
+
+def test_display_number_counts_only_applicable():
+    seen = {}
+
+    def rec(key):
+        def fn(answers, allow_back, step_no):
+            seen[key] = step_no
+            return key.upper()
+
+        return fn
+
+    a = _script_step("a", [rec("a")])
+    b = _script_step("b", [rec("b")], applies=lambda ans: False)
+    c = _script_step("c", [rec("c")])
+    asyncio.run(run_wizard([a, b, c]))
+    assert seen == {"a": 1, "c": 2}  # b skipped, c numbered 2 not 3

--- a/xinas_menu/screens/nfs.py
+++ b/xinas_menu/screens/nfs.py
@@ -23,6 +23,7 @@ from xinas_menu.widgets.input_dialog import InputDialog
 from xinas_menu.widgets.menu_list import MenuItem, NavigableMenu
 from xinas_menu.widgets.select_dialog import SelectDialog
 from xinas_menu.widgets.text_view import ScrollableTextView
+from xinas_menu.widgets.wizard import BACK, CANCEL, WizardStep, run_wizard
 
 _HOST_CHOICES = [
     "Everyone (any host on the network)",
@@ -53,6 +54,27 @@ def _path_prefill(stored: str, mount_points: list[str]) -> tuple[str | None, str
     if stored in mount_points:
         return stored, "/mnt/data/"
     return _CUSTOM_PATH, stored
+
+
+def _share_summary(path, host, access, root_squash, sync_mode, sec, options) -> str:
+    access_label = "Read & Write" if access == "rw" else "Read Only"
+    admin_label = "Yes (no_root_squash)" if root_squash == "no_root_squash" else "No (root_squash)"
+    sync_label = "Sync (safer)" if sync_mode == "sync" else "Async (faster)"
+    sec_labels = {
+        "sys": "Standard UID/GID",
+        "krb5": "Kerberos",
+        "krb5i": "Kerberos + integrity",
+        "krb5p": "Kerberos + encryption",
+    }
+    return (
+        f"Path:       {path}\n"
+        f"Access:     {host}\n"
+        f"Permission: {access_label}\n"
+        f"Admin:      {admin_label}\n"
+        f"Sync:       {sync_label}\n"
+        f"Security:   {sec_labels.get(sec, sec)}\n"
+        f"Options:    {','.join(options)}"
+    )
 
 
 _MENU = [
@@ -146,193 +168,218 @@ class NFSScreen(XiNASAppMixin, Screen):
 
         return _cb
 
-    # ── Shared access-control wizard (4 steps) ─────────────────────────────
+    # ── Shared access-control steps (host / perms / admin / sync / security) ──
 
-    async def _access_wizard(
-        self,
-        title_prefix: str,
-        step_offset: int,
-        total_steps: int,
-        current: dict | None = None,
-    ) -> dict | None:
-        """Run 5 structured access-control steps.
+    def _access_steps(self, prefix: str, total: int) -> list[WizardStep]:
+        """Build the 5 shared access-control steps.
 
-        Returns ``{"host", "access", "root_squash", "sync_mode", "sec"}``
-        or *None* if the user cancelled at any step.
+        Each step reads its working value from ``answers`` (retained across
+        Back) and, when ``answers`` carries an ``_orig`` snapshot (Edit),
+        annotates the prompt with the share's original value.
         """
-        cur = current or {}
 
-        # ── Step: Who Can Access? ────────────────────────────────────────
-        step = step_offset
-        cur_host = cur.get("host", "*")
-        if cur_host == "*":
-            cur_hint = "Everyone"
-        elif "/" in cur_host:
-            cur_hint = f"Network {cur_host}"
-        else:
-            cur_hint = f"Host {cur_host}"
-        prompt = "Who should be able to connect?"
-        if current:
-            prompt += f"\n(Current: {cur_hint})"
+        def title(step_no: int) -> str:
+            return f"{prefix} — Step {step_no}/{total}"
 
-        who = await self.app.push_screen_wait(
-            SelectDialog(
-                [
-                    "Everyone (any host on the network)",
-                    "Specific network (e.g., 192.168.1.0/24)",
-                    "Single host (by IP address)",
-                ],
-                title=f"{title_prefix} — Step {step}/{total_steps}",
-                prompt=prompt,
-            )
-        )
-        if who is None:
-            return None
+        def orig(answers: dict) -> dict | None:
+            return answers.get("_orig")
 
-        if who.startswith("Everyone"):
-            host = "*"
-        elif who.startswith("Specific"):
-            host = await self.app.push_screen_wait(
-                InputDialog(
-                    "Network address:",
-                    f"{title_prefix} — Step {step}/{total_steps}",
-                    default=cur_host if "/" in cur_host else "192.168.1.0/24",
-                    placeholder="192.168.1.0/24",
+        async def host_step(answers, allow_back, step_no):
+            while True:
+                cur_host = answers.get("host", "*")
+                selected, _ = _host_prefill(cur_host)
+                prompt = "Who should be able to connect?"
+                o = orig(answers)
+                if o is not None:
+                    _, hint = _host_prefill(o.get("host", "*"))
+                    prompt += f"\n(Current: {hint})"
+                who = await self.app.push_screen_wait(
+                    SelectDialog(
+                        _HOST_CHOICES,
+                        title=title(step_no),
+                        prompt=prompt,
+                        selected=selected,
+                        allow_back=allow_back,
+                    )
                 )
-            )
-            if not host:
-                return None
-        else:
-            host = await self.app.push_screen_wait(
-                InputDialog(
-                    "Host IP address:",
-                    f"{title_prefix} — Step {step}/{total_steps}",
-                    default=cur_host if cur_host != "*" and "/" not in cur_host else "",
-                    placeholder="192.168.1.100",
-                )
-            )
-            if not host:
-                return None
+                if who is None:
+                    return CANCEL
+                if who is BACK:
+                    return BACK
+                if who.startswith("Everyone"):
+                    return "*"
+                if who.startswith("Specific"):
+                    default = cur_host if "/" in cur_host else "192.168.1.0/24"
+                    sub = await self.app.push_screen_wait(
+                        InputDialog(
+                            "Network address:",
+                            title(step_no),
+                            default=default,
+                            placeholder="192.168.1.0/24",
+                            allow_back=True,
+                        )
+                    )
+                else:
+                    default = cur_host if (cur_host != "*" and "/" not in cur_host) else ""
+                    sub = await self.app.push_screen_wait(
+                        InputDialog(
+                            "Host IP address:",
+                            title(step_no),
+                            default=default,
+                            placeholder="192.168.1.100",
+                            allow_back=True,
+                        )
+                    )
+                if sub is None:
+                    return CANCEL
+                if sub is BACK or not sub:
+                    continue  # back to (or empty at) the who-select
+                return sub
 
-        # ── Step: Access Permissions ─────────────────────────────────────
-        step = step_offset + 1
-        cur_access = cur.get("access", "rw")
-        prompt = "What can connected hosts do?"
-        if current:
-            label = "Read & Write" if cur_access == "rw" else "Read Only"
-            prompt += f"\n(Current: {label})"
-
-        access_choice = await self.app.push_screen_wait(
-            SelectDialog(
-                [
-                    "Read & Write (can add, edit, delete files)",
-                    "Read Only (can only view files)",
-                ],
-                title=f"{title_prefix} — Step {step}/{total_steps}",
-                prompt=prompt,
-            )
-        )
-        if access_choice is None:
-            return None
-        access = "rw" if access_choice.startswith("Read & Write") else "ro"
-
-        # ── Step: Admin Access ───────────────────────────────────────────
-        step = step_offset + 2
-        cur_root = cur.get("root_squash", "no_root_squash")
-        prompt = "Allow full administrator access?"
-        if current:
-            label = "Yes" if cur_root == "no_root_squash" else "No"
-            prompt += f"\n(Current: {label})"
-
-        admin_choice = await self.app.push_screen_wait(
-            SelectDialog(
-                [
-                    "Yes - Full admin access (recommended)",
-                    "No - Limited access (more secure)",
-                ],
-                title=f"{title_prefix} — Step {step}/{total_steps}",
-                prompt=prompt,
-            )
-        )
-        if admin_choice is None:
-            return None
-        root_squash = "no_root_squash" if admin_choice.startswith("Yes") else "root_squash"
-
-        # ── Step: Sync Mode ──────────────────────────────────────────────
-        step = step_offset + 3
-        cur_sync = cur.get("sync_mode", "sync")
-        prompt = "When should the server confirm writes?"
-        if current:
-            label = "Sync (safer)" if cur_sync == "sync" else "Async (faster)"
-            prompt += f"\n(Current: {label})"
-
-        sync_choice = await self.app.push_screen_wait(
-            SelectDialog(
-                [
-                    "Sync - confirm after writing to disk (safer, recommended)",
-                    "Async - confirm immediately (faster, risk of data loss on crash)",
-                ],
-                title=f"{title_prefix} — Step {step}/{total_steps}",
-                prompt=prompt,
-            )
-        )
-        if sync_choice is None:
-            return None
-        sync_mode = "sync" if sync_choice.startswith("Sync") else "async"
-
-        # ── Step: Security Mode ──────────────────────────────────────────
-        step = step_offset + 4
-        cur_sec = cur.get("sec", "sys")
-        sec_labels = {
-            "sys": "Standard UID/GID",
-            "krb5": "Kerberos",
-            "krb5i": "Kerberos + integrity",
-            "krb5p": "Kerberos + encryption",
-        }
-        prompt = "Select authentication mode:"
-        if current:
-            prompt += f"\n(Current: {sec_labels.get(cur_sec, cur_sec)})"
-
-        sec_choice = await self.app.push_screen_wait(
-            SelectDialog(
-                [
-                    "Standard UID/GID (default)",
-                    "Kerberos authentication",
-                    "Kerberos + integrity",
-                    "Kerberos + encryption",
-                ],
-                title=f"{title_prefix} — Step {step}/{total_steps}",
-                prompt=prompt,
-            )
-        )
-        if sec_choice is None:
-            return None
-        sec_map = {
+        access_choices = [
+            "Read & Write (can add, edit, delete files)",
+            "Read Only (can only view files)",
+        ]
+        admin_choices = [
+            "Yes - Full admin access (recommended)",
+            "No - Limited access (more secure)",
+        ]
+        sync_choices = [
+            "Sync - confirm after writing to disk (safer, recommended)",
+            "Async - confirm immediately (faster, risk of data loss on crash)",
+        ]
+        sec_choices = [
+            "Standard UID/GID (default)",
+            "Kerberos authentication",
+            "Kerberos + integrity",
+            "Kerberos + encryption",
+        ]
+        _SEC_MAP = {
             "Standard": "sys",
             "Kerberos authentication": "krb5",
             "Kerberos + integrity": "krb5i",
             "Kerberos + encryption": "krb5p",
         }
-        sec = "sys"
-        for key, val in sec_map.items():
-            if sec_choice.startswith(key):
-                sec = val
-                break
-
-        return {
-            "host": host,
-            "access": access,
-            "root_squash": root_squash,
-            "sync_mode": sync_mode,
-            "sec": sec,
+        _SEC_LABELS = {
+            "sys": "Standard UID/GID",
+            "krb5": "Kerberos",
+            "krb5i": "Kerberos + integrity",
+            "krb5p": "Kerberos + encryption",
         }
+
+        def _sec_value(choice: str) -> str:
+            for key, val in _SEC_MAP.items():
+                if choice.startswith(key):
+                    return val
+            return "sys"
+
+        steps: list[WizardStep] = [WizardStep(key="host", run=host_step)]
+
+        async def access_run_fn(answers, allow_back, step_no):
+            cur = answers.get("access", "rw")
+            selected = access_choices[0] if cur == "rw" else access_choices[1]
+            prompt = "What can connected hosts do?"
+            o = orig(answers)
+            if o is not None:
+                prompt += "\n(Current: %s)" % (
+                    "Read & Write" if o.get("access") == "rw" else "Read Only"
+                )
+            pick = await self.app.push_screen_wait(
+                SelectDialog(
+                    access_choices,
+                    title=title(step_no),
+                    prompt=prompt,
+                    selected=selected,
+                    allow_back=allow_back,
+                )
+            )
+            if pick is None:
+                return CANCEL
+            if pick is BACK:
+                return BACK
+            return "rw" if pick.startswith("Read & Write") else "ro"
+
+        async def admin_run_fn(answers, allow_back, step_no):
+            cur = answers.get("root_squash", "no_root_squash")
+            selected = admin_choices[0] if cur == "no_root_squash" else admin_choices[1]
+            prompt = "Allow full administrator access?"
+            o = orig(answers)
+            if o is not None:
+                prompt += "\n(Current: %s)" % (
+                    "Yes" if o.get("root_squash") == "no_root_squash" else "No"
+                )
+            pick = await self.app.push_screen_wait(
+                SelectDialog(
+                    admin_choices,
+                    title=title(step_no),
+                    prompt=prompt,
+                    selected=selected,
+                    allow_back=allow_back,
+                )
+            )
+            if pick is None:
+                return CANCEL
+            if pick is BACK:
+                return BACK
+            return "no_root_squash" if pick.startswith("Yes") else "root_squash"
+
+        async def sync_run_fn(answers, allow_back, step_no):
+            cur = answers.get("sync_mode", "sync")
+            selected = sync_choices[0] if cur == "sync" else sync_choices[1]
+            prompt = "When should the server confirm writes?"
+            o = orig(answers)
+            if o is not None:
+                prompt += "\n(Current: %s)" % (
+                    "Sync (safer)" if o.get("sync_mode") == "sync" else "Async (faster)"
+                )
+            pick = await self.app.push_screen_wait(
+                SelectDialog(
+                    sync_choices,
+                    title=title(step_no),
+                    prompt=prompt,
+                    selected=selected,
+                    allow_back=allow_back,
+                )
+            )
+            if pick is None:
+                return CANCEL
+            if pick is BACK:
+                return BACK
+            return "sync" if pick.startswith("Sync") else "async"
+
+        async def sec_run_fn(answers, allow_back, step_no):
+            cur = answers.get("sec", "sys")
+            selected = next((c for c in sec_choices if _sec_value(c) == cur), sec_choices[0])
+            prompt = "Select authentication mode:"
+            o = orig(answers)
+            if o is not None:
+                prompt += f"\n(Current: {_SEC_LABELS.get(o.get('sec'), o.get('sec'))})"
+            pick = await self.app.push_screen_wait(
+                SelectDialog(
+                    sec_choices,
+                    title=title(step_no),
+                    prompt=prompt,
+                    selected=selected,
+                    allow_back=allow_back,
+                )
+            )
+            if pick is None:
+                return CANCEL
+            if pick is BACK:
+                return BACK
+            return _sec_value(pick)
+
+        steps.append(WizardStep(key="access", run=access_run_fn))
+        steps.append(WizardStep(key="root_squash", run=admin_run_fn))
+        steps.append(WizardStep(key="sync_mode", run=sync_run_fn))
+        steps.append(WizardStep(key="sec", run=sec_run_fn))
+        return steps
 
     # ── Wizard: Add Share ────────────────────────────────────────────────
 
     @work(exclusive=True)
     async def _add_share_wizard(self) -> None:
-        """6-step share creation wizard."""
-        # Step 1: Export path — list mounted XFS filesystems + custom option
+        """7-step share creation wizard with Back navigation."""
         from xinas_menu.utils.xfs_helpers import run_async_cmd
 
         mount_points: list[str] = []
@@ -340,92 +387,101 @@ class NFSScreen(XiNASAppMixin, Screen):
         if ok and out:
             mount_points = [line.strip() for line in out.splitlines() if line.strip()]
 
-        _CUSTOM = "Custom path…"
-        if mount_points:
-            choices = mount_points + [_CUSTOM]
-            choice = await self.app.push_screen_wait(
-                SelectDialog(
-                    choices,
-                    title="Add Share — Step 1/7",
-                    prompt="Select filesystem to export (or choose custom for a subfolder):",
-                )
-            )
-            if not choice:
-                return
-            if choice == _CUSTOM:
-                path = await self.app.push_screen_wait(
-                    InputDialog(
-                        "Export path:",
-                        "Add Share — Step 1/7",
-                        default="/mnt/data/",
-                        placeholder="/mnt/data/share1",
+        async def path_step(answers, allow_back, step_no):
+            stored = answers.get("path", "")
+            title = f"Add Share — Step {step_no}/7"
+            while True:
+                if mount_points:
+                    selected, custom_default = _path_prefill(stored, mount_points)
+                    choice = await self.app.push_screen_wait(
+                        SelectDialog(
+                            mount_points + [_CUSTOM_PATH],
+                            title=title,
+                            prompt="Select filesystem to export (or choose custom for a subfolder):",
+                            selected=selected,
+                            allow_back=allow_back,
+                        )
                     )
-                )
-                if not path:
-                    return
-            else:
-                path = choice
-        else:
-            path = await self.app.push_screen_wait(
-                InputDialog(
-                    "Export path:",
-                    "Add Share — Step 1/7",
-                    default="/mnt/data/",
-                    placeholder="/mnt/data/share1",
+                    if choice is None:
+                        return CANCEL
+                    if choice is BACK:
+                        return BACK
+                    if choice == _CUSTOM_PATH:
+                        sub = await self.app.push_screen_wait(
+                            InputDialog(
+                                "Export path:",
+                                title,
+                                default=custom_default,
+                                placeholder="/mnt/data/share1",
+                                allow_back=True,
+                            )
+                        )
+                        if sub is None:
+                            return CANCEL
+                        if sub is BACK:
+                            continue
+                        path = sub
+                    else:
+                        path = choice
+                else:
+                    sub = await self.app.push_screen_wait(
+                        InputDialog(
+                            "Export path:",
+                            title,
+                            default=stored or "/mnt/data/",
+                            placeholder="/mnt/data/share1",
+                            allow_back=allow_back,
+                        )
+                    )
+                    if sub is None:
+                        return CANCEL
+                    if sub is BACK:
+                        return BACK
+                    path = sub
+                if not path.startswith("/"):
+                    self.app.notify("Export path must start with '/'.", severity="error")
+                    continue
+                return path.rstrip("/") or "/"
+
+        async def confirm_step(answers, allow_back, step_no):
+            host = answers["host"]
+            access = answers["access"]
+            root_squash = answers["root_squash"]
+            sync_mode = answers["sync_mode"]
+            sec = answers["sec"]
+            options = [access, sync_mode, "no_subtree_check", root_squash]
+            if sec != "sys":
+                options.append(f"sec={sec}")
+            summary = _share_summary(
+                answers["path"], host, access, root_squash, sync_mode, sec, options
+            )
+            result = await self.app.push_screen_wait(
+                ConfirmDialog(
+                    f"Create this export?\n\n{summary}",
+                    f"Add Share — Step {step_no}/7",
+                    allow_back=allow_back,
                 )
             )
-            if not path:
-                return
+            if result is BACK:
+                return BACK
+            return True if result is True else CANCEL
 
-        if not path.startswith("/"):
-            self.app.notify("Export path must start with '/'.", severity="error")
-            return
-        # The API requires a canonical export path — trim trailing slashes
-        # here; deeper canonicalization errors surface from the plan.
-        path = path.rstrip("/") or "/"
-
-        # Steps 2-6: Access control wizard (who / permissions / admin / sync / security)
-        result = await self._access_wizard("Add Share", step_offset=2, total_steps=7)
-        if result is None:
+        steps = (
+            [WizardStep(key="path", run=path_step)]
+            + self._access_steps("Add Share", total=7)
+            + [WizardStep(key="confirmed", run=confirm_step)]
+        )
+        answers = await run_wizard(steps)
+        if answers is None:
             return
 
-        # Step 7: Confirm
-        host = result["host"]
-        access = result["access"]
-        root_squash = result["root_squash"]
-        sync_mode = result["sync_mode"]
-        sec = result["sec"]
-        options = [access, sync_mode, "no_subtree_check", root_squash]
-        if sec != "sys":
-            options.append(f"sec={sec}")
+        path = answers["path"]
+        host = answers["host"]
+        access = answers["access"]
+        root_squash = answers["root_squash"]
+        sync_mode = answers["sync_mode"]
+        sec = answers["sec"]
 
-        access_label = "Read & Write" if access == "rw" else "Read Only"
-        admin_label = (
-            "Yes (no_root_squash)" if root_squash == "no_root_squash" else "No (root_squash)"
-        )
-        sync_label = "Sync (safer)" if sync_mode == "sync" else "Async (faster)"
-        sec_labels = {
-            "sys": "Standard UID/GID",
-            "krb5": "Kerberos",
-            "krb5i": "Kerberos + integrity",
-            "krb5p": "Kerberos + encryption",
-        }
-        summary = (
-            f"Path:       {path}\n"
-            f"Access:     {host}\n"
-            f"Permission: {access_label}\n"
-            f"Admin:      {admin_label}\n"
-            f"Sync:       {sync_label}\n"
-            f"Security:   {sec_labels.get(sec, sec)}\n"
-            f"Options:    {','.join(options)}"
-        )
-        confirmed = await self.app.push_screen_wait(
-            ConfirmDialog(f"Create this export?\n\n{summary}", "Add Share — Step 7/7")
-        )
-        if not confirmed:
-            return
-
-        # Ensure export directory exists
         loop = asyncio.get_running_loop()
         try:
             await loop.run_in_executor(None, lambda: os.makedirs(path, exist_ok=True))
@@ -435,10 +491,6 @@ class NFSScreen(XiNASAppMixin, Screen):
             )
             return
 
-        # The API requires a unique integer fsid per share (the legacy
-        # nfs-helper flow never carried one): derive max(existing)+1 so a
-        # freed fsid is not immediately reused under clients that still
-        # cache filehandles. fsid 0 stays reserved (NFSv4 pseudo-root).
         used: set[int] = set()
         for row in await self._get_exports():
             fsid = row.get("fsid")
@@ -449,8 +501,6 @@ class NFSScreen(XiNASAppMixin, Screen):
         spec: dict[str, Any] = {
             "path": path,
             "fsid": max(used, default=0) + 1,
-            # sync and security_mode are share-level API fields; the
-            # remaining legacy option tokens stay per-client.
             "clients": [{"pattern": host, "options": [access, root_squash, "no_subtree_check"]}],
             "sync": sync_mode,
         }
@@ -468,16 +518,12 @@ class NFSScreen(XiNASAppMixin, Screen):
             await self.app.push_screen_wait(ConfirmDialog(f"Failed: {exc}", "Error", ok_only=True))
             return
         self.app.audit.log("nfs.add_export", path, "OK")
-        await self.app.snapshots.record(
-            "share_create",
-            diff_summary=f"Added NFS share {path}",
-        )
+        await self.app.snapshots.record("share_create", diff_summary=f"Added NFS share {path}")
         self._load_exports()
 
     @work(exclusive=True)
     async def _edit_share(self) -> None:
-        """6-step edit share wizard with structured access control."""
-        # Step 1: Select export to edit
+        """7-step edit share wizard with Back navigation."""
         exports = await self._get_exports()
         if not exports:
             await self.app.push_screen_wait(
@@ -485,78 +531,80 @@ class NFSScreen(XiNASAppMixin, Screen):
             )
             return
         paths = [e["path"] for e in exports]
-        path = await self.app.push_screen_wait(
-            SelectDialog(paths, title="Edit Share — Step 1/7", prompt="Select export to edit:")
-        )
-        if not path:
-            return
 
-        # Parse current values for pre-population
-        export = next((e for e in exports if e["path"] == path), {})
-        share_id = str(export.get("id", ""))
-        if not share_id:
-            await self.app.push_screen_wait(
-                ConfirmDialog("Share not found.", "Edit Share", ok_only=True)
+        async def select_step(answers, allow_back, step_no):
+            choice = await self.app.push_screen_wait(
+                SelectDialog(
+                    paths,
+                    title=f"Edit Share — Step {step_no}/7",
+                    prompt="Select export to edit:",
+                    selected=answers.get("path"),
+                    allow_back=allow_back,
+                )
             )
+            if choice is None:
+                return CANCEL
+            if choice is BACK:
+                return BACK
+            if choice != answers.get("path"):
+                export = next((e for e in exports if e["path"] == choice), {})
+                share_id = str(export.get("id", ""))
+                if not share_id:
+                    await self.app.push_screen_wait(
+                        ConfirmDialog("Share not found.", "Edit Share", ok_only=True)
+                    )
+                    return CANCEL
+                current = _parse_current_export(export)
+                answers["_orig"] = current
+                answers["share_id"] = share_id
+                for k in ("host", "access", "root_squash", "sync_mode", "sec"):
+                    answers[k] = current[k]
+            return choice
+
+        async def confirm_step(answers, allow_back, step_no):
+            host = answers["host"]
+            access = answers["access"]
+            root_squash = answers["root_squash"]
+            sync_mode = answers["sync_mode"]
+            sec = answers["sec"]
+            extra = answers["_orig"]["extra_opts"]
+            options = [access, sync_mode, root_squash]
+            if sec != "sys":
+                options.append(f"sec={sec}")
+            options.extend(extra)
+            summary = _share_summary(
+                answers["path"], host, access, root_squash, sync_mode, sec, options
+            )
+            result = await self.app.push_screen_wait(
+                ConfirmDialog(
+                    f"Update this export?\n\n{summary}",
+                    f"Edit Share — Step {step_no}/7",
+                    allow_back=allow_back,
+                )
+            )
+            if result is BACK:
+                return BACK
+            return True if result is True else CANCEL
+
+        steps = (
+            [WizardStep(key="path", run=select_step)]
+            + self._access_steps("Edit Share", total=7)
+            + [WizardStep(key="confirmed", run=confirm_step)]
+        )
+        answers = await run_wizard(steps)
+        if answers is None:
             return
-        current = _parse_current_export(export)
 
-        # Steps 2-6: Access control wizard with current values shown
-        result = await self._access_wizard(
-            "Edit Share",
-            step_offset=2,
-            total_steps=7,
-            current=current,
-        )
-        if result is None:
-            return
+        host = answers["host"]
+        access = answers["access"]
+        root_squash = answers["root_squash"]
+        sync_mode = answers["sync_mode"]
+        sec = answers["sec"]
+        share_id = answers["share_id"]
+        extra = answers["_orig"]["extra_opts"]
 
-        # Step 7: Confirm
-        host = result["host"]
-        access = result["access"]
-        root_squash = result["root_squash"]
-        sync_mode = result["sync_mode"]
-        sec = result["sec"]
-
-        # Assemble options: wizard-managed + preserved extras from original
-        options = [access, sync_mode, root_squash]
-        if sec != "sys":
-            options.append(f"sec={sec}")
-        options.extend(current["extra_opts"])
-
-        access_label = "Read & Write" if access == "rw" else "Read Only"
-        admin_label = (
-            "Yes (no_root_squash)" if root_squash == "no_root_squash" else "No (root_squash)"
-        )
-        sync_label = "Sync (safer)" if sync_mode == "sync" else "Async (faster)"
-        sec_labels = {
-            "sys": "Standard UID/GID",
-            "krb5": "Kerberos",
-            "krb5i": "Kerberos + integrity",
-            "krb5p": "Kerberos + encryption",
-        }
-        summary = (
-            f"Path:       {path}\n"
-            f"Access:     {host}\n"
-            f"Permission: {access_label}\n"
-            f"Admin:      {admin_label}\n"
-            f"Sync:       {sync_label}\n"
-            f"Security:   {sec_labels.get(sec, sec)}\n"
-            f"Options:    {','.join(options)}"
-        )
-        confirmed = await self.app.push_screen_wait(
-            ConfirmDialog(f"Update this export?\n\n{summary}", "Edit Share — Step 7/7")
-        )
-        if not confirmed:
-            return
-
-        # PATCH is a top-level merge on the server: clients are replaced
-        # wholesale; sync/security_mode ride in their share-level fields;
-        # path and fsid are left untouched (path is immutable server-side).
         patch: dict[str, Any] = {
-            "clients": [
-                {"pattern": host, "options": [access, root_squash, *current["extra_opts"]]}
-            ],
+            "clients": [{"pattern": host, "options": [access, root_squash, *extra]}],
             "sync": sync_mode,
             "security_mode": sec,
         }
@@ -571,10 +619,9 @@ class NFSScreen(XiNASAppMixin, Screen):
         except ControlPathError as exc:
             await self.app.push_screen_wait(ConfirmDialog(f"Failed: {exc}", "Error", ok_only=True))
             return
-        self.app.audit.log("nfs.update_export", path, "OK")
+        self.app.audit.log("nfs.update_export", answers["path"], "OK")
         await self.app.snapshots.record(
-            "share_modify",
-            diff_summary=f"Updated NFS share {path}",
+            "share_modify", diff_summary=f"Updated NFS share {answers['path']}"
         )
         self._load_exports()
 

--- a/xinas_menu/screens/nfs.py
+++ b/xinas_menu/screens/nfs.py
@@ -56,7 +56,15 @@ def _path_prefill(stored: str, mount_points: list[str]) -> tuple[str | None, str
     return _CUSTOM_PATH, stored
 
 
-def _share_summary(path, host, access, root_squash, sync_mode, sec, options) -> str:
+def _share_summary(
+    path: str,
+    host: str,
+    access: str,
+    root_squash: str,
+    sync_mode: str,
+    sec: str,
+    options: list[str],
+) -> str:
     access_label = "Read & Write" if access == "rw" else "Read Only"
     admin_label = "Yes (no_root_squash)" if root_squash == "no_root_squash" else "No (root_squash)"
     sync_label = "Sync (safer)" if sync_mode == "sync" else "Async (faster)"
@@ -232,8 +240,11 @@ class NFSScreen(XiNASAppMixin, Screen):
                     )
                 if sub is None:
                     return CANCEL
-                if sub is BACK or not sub:
-                    continue  # back to (or empty at) the who-select
+                if sub is BACK:
+                    continue  # back to the who-select
+                if not sub:
+                    self.app.notify("Host/network must not be empty.", severity="error")
+                    continue
                 return sub
 
         access_choices = [

--- a/xinas_menu/screens/nfs.py
+++ b/xinas_menu/screens/nfs.py
@@ -24,6 +24,37 @@ from xinas_menu.widgets.menu_list import MenuItem, NavigableMenu
 from xinas_menu.widgets.select_dialog import SelectDialog
 from xinas_menu.widgets.text_view import ScrollableTextView
 
+_HOST_CHOICES = [
+    "Everyone (any host on the network)",
+    "Specific network (e.g., 192.168.1.0/24)",
+    "Single host (by IP address)",
+]
+_CUSTOM_PATH = "Custom path…"
+
+
+def _host_prefill(host: str) -> tuple[str, str]:
+    """Map a stored export host to (selected radio label, "(Current:)" hint)."""
+    if host == "*":
+        return _HOST_CHOICES[0], "Everyone"
+    if "/" in host:
+        return _HOST_CHOICES[1], f"Network {host}"
+    return _HOST_CHOICES[2], f"Host {host}"
+
+
+def _path_prefill(stored: str, mount_points: list[str]) -> tuple[str | None, str]:
+    """Map a stored path to (SelectDialog pre-selection, custom-input default).
+
+    Returns ``(mount, "/mnt/data/")`` when *stored* is one of *mount_points*,
+    ``("Custom path…", stored)`` when it is a non-empty non-mount path, and
+    ``(None, "/mnt/data/")`` when *stored* is empty (first entry).
+    """
+    if not stored:
+        return None, "/mnt/data/"
+    if stored in mount_points:
+        return stored, "/mnt/data/"
+    return _CUSTOM_PATH, stored
+
+
 _MENU = [
     MenuItem("1", "Show NFS Exports"),
     MenuItem("2", "Add Share"),

--- a/xinas_menu/screens/nfs.py
+++ b/xinas_menu/screens/nfs.py
@@ -364,7 +364,8 @@ class NFSScreen(XiNASAppMixin, Screen):
             prompt = "Select authentication mode:"
             o = orig(answers)
             if o is not None:
-                prompt += f"\n(Current: {_SEC_LABELS.get(o.get('sec'), o.get('sec'))})"
+                cur_sec = o.get("sec", "sys")
+                prompt += f"\n(Current: {_SEC_LABELS.get(cur_sec, cur_sec)})"
             pick = await self.app.push_screen_wait(
                 SelectDialog(
                     sec_choices,

--- a/xinas_menu/screens/raid.py
+++ b/xinas_menu/screens/raid.py
@@ -425,12 +425,14 @@ class RAIDScreen(XiNASAppMixin, Screen):
         try:
             disk_rows = await _list_api_disks(self.app.control)
         except ControlPathError as exc:
-            await self.app.push_screen_wait(ConfirmDialog(f"Could not list disks.\n{exc}", "Error"))
+            await self.app.push_screen_wait(
+                ConfirmDialog(f"Could not list disks.\n{exc}", "Error", ok_only=True)
+            )
             return
         groups, nvme = _drive_groups(disk_rows)
         if not nvme:
             await self.app.push_screen_wait(
-                ConfirmDialog("No available NVMe drives found.", "Error")
+                ConfirmDialog("No available NVMe drives found.", "Error", ok_only=True)
             )
             return
 
@@ -474,7 +476,9 @@ class RAIDScreen(XiNASAppMixin, Screen):
             drives = selected
 
         if not drives:
-            await self.app.push_screen_wait(ConfirmDialog("No drives selected.", "Error"))
+            await self.app.push_screen_wait(
+                ConfirmDialog("No drives selected.", "Error", ok_only=True)
+            )
             return
 
         # Step 4: Strip size
@@ -599,7 +603,9 @@ class RAIDScreen(XiNASAppMixin, Screen):
             )
             return
         if error is not None:
-            await self.app.push_screen_wait(ConfirmDialog(f"Create failed.\n{error}", "Error"))
+            await self.app.push_screen_wait(
+                ConfirmDialog(f"Create failed.\n{error}", "Error", ok_only=True)
+            )
             return
         self.app.audit.log("raid.create", f"{name} RAID-{level} ({len(drives)} drives)", "OK")
         await self.app.snapshots.record(
@@ -617,7 +623,7 @@ class RAIDScreen(XiNASAppMixin, Screen):
             rows = await asyncio.to_thread(self.app.control.result, "/api/v1/arrays")
         except ControlPathError as exc:
             await self.app.push_screen_wait(
-                ConfirmDialog(f"No arrays available.\n{exc}", "Edit Array")
+                ConfirmDialog(f"No arrays available.\n{exc}", "Edit Array", ok_only=True)
             )
             return
 
@@ -625,7 +631,7 @@ class RAIDScreen(XiNASAppMixin, Screen):
         names = list(arrays.keys())
         if not names:
             await self.app.push_screen_wait(
-                ConfirmDialog("No RAID arrays configured.", "Edit Array")
+                ConfirmDialog("No RAID arrays configured.", "Edit Array", ok_only=True)
             )
             return
 
@@ -706,6 +712,7 @@ class RAIDScreen(XiNASAppMixin, Screen):
                             f"Invalid CPU list format: '{raw}'\n"
                             "Expected: comma-separated numbers or ranges (e.g. 0,2,4-7)",
                             "Error",
+                            ok_only=True,
                         )
                     )
                     return
@@ -780,7 +787,9 @@ class RAIDScreen(XiNASAppMixin, Screen):
                 patch_spec = {"tuning": {key: vtype(value)}}
             except (ValueError, TypeError):
                 await self.app.push_screen_wait(
-                    ConfirmDialog(f"Invalid value: expected {vtype.__name__}", "Error")
+                    ConfirmDialog(
+                        f"Invalid value: expected {vtype.__name__}", "Error", ok_only=True
+                    )
                 )
                 return
 
@@ -793,7 +802,9 @@ class RAIDScreen(XiNASAppMixin, Screen):
                 on_progress=self._task_progress(f"Edit {arr_name}"),
             )
         except ControlPathError as exc:
-            await self.app.push_screen_wait(ConfirmDialog(f"Edit failed.\n{exc}", "Error"))
+            await self.app.push_screen_wait(
+                ConfirmDialog(f"Edit failed.\n{exc}", "Error", ok_only=True)
+            )
             return
         self.app.audit.log("raid.modify", f"{arr_name} {key}={value}", "OK")
         await self.app.snapshots.record(
@@ -832,6 +843,7 @@ class RAIDScreen(XiNASAppMixin, Screen):
                 "Teardown stopped at this step. No cross-step rollback; the "
                 "failed task rolled itself back where supported.",
                 "Delete Array — Stopped",
+                ok_only=True,
             )
         )
 
@@ -851,7 +863,7 @@ class RAIDScreen(XiNASAppMixin, Screen):
             rows = await asyncio.to_thread(self.app.control.result, "/api/v1/arrays")
         except ControlPathError as exc:
             await self.app.push_screen_wait(
-                ConfirmDialog(f"No arrays available.\n{exc}", "Delete Array")
+                ConfirmDialog(f"No arrays available.\n{exc}", "Delete Array", ok_only=True)
             )
             return
 
@@ -859,7 +871,7 @@ class RAIDScreen(XiNASAppMixin, Screen):
         names = list(arrays.keys())
         if not names:
             await self.app.push_screen_wait(
-                ConfirmDialog("No RAID arrays configured.", "Delete Array")
+                ConfirmDialog("No RAID arrays configured.", "Delete Array", ok_only=True)
             )
             return
 

--- a/xinas_menu/screens/raid.py
+++ b/xinas_menu/screens/raid.py
@@ -36,6 +36,7 @@ from xinas_menu.widgets.menu_list import MenuItem, NavigableMenu
 from xinas_menu.widgets.select_dialog import SelectDialog
 from xinas_menu.widgets.task_wait_dialog import TaskWaitDialog
 from xinas_menu.widgets.text_view import ScrollableTextView
+from xinas_menu.widgets.wizard import BACK, CANCEL, WizardStep, run_wizard
 
 _ARRAY_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 _RAID_LEVELS = ["0", "1", "5", "6", "10", "50", "60"]
@@ -395,33 +396,9 @@ class RAIDScreen(XiNASAppMixin, Screen):
 
     @work(exclusive=True)
     async def _create_array_wizard(self) -> None:
-        """Multi-step wizard: name -> level -> drives -> strip -> group_size -> spare -> confirm."""
-        # Step 1: Array name (with validation)
-        while True:
-            name = await self.app.push_screen_wait(
-                InputDialog("Array name:", "Create Array — Step 1", placeholder="data0")
-            )
-            if not name:
-                return
-            if len(name) > 64:
-                self.app.notify("Array name must be 64 characters or fewer.", severity="error")
-                continue
-            if not _ARRAY_NAME_RE.match(name):
-                self.app.notify(
-                    "Array name must contain only letters, digits, hyphens, and underscores.",
-                    severity="error",
-                )
-                continue
-            break
-
-        # Step 2: RAID level
-        level = await self.app.push_screen_wait(
-            SelectDialog(_RAID_LEVELS, title="Create Array — Step 2", prompt="Select RAID level:")
-        )
-        if not level:
-            return
-
-        # Step 3: Select drives (grouped by NUMA/size; API disk listing)
+        """Create-array wizard with Back navigation."""
+        # Fetch disks up front so the drive + spare steps and their applies()
+        # predicates have their data; fail fast if there are no NVMe drives.
         try:
             disk_rows = await _list_api_disks(self.app.control)
         except ControlPathError as exc:
@@ -435,148 +412,247 @@ class RAIDScreen(XiNASAppMixin, Screen):
                 ConfirmDialog("No available NVMe drives found.", "Error", ok_only=True)
             )
             return
-
-        choices = list(groups.keys()) + ["Pick individual drives"]
-        group_choice = await self.app.push_screen_wait(
-            SelectDialog(choices, title="Create Array — Step 3", prompt="Select drive group:")
-        )
-        if not group_choice:
-            return
-
-        if group_choice == "Pick individual drives":
-            # Full-featured drive picker with filters, sort, detail view
-            selected = await self.app.push_screen_wait(
-                DrivePickerScreen(nvme, title="Create Array — Select Drives")
-            )
-            if not selected:
-                return
-            drives = selected
-        else:
-            # Show group drives in picker for review (all pre-selected)
-            group_drives = groups.get(group_choice, [])
-            group_names = {d if isinstance(d, str) else d.get("name", "") for d in group_drives}
-            # Filter full drive info for this group
-            group_drive_info: list[dict[str, Any]] = [
-                d for d in nvme if d.get("name") in group_names
-            ]
-            if not group_drive_info:
-                # Fallback: bare name strings, not the dict shape DrivePicker
-                # expects. Unreachable in practice (groups are built from
-                # nvme), kept as-is for behavior parity.
-                group_drive_info = group_drives  # pyright: ignore[reportAssignmentType]
-            selected = await self.app.push_screen_wait(
-                DrivePickerScreen(
-                    group_drive_info,
-                    title=f"Review — {group_choice}",
-                    preselected=group_names,
-                )
-            )
-            if not selected:
-                return
-            drives = selected
-
-        if not drives:
-            await self.app.push_screen_wait(
-                ConfirmDialog("No drives selected.", "Error", ok_only=True)
-            )
-            return
-
-        # Step 4: Strip size
-        strip = await self.app.push_screen_wait(
-            SelectDialog(
-                _STRIP_SIZES, title="Create Array — Step 4", prompt="Strip size (KB), default 64:"
-            )
-        )
-        if not strip:
-            strip = "64"
-
-        # The picker returns drive NAMES; the API spec references Disk ids.
         name_to_id = {d["name"]: d["id"] for d in nvme}
-        spec: dict[str, Any] = {
-            "name": name,
-            "level": f"raid{level}",
-            "member_disk_ids": [name_to_id.get(n, n) for n in drives],
-            "strip_size_kib": int(strip),
-        }
 
-        # Step 5: Group size (mandatory for RAID 50/60)
-        if level in ("50", "60"):
-            while True:
-                group_size = await self.app.push_screen_wait(
-                    InputDialog(
-                        "Group size (required for RAID 50/60):",
-                        "Create Array — Step 5",
-                        placeholder="4",
-                    )
-                )
-                if not group_size:
-                    return
-                try:
-                    gs = int(group_size)
-                    if gs <= 0:
-                        raise ValueError
-                except ValueError:
-                    self.app.notify("Group size must be a positive integer.", severity="error")
-                    continue
-                spec["group_size"] = gs
-                break
-
-        # Step 6: Spare pool (optional) — pick from existing pools (GET
-        # /api/v1/pools, S9 T11); the pool's drives become the API
-        # spec's spare_disk_ids (the executor provisions xnsp_<name>).
         _NONE_POOL = "(none)"
-        spare_pool_label = ""
         try:
             p_rows = await asyncio.to_thread(self.app.control.result, "/api/v1/pools")
         except ControlPathError:
             p_rows = []
         pools = _pools_by_name(p_rows)
-        if pools:
-            pool_choices = [_NONE_POOL] + sorted(pools.keys())
-            sparepool = await self.app.push_screen_wait(
+
+        async def name_step(answers, allow_back, step_no):
+            default = answers.get("name", "")
+            while True:
+                name = await self.app.push_screen_wait(
+                    InputDialog(
+                        "Array name:",
+                        f"Create Array — Step {step_no}",
+                        default=default,
+                        placeholder="data0",
+                        allow_back=allow_back,
+                    )
+                )
+                if name is None:
+                    return CANCEL
+                if name is BACK:
+                    return BACK
+                if len(name) > 64:
+                    self.app.notify("Array name must be 64 characters or fewer.", severity="error")
+                    default = name
+                    continue
+                if not _ARRAY_NAME_RE.match(name):
+                    self.app.notify(
+                        "Array name must contain only letters, digits, hyphens, and underscores.",
+                        severity="error",
+                    )
+                    default = name
+                    continue
+                return name
+
+        async def level_step(answers, allow_back, step_no):
+            pick = await self.app.push_screen_wait(
                 SelectDialog(
-                    pool_choices,
-                    title="Create Array — Spare Pool",
-                    prompt="Select spare pool (or none):",
+                    _RAID_LEVELS,
+                    title=f"Create Array — Step {step_no}",
+                    prompt="Select RAID level:",
+                    selected=answers.get("level"),
+                    allow_back=allow_back,
                 )
             )
-            if sparepool is None:
-                return
-            if sparepool != _NONE_POOL:
-                path_to_id = {d["device_path"]: d["id"] for d in disk_rows}
-                spare_ids = [
-                    path_to_id.get(p, p.rsplit("/", 1)[-1])
-                    for p in _pool_drive_paths(pools.get(sparepool, {}))
-                ]
-                if spare_ids:
-                    spec["spare_disk_ids"] = spare_ids
-                    spare_pool_label = f"{sparepool} ({len(spare_ids)} drive(s))"
-                else:
-                    self.app.notify(
-                        f"Pool '{sparepool}' has no drives — skipping spare assignment.",
-                        severity="warning",
+            if pick is None:
+                return CANCEL
+            if pick is BACK:
+                return BACK
+            return pick
+
+        async def drives_step(answers, allow_back, step_no):
+            prior = answers.get("drives")
+            if prior:
+                # Re-entry: jump straight to the picker with the prior selection.
+                selected = await self.app.push_screen_wait(
+                    DrivePickerScreen(
+                        nvme,
+                        title="Create Array — Select Drives",
+                        preselected=prior,
+                        allow_back=allow_back,
                     )
-        # If no pools exist, skip silently (no spare pool assigned)
+                )
+                if selected is None:
+                    return CANCEL
+                if selected is BACK:
+                    return BACK
+                return selected
+            while True:
+                choices = list(groups.keys()) + ["Pick individual drives"]
+                group_choice = await self.app.push_screen_wait(
+                    SelectDialog(
+                        choices,
+                        title=f"Create Array — Step {step_no}",
+                        prompt="Select drive group:",
+                        allow_back=allow_back,
+                    )
+                )
+                if group_choice is None:
+                    return CANCEL
+                if group_choice is BACK:
+                    return BACK
+                if group_choice == "Pick individual drives":
+                    selected = await self.app.push_screen_wait(
+                        DrivePickerScreen(
+                            nvme, title="Create Array — Select Drives", allow_back=True
+                        )
+                    )
+                else:
+                    group_drives = groups.get(group_choice, [])
+                    group_names = {
+                        d if isinstance(d, str) else d.get("name", "") for d in group_drives
+                    }
+                    group_drive_info: list[dict[str, Any]] = [
+                        d for d in nvme if d.get("name") in group_names
+                    ] or group_drives  # pyright: ignore[reportAssignmentType]
+                    selected = await self.app.push_screen_wait(
+                        DrivePickerScreen(
+                            group_drive_info,
+                            title=f"Review — {group_choice}",
+                            preselected=group_names,
+                            allow_back=True,
+                        )
+                    )
+                if selected is None:
+                    return CANCEL
+                if selected is BACK:
+                    continue  # back to the group select
+                if not selected:
+                    await self.app.push_screen_wait(
+                        ConfirmDialog("No drives selected.", "Error", ok_only=True)
+                    )
+                    continue
+                return selected
 
-        # Confirm
-        summary = (
-            f"Name:       {name}\n"
-            f"Level:      RAID-{level}\n"
-            f"Drives:     {', '.join(drives)}\n"
-            f"Strip Size: {strip} KB"
-        )
-        if "group_size" in spec:
-            summary += f"\nGroup Size: {spec['group_size']}"
-        if spare_pool_label:
-            summary += f"\nSpare Pool: {spare_pool_label}"
+        async def strip_step(answers, allow_back, step_no):
+            pick = await self.app.push_screen_wait(
+                SelectDialog(
+                    _STRIP_SIZES,
+                    title=f"Create Array — Step {step_no}",
+                    prompt="Strip size (KB), default 64:",
+                    selected=answers.get("strip", "64"),
+                    allow_back=allow_back,
+                )
+            )
+            if pick is None:
+                return CANCEL
+            if pick is BACK:
+                return BACK
+            return pick
 
-        confirmed = await self.app.push_screen_wait(
-            ConfirmDialog(f"Create this RAID array?\n\n{summary}", "Confirm Create")
-        )
-        if not confirmed:
+        async def group_size_step(answers, allow_back, step_no):
+            default = str(answers.get("group_size", ""))
+            while True:
+                value = await self.app.push_screen_wait(
+                    InputDialog(
+                        "Group size (required for RAID 50/60):",
+                        f"Create Array — Step {step_no}",
+                        default=default,
+                        placeholder="4",
+                        allow_back=allow_back,
+                    )
+                )
+                if value is None:
+                    return CANCEL
+                if value is BACK:
+                    return BACK
+                try:
+                    gs = int(value)
+                    if gs <= 0:
+                        raise ValueError
+                except ValueError:
+                    self.app.notify("Group size must be a positive integer.", severity="error")
+                    default = value
+                    continue
+                return gs
+
+        async def spare_step(answers, allow_back, step_no):
+            pool_choices = [_NONE_POOL] + sorted(pools.keys())
+            pick = await self.app.push_screen_wait(
+                SelectDialog(
+                    pool_choices,
+                    title=f"Create Array — Step {step_no}",
+                    prompt="Select spare pool (or none):",
+                    selected=answers.get("spare", _NONE_POOL),
+                    allow_back=allow_back,
+                )
+            )
+            if pick is None:
+                return CANCEL
+            if pick is BACK:
+                return BACK
+            return pick
+
+        async def confirm_step(answers, allow_back, step_no):
+            summary = (
+                f"Name:       {answers['name']}\n"
+                f"Level:      RAID-{answers['level']}\n"
+                f"Drives:     {', '.join(answers['drives'])}\n"
+                f"Strip Size: {answers['strip']} KB"
+            )
+            if answers["level"] in ("50", "60"):
+                summary += f"\nGroup Size: {answers.get('group_size')}"
+            spare = answers.get("spare", _NONE_POOL)
+            if spare != _NONE_POOL:
+                summary += f"\nSpare Pool: {spare}"
+            result = await self.app.push_screen_wait(
+                ConfirmDialog(
+                    f"Create this RAID array?\n\n{summary}", "Confirm Create", allow_back=allow_back
+                )
+            )
+            if result is BACK:
+                return BACK
+            return True if result is True else CANCEL
+
+        steps = [
+            WizardStep(key="name", run=name_step),
+            WizardStep(key="level", run=level_step),
+            WizardStep(key="drives", run=drives_step),
+            WizardStep(key="strip", run=strip_step),
+            WizardStep(
+                key="group_size",
+                run=group_size_step,
+                applies=lambda a: a.get("level") in ("50", "60"),
+            ),
+            WizardStep(key="spare", run=spare_step, applies=lambda a: bool(pools)),
+            WizardStep(key="confirmed", run=confirm_step),
+        ]
+        answers = await run_wizard(steps)
+        if answers is None:
             return
 
-        dialog = TaskWaitDialog(f"Creating RAID array '{name}'…", "Create Array")
+        # Assemble the API spec from the collected answers.
+        drives = answers["drives"]
+        spec: dict[str, Any] = {
+            "name": answers["name"],
+            "level": f"raid{answers['level']}",
+            "member_disk_ids": [name_to_id.get(n, n) for n in drives],
+            "strip_size_kib": int(answers["strip"]),
+        }
+        if answers["level"] in ("50", "60"):
+            spec["group_size"] = int(answers["group_size"])
+        spare = answers.get("spare", _NONE_POOL)
+        if spare != _NONE_POOL:
+            path_to_id = {d["device_path"]: d["id"] for d in disk_rows}
+            spare_ids = [
+                path_to_id.get(p, p.rsplit("/", 1)[-1])
+                for p in _pool_drive_paths(pools.get(spare, {}))
+            ]
+            if spare_ids:
+                spec["spare_disk_ids"] = spare_ids
+            else:
+                self.app.notify(
+                    f"Pool '{spare}' has no drives — skipping spare assignment.",
+                    severity="warning",
+                )
+
+        dialog = TaskWaitDialog(f"Creating RAID array '{answers['name']}'…", "Create Array")
         self.app.push_screen(dialog)
         cancelled = False
         error: ControlPathError | None = None
@@ -607,10 +683,12 @@ class RAIDScreen(XiNASAppMixin, Screen):
                 ConfirmDialog(f"Create failed.\n{error}", "Error", ok_only=True)
             )
             return
-        self.app.audit.log("raid.create", f"{name} RAID-{level} ({len(drives)} drives)", "OK")
+        self.app.audit.log(
+            "raid.create", f"{answers['name']} RAID-{answers['level']} ({len(drives)} drives)", "OK"
+        )
         await self.app.snapshots.record(
             "raid_create",
-            diff_summary=f"Created RAID-{level} array '{name}' with {len(drives)} drives",
+            diff_summary=f"Created RAID-{answers['level']} array '{answers['name']}' with {len(drives)} drives",
         )
         self._show_quick()
 

--- a/xinas_menu/widgets/confirm_dialog.py
+++ b/xinas_menu/widgets/confirm_dialog.py
@@ -7,8 +7,10 @@ from textual.binding import Binding
 from textual.screen import ModalScreen
 from textual.widgets import Button, Label
 
+from xinas_menu.widgets.wizard import BACK
 
-class ConfirmDialog(ModalScreen[bool]):
+
+class ConfirmDialog(ModalScreen["bool | object"]):
     """Modal confirmation or informational dialog.
 
     When *ok_only* is ``False`` (default) the dialog shows **Yes / No**
@@ -32,6 +34,7 @@ class ConfirmDialog(ModalScreen[bool]):
 
     BINDINGS = [
         Binding("escape", "dismiss_no", "Cancel", show=False),
+        Binding("left", "back", "Back", show=False),
         Binding("y", "dismiss_yes", "Yes", show=False),
         Binding("n", "dismiss_no", "No", show=False),
         Binding("enter", "dismiss_ok", "OK", show=False),
@@ -47,6 +50,7 @@ class ConfirmDialog(ModalScreen[bool]):
         yes_label: str | None = None,
         no_label: str | None = None,
         copy_text: str | None = None,
+        allow_back: bool = False,
     ) -> None:
         super().__init__()
         self._message = message
@@ -55,6 +59,7 @@ class ConfirmDialog(ModalScreen[bool]):
         self._yes_label = yes_label or "Yes [y]"
         self._no_label = no_label or "No [n]"
         self._copy_text = copy_text if copy_text is not None else message
+        self._allow_back = allow_back
 
     def compose(self) -> ComposeResult:
         from textual.containers import Horizontal, Vertical
@@ -63,6 +68,8 @@ class ConfirmDialog(ModalScreen[bool]):
             yield Label(self._title, id="dialog-title")
             yield Label(self._message, id="dialog-body", markup=False)
             with Horizontal(id="dialog-buttons"):
+                if self._allow_back:
+                    yield Button("Back [←]", variant="default", id="btn-back", classes="dialog-btn")
                 if self._ok_only:
                     yield Button("OK", variant="primary", id="btn-ok", classes="dialog-btn")
                 else:
@@ -74,10 +81,16 @@ class ConfirmDialog(ModalScreen[bool]):
                     )
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id == "btn-ok":
+        if event.button.id == "btn-back":
+            self.action_back()
+        elif event.button.id == "btn-ok":
             self.dismiss(True)
         else:
             self.dismiss(event.button.id == "btn-yes")
+
+    def action_back(self) -> None:
+        if self._allow_back:
+            self.dismiss(BACK)
 
     def action_dismiss_yes(self) -> None:
         if not self._ok_only:

--- a/xinas_menu/widgets/confirm_dialog.py
+++ b/xinas_menu/widgets/confirm_dialog.py
@@ -10,7 +10,7 @@ from textual.widgets import Button, Label
 from xinas_menu.widgets.wizard import BACK
 
 
-class ConfirmDialog(ModalScreen["bool | object"]):
+class ConfirmDialog(ModalScreen["bool"]):
     """Modal confirmation or informational dialog.
 
     When *ok_only* is ``False`` (default) the dialog shows **Yes / No**
@@ -90,7 +90,7 @@ class ConfirmDialog(ModalScreen["bool | object"]):
 
     def action_back(self) -> None:
         if self._allow_back:
-            self.dismiss(BACK)
+            self.dismiss(BACK)  # pyright: ignore[reportArgumentType]
 
     def action_dismiss_yes(self) -> None:
         if not self._ok_only:

--- a/xinas_menu/widgets/drive_picker.py
+++ b/xinas_menu/widgets/drive_picker.py
@@ -158,9 +158,9 @@ class DrivePickerScreen(ModalScreen["list[str] | object | None"]):
             yield Static("", id="picker-filter-bar")
             yield DataTable(id="picker-table")
             with Horizontal(id="picker-buttons"):
-                yield Button("OK [Enter]", variant="primary", id="btn-ok")
                 if self._allow_back:
                     yield Button("Back [b]", variant="default", id="btn-back")
+                yield Button("OK [Enter]", variant="primary", id="btn-ok")
                 yield Button("Cancel [Esc]", variant="default", id="btn-cancel")
         yield Static("", id="picker-detail")
 

--- a/xinas_menu/widgets/drive_picker.py
+++ b/xinas_menu/widgets/drive_picker.py
@@ -35,7 +35,7 @@ def _fmt_size(size_bytes: float) -> str:
     return f"{size_bytes:.1f} EB"
 
 
-class DrivePickerScreen(ModalScreen["list[str] | object | None"]):
+class DrivePickerScreen(ModalScreen["list[str] | None"]):
     """Full-featured drive picker with filtering, sorting, and multi-select.
 
     Returns list of selected drive names, :data:`BACK` if the user requested
@@ -394,7 +394,7 @@ class DrivePickerScreen(ModalScreen["list[str] | object | None"]):
 
     def action_back(self) -> None:
         if self._allow_back:
-            self.dismiss(BACK)
+            self.dismiss(BACK)  # pyright: ignore[reportArgumentType]
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "btn-ok":

--- a/xinas_menu/widgets/drive_picker.py
+++ b/xinas_menu/widgets/drive_picker.py
@@ -19,6 +19,8 @@ from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Button, DataTable, Label, Static
 
+from xinas_menu.widgets.wizard import BACK
+
 _log = logging.getLogger(__name__)
 
 
@@ -33,14 +35,16 @@ def _fmt_size(size_bytes: float) -> str:
     return f"{size_bytes:.1f} EB"
 
 
-class DrivePickerScreen(ModalScreen[list[str] | None]):
+class DrivePickerScreen(ModalScreen["list[str] | object | None"]):
     """Full-featured drive picker with filtering, sorting, and multi-select.
 
-    Returns list of selected drive names, or None if cancelled.
+    Returns list of selected drive names, :data:`BACK` if the user requested
+    back-navigation, or None if cancelled.
     """
 
     BINDINGS = [
         Binding("escape", "cancel", "Cancel", show=True, key_display="Esc"),
+        Binding("b", "back", "Back", show=True),
         Binding("space", "toggle_select", "Toggle", show=True),
         Binding("a", "toggle_all", "All", show=True),
         Binding("s", "cycle_sort", "Sort", show=True),
@@ -132,6 +136,8 @@ class DrivePickerScreen(ModalScreen[list[str] | None]):
         drives: list[dict[str, Any]],
         title: str = "Select Drives",
         preselected: set[str] | list[str] | None = None,
+        *,
+        allow_back: bool = False,
     ) -> None:
         super().__init__()
         self._all_drives = list(drives)
@@ -143,6 +149,7 @@ class DrivePickerScreen(ModalScreen[list[str] | None]):
         self._filter_numa: int | None = None
         self._filter_size_min: int = 0
         self._filter_size_max: int = 0
+        self._allow_back = allow_back
 
     def compose(self) -> ComposeResult:
         with Vertical(id="picker-container"):
@@ -152,6 +159,8 @@ class DrivePickerScreen(ModalScreen[list[str] | None]):
             yield DataTable(id="picker-table")
             with Horizontal(id="picker-buttons"):
                 yield Button("OK [Enter]", variant="primary", id="btn-ok")
+                if self._allow_back:
+                    yield Button("Back [b]", variant="default", id="btn-back")
                 yield Button("Cancel [Esc]", variant="default", id="btn-cancel")
         yield Static("", id="picker-detail")
 
@@ -383,8 +392,14 @@ class DrivePickerScreen(ModalScreen[list[str] | None]):
     def action_cancel(self) -> None:
         self.dismiss(None)
 
+    def action_back(self) -> None:
+        if self._allow_back:
+            self.dismiss(BACK)
+
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "btn-ok":
             self.action_confirm()
+        elif event.button.id == "btn-back":
+            self.action_back()
         else:
             self.action_cancel()

--- a/xinas_menu/widgets/input_dialog.py
+++ b/xinas_menu/widgets/input_dialog.py
@@ -10,7 +10,7 @@ from textual.widgets import Button, Input, Label
 from xinas_menu.widgets.wizard import BACK
 
 
-class InputDialog(ModalScreen["str | object | None"]):
+class InputDialog(ModalScreen["str | None"]):
     """Modal text (or password) input dialog.
 
     Returns the entered string, :data:`BACK` if the user requested
@@ -75,4 +75,4 @@ class InputDialog(ModalScreen["str | object | None"]):
 
     def _dismiss_back(self) -> None:
         if self._allow_back:
-            self.dismiss(BACK)
+            self.dismiss(BACK)  # pyright: ignore[reportArgumentType]

--- a/xinas_menu/widgets/input_dialog.py
+++ b/xinas_menu/widgets/input_dialog.py
@@ -7,11 +7,14 @@ from textual.binding import Binding
 from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Label
 
+from xinas_menu.widgets.wizard import BACK
 
-class InputDialog(ModalScreen[str | None]):
+
+class InputDialog(ModalScreen["str | object | None"]):
     """Modal text (or password) input dialog.
 
-    Returns the entered string, or None if cancelled.
+    Returns the entered string, :data:`BACK` if the user requested
+    back-navigation, or None if cancelled.
     """
 
     BINDINGS = [
@@ -25,6 +28,8 @@ class InputDialog(ModalScreen[str | None]):
         default: str = "",
         password: bool = False,
         placeholder: str = "",
+        *,
+        allow_back: bool = False,
     ) -> None:
         super().__init__()
         self._prompt = prompt
@@ -32,6 +37,7 @@ class InputDialog(ModalScreen[str | None]):
         self._default = default
         self._password = password
         self._placeholder = placeholder
+        self._allow_back = allow_back
 
     def compose(self) -> ComposeResult:
         from textual.containers import Horizontal, Vertical
@@ -47,12 +53,16 @@ class InputDialog(ModalScreen[str | None]):
             )
             with Horizontal(id="dialog-buttons"):
                 yield Button("OK [Enter]", variant="primary", id="btn-ok")
+                if self._allow_back:
+                    yield Button("Back", variant="default", id="btn-back")
                 yield Button("Cancel [Esc]", variant="default", id="btn-cancel")
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "btn-ok":
             inp = self.query_one("#dialog-input", Input)
             self.dismiss(inp.value)
+        elif event.button.id == "btn-back":
+            self._dismiss_back()
         else:
             self.dismiss(None)
 
@@ -62,3 +72,7 @@ class InputDialog(ModalScreen[str | None]):
 
     def action_cancel(self) -> None:
         self.dismiss(None)
+
+    def _dismiss_back(self) -> None:
+        if self._allow_back:
+            self.dismiss(BACK)

--- a/xinas_menu/widgets/input_dialog.py
+++ b/xinas_menu/widgets/input_dialog.py
@@ -52,9 +52,9 @@ class InputDialog(ModalScreen["str | object | None"]):
                 id="dialog-input",
             )
             with Horizontal(id="dialog-buttons"):
-                yield Button("OK [Enter]", variant="primary", id="btn-ok")
                 if self._allow_back:
                     yield Button("Back", variant="default", id="btn-back")
+                yield Button("OK [Enter]", variant="primary", id="btn-ok")
                 yield Button("Cancel [Esc]", variant="default", id="btn-cancel")
 
     def on_button_pressed(self, event: Button.Pressed) -> None:

--- a/xinas_menu/widgets/select_dialog.py
+++ b/xinas_menu/widgets/select_dialog.py
@@ -11,7 +11,7 @@ from textual.widgets.option_list import Option
 from xinas_menu.widgets.wizard import BACK
 
 
-class SelectDialog(ModalScreen["str | object | None"]):
+class SelectDialog(ModalScreen["str | None"]):
     """Modal dialog that lets the user pick one item from a list.
 
     Returns the selected string value, :data:`BACK` if the user requested
@@ -74,4 +74,4 @@ class SelectDialog(ModalScreen["str | object | None"]):
 
     def action_back(self) -> None:
         if self._allow_back:
-            self.dismiss(BACK)
+            self.dismiss(BACK)  # pyright: ignore[reportArgumentType]

--- a/xinas_menu/widgets/select_dialog.py
+++ b/xinas_menu/widgets/select_dialog.py
@@ -8,15 +8,19 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Label, OptionList
 from textual.widgets.option_list import Option
 
+from xinas_menu.widgets.wizard import BACK
 
-class SelectDialog(ModalScreen[str | None]):
+
+class SelectDialog(ModalScreen["str | object | None"]):
     """Modal dialog that lets the user pick one item from a list.
 
-    Returns the selected string value, or None if cancelled.
+    Returns the selected string value, :data:`BACK` if the user requested
+    back-navigation, or None if cancelled.
     """
 
     BINDINGS = [
         Binding("escape", "cancel", "Cancel", show=False),
+        Binding("left", "back", "Back", show=False),
     ]
 
     def __init__(
@@ -24,11 +28,16 @@ class SelectDialog(ModalScreen[str | None]):
         items: list[str],
         title: str = "Select",
         prompt: str = "",
+        *,
+        selected: str | None = None,
+        allow_back: bool = False,
     ) -> None:
         super().__init__()
         self._items = items
         self._title = title
         self._prompt = prompt
+        self._selected = selected
+        self._allow_back = allow_back
 
     def compose(self) -> ComposeResult:
         from textual.containers import Horizontal, Vertical
@@ -42,13 +51,27 @@ class SelectDialog(ModalScreen[str | None]):
                 id="dialog-select",
             )
             with Horizontal(id="dialog-buttons"):
+                if self._allow_back:
+                    yield Button("Back [←]", variant="default", id="btn-back")
                 yield Button("Cancel [Esc]", variant="default", id="btn-cancel")
+
+    def on_mount(self) -> None:
+        if self._selected is not None and self._selected in self._items:
+            option_list = self.query_one("#dialog-select", OptionList)
+            option_list.highlighted = self._items.index(self._selected)
 
     def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
         self.dismiss(str(event.option.prompt))
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        self.dismiss(None)
+        if event.button.id == "btn-back":
+            self.action_back()
+        else:
+            self.dismiss(None)
 
     def action_cancel(self) -> None:
         self.dismiss(None)
+
+    def action_back(self) -> None:
+        if self._allow_back:
+            self.dismiss(BACK)

--- a/xinas_menu/widgets/wizard.py
+++ b/xinas_menu/widgets/wizard.py
@@ -1,0 +1,88 @@
+# xinas_menu/widgets/wizard.py
+"""Generic back-navigable wizard driver for the Textual management wizards.
+
+A wizard is an ordered list of :class:`WizardStep`. Each step's ``run``
+coroutine drives one logical step (which may internally show more than one
+dialog) and returns the step's answer value, or one of the sentinels
+:data:`BACK` / :data:`CANCEL`.
+
+``run_wizard`` owns the current index, back navigation, and the accumulated
+answers dict. It has no Textual dependency, so it is unit-tested headless with
+fake steps.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class _Sentinel:
+    __slots__ = ("_name",)
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return self._name
+
+
+#: Returned by a step's ``run`` to go back to the previous applicable step.
+BACK = _Sentinel("BACK")
+#: Returned by a step's ``run`` to abort the whole wizard.
+CANCEL = _Sentinel("CANCEL")
+
+#: ``run(answers, allow_back, step_no) -> value | BACK | CANCEL``
+StepRun = Callable[[dict, bool, int], Awaitable[Any]]
+
+
+@dataclass
+class WizardStep:
+    key: str
+    run: StepRun
+    applies: Callable[[dict], bool] = field(default=lambda answers: True)
+
+
+def _applicable(steps: list[WizardStep], answers: dict) -> list[int]:
+    return [i for i, s in enumerate(steps) if s.applies(answers)]
+
+
+def _has_prior_applicable(steps: list[WizardStep], idx: int, answers: dict) -> bool:
+    return any(i < idx for i in _applicable(steps, answers))
+
+
+def _prev_applicable(steps: list[WizardStep], idx: int, answers: dict) -> int:
+    prior = [i for i in _applicable(steps, answers) if i < idx]
+    return prior[-1] if prior else idx  # stay put if nothing earlier applies
+
+
+def _display_number(steps: list[WizardStep], idx: int, answers: dict) -> int:
+    return sum(1 for i in _applicable(steps, answers) if i <= idx)
+
+
+async def run_wizard(steps: list[WizardStep], initial: dict | None = None) -> dict | None:
+    """Drive ``steps`` with Back/Cancel navigation.
+
+    Returns the accumulated answers dict when the user advances past the last
+    step, or ``None`` if any step returns :data:`CANCEL`. ``initial`` seeds the
+    answers dict (used by Edit to pre-fill from the current share).
+    """
+    answers: dict = dict(initial or {})
+    idx = 0
+    while idx < len(steps):
+        step = steps[idx]
+        if not step.applies(answers):
+            idx += 1
+            continue
+        allow_back = _has_prior_applicable(steps, idx, answers)
+        step_no = _display_number(steps, idx, answers)
+        result = await step.run(answers, allow_back, step_no)
+        if result is CANCEL:
+            return None
+        if result is BACK:
+            idx = _prev_applicable(steps, idx, answers)
+            continue
+        answers[step.key] = result
+        idx += 1
+    return answers

--- a/xinas_menu/widgets/wizard.py
+++ b/xinas_menu/widgets/wizard.py
@@ -67,12 +67,17 @@ async def run_wizard(steps: list[WizardStep], initial: dict | None = None) -> di
     Returns the accumulated answers dict when the user advances past the last
     step, or ``None`` if any step returns :data:`CANCEL`. ``initial`` seeds the
     answers dict (used by Edit to pre-fill from the current share).
+
+    The returned dict never contains a key for a step that is inapplicable on
+    the taken path (such keys are dropped when the step is skipped); answers for
+    still-applicable later steps are retained across Back.
     """
     answers: dict = dict(initial or {})
     idx = 0
     while idx < len(steps):
         step = steps[idx]
         if not step.applies(answers):
+            answers.pop(step.key, None)  # forget a now-inapplicable step's stale answer
             idx += 1
             continue
         allow_back = _has_prior_applicable(steps, idx, answers)


### PR DESCRIPTION
## Summary

Adds a state-preserving **Back** button to the three day-2 Textual TUI wizards — Add Share, Edit Share, and Create Array — so an operator who mis-answers an early step can go back and fix it instead of cancelling and starting over. (Resolves the "here should be a button to go back" request on the Add Share screen.)

- **New headless wizard driver** ([xinas_menu/widgets/wizard.py](xinas_menu/widgets/wizard.py)): `run_wizard(steps)` with `BACK`/`CANCEL` sentinels, a `WizardStep` model with an `applies(answers)` predicate for conditional steps, and Back navigation that skips inapplicable steps and prunes their stale answers. Fully unit-tested, zero Textual dependency.
- **Dialog `allow_back`**: `SelectDialog`/`InputDialog`/`ConfirmDialog`/`DrivePickerScreen` gain a Back button (dismisses with `BACK`; `Esc` still Cancels; `←` on Select/Confirm, `b` on the drive picker), plus `SelectDialog` pre-selection so prior answers are remembered.
- **Wizards rewritten onto the driver**: Add/Edit Share share a `_access_steps()` builder; Create Array uses conditional steps (group-size for RAID 50/60, spare-pool when pools exist). Answers are remembered across Back; Back can cross from the first access step back to the path/name step; the confirm step can go Back to revise. Dispatch (API calls, audit, snapshots) is behavior-identical to before.
- **Reconciled with the recent `ok_only` dialog-convention fix** on main: informational/error dialogs in the rewritten wizards stay OK-only; Yes/No + Back is reserved for the genuine confirm steps.
- **Docs**: `fs-shares-management-spec.md` and `raid-management-spec.md` updated to describe the wizard-navigation model. Python-TUI-only change — **no `Requires-Rebuild:` trailer**.

Two intentional, documented behavior refinements: an empty host/network input now re-prompts (instead of aborting the wizard), and `Esc` on the RAID strip-size step now cancels like every other step (the dialog pre-selects `64`, so Enter still yields 64).

## Test Plan

- [x] `pytest` — **142 passed** (new suites: `test_wizard_driver.py`, `test_nfs_wizard_helpers.py`, `test_wizard_dialogs.py`).
- [x] `ruff check` / `ruff format --check` — clean.
- [x] **Live Textual pilot smoke** (textual 8.2.8): Back button + `←`/`b` dismiss with `BACK`, `Esc` cancels to `None`, `SelectDialog` pre-highlight works, `allow_back=False` renders no Back button.
- [x] Rebased onto current `main`; informational-dialog `ok_only` reconciliation verified; specs retain both the new wizard-navigation content and main's dialog-convention sections.
- [ ] Manual walk-through in a live deployment (drive Add Share / Create Array, press Back at each step, confirm prior answers are remembered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)