### PR TITLE
fix(tui): drop retired xinas-mcp from the service status board

### DIFF
--- a/xinas_menu/__main__.py
+++ b/xinas_menu/__main__.py
@@ -65,7 +65,7 @@ def _print_status() -> None:
     print(f"OS:        {platform.system()} {platform.release()}")
 
     ctl = ServiceController()
-    for svc in ("xiraid-server", "nfs-server", "xinas-nfs-helper", "xinas-mcp"):
+    for svc in ("xiraid-server", "nfs-server", "xinas-nfs-helper", "xinas-api", "xinas-agent"):
         st = ctl.state(svc)
         sym = "●" if st.is_active else "○"
         print(f"  {sym} {svc:<30} {st.active}")

--- a/xinas_menu/screens/system_status.py
+++ b/xinas_menu/screens/system_status.py
@@ -247,7 +247,7 @@ def _build_fallback_status() -> str:
         from xinas_menu.utils.service_ctl import ServiceController
 
         ctl = ServiceController()
-        for svc in ("xiraid-server", "nfs-server", "xinas-nfs-helper", "xinas-mcp"):
+        for svc in ("xiraid-server", "nfs-server", "xinas-nfs-helper", "xinas-api", "xinas-agent"):
             st = ctl.state(svc)
             if st.is_active:
                 lines.append(f"  {GRN}●{NC} {svc:<28} {GRN}{st.active}{NC}")


### PR DESCRIPTION
## Problem
The `xinas_menu` TUI service board — both the startup banner (`__main__.py`) and the system-status screen (`screens/system_status.py`) — iterated a hardcoded service tuple that still included **`xinas-mcp`**.

But the standalone `xinas-mcp.service` is **deliberately removed at install time** by the `xinas_mcp` role (its README: *"stops/disables/removes the legacy standalone `xinas-mcp.service`"*). MCP now runs on-demand over **Streamable HTTP** via `xinas-api`'s `/mcp` endpoint (ADR-0010), bridged locally by `xinas-mcp-stdio`.

Result: `ServiceController.state("xinas-mcp")` returns `inactive`, so the board painted it **red "inactive" on every healthy install** — a persistent false alarm that reads as "something failed" when nothing has.

## Fix
Replace `xinas-mcp` in both display tuples with the **real control-plane daemons** that actually run:
- `xinas-api` — serves the MCP surface (`/mcp`) plus the REST/state API
- `xinas-agent` — the privileged observation/execution daemon (previously unmonitored on this board)

## Verification
- `py_compile` clean on both files.
- Applied live on a v3.2.1 node — board now shows all five services green:

```
● xiraid-server    active/running
● nfs-server       active/exited
● xinas-nfs-helper active/running
● xinas-api        active/running
● xinas-agent      active/running
```

## Scope / follow-up
This PR fixes only the **cosmetic status-board** false alarm. Separate (functional) references to the retired unit remain and will be handled in a follow-up: `screens/mcp.py` (`systemctl restart xinas-mcp` after a config write, lines 88 & 305) and `screens/quick_actions.py:42`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)