### PR TITLE
fix(tui): merge control-path audit trail into View Audit Log

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ spec dump — every doc belongs to an area.
 |-----------|----------------|
 | `docs/Installer/` | Install-time / Ansible-driven behavior: `spec.md` (preset + playbook + role map), `network-spec.md`, `raid-spec.md`, `fs-exports-spec.md`, `uninstall-spec.md` (uninstaller contract), `update-spec.md` (GitHub-Releases-only install + update contract) |
 | `docs/Storage/` | Day-2 storage management surface (TUI screens, helpers, gRPC): `raid-management-spec.md`, `fs-shares-management-spec.md` |
-| `docs/Management/` | Day-2 System→Management submenu screens: `user-management-spec.md` (User Management TUI — accounts, lock status, groups, quota) |
+| `docs/Management/` | Day-2 System management screens: `user-management-spec.md` (User Management TUI — accounts, lock status, groups, quota), `audit-log-spec.md` (View Audit Log — merges the local TUI trail with the control-path `GET /audit` trail) |
 | `docs/MCP/` | MCP server spec set: `REQUIREMENTS.md`, `spec-core.md`, `spec-tools.md`, `spec-middleware.md`, `spec-config-history.md`, `spec-mail.md`, `spec-nfs-helper.md`, `spec-os.md`, `spec-server.md`, `modules.md` |
 | `docs/Network/` | Cross-cutting network management (netplan ownership, PBR, day-2 IP edits): `spec-network-management.md` |
 | `docs/Notifications/` | Email / alerting pipelines (xiNAS SMTP + xiRAID sendmail): `spec-email-notifications.md` |

--- a/docs/Management/audit-log-spec.md
+++ b/docs/Management/audit-log-spec.md
@@ -1,0 +1,86 @@
+# View Audit Log — merged audit trail (spec)
+
+**Owns:** the System → Quick Actions → **View Audit Log** screen
+(`xinas_menu/screens/quick_actions.py::_view_audit_log`) and its merge
+helper (`xinas_menu/utils/audit_view.py`).
+
+**Status:** design (2026-07-05).
+
+## Problem
+
+xiNAS records audit activity in **two disjoint trails**:
+
+| Trail | Written by | Captures |
+|-------|-----------|----------|
+| `/var/log/xinas/audit.log` (plain text) | TUI `AuditLogger` (`xinas_menu/utils/audit.py`) | TUI-**direct** actions only: user management (`useradd`/`passwd` run in-process), service restart, system update |
+| control-path trail — `GET /api/v1/audit` (hash-chained `audit.jsonl`, ADR-0011) | `xinas-api` server (`xiNAS-MCP/src/state/audit.ts`) | **every** control-path operation from **any** client (TUI, `xinasctl`, MCP): `share.create`/`share.delete`, RAID, network, filesystem, … |
+
+Before this spec the View Audit Log screen read **only** the local
+`audit.log`. Share creation is a control-path operation applied through
+`POST /api/v1/shares`; it is recorded only in the control-path trail
+(as `share.create`). In particular a share created via **MCP** never
+touches `audit.log`, so it was invisible in the screen even though the
+audit chain recorded it. The screen showed an incomplete picture that
+omitted all control-path activity (shares, RAID, network, and every
+MCP/CLI action).
+
+## Behavior
+
+The View Audit Log screen presents a **single, unified, time-ordered**
+view that merges both trails:
+
+1. Read the tail of the local `audit.log` (last `LIMIT` lines).
+2. Query the control-path trail via `GET /api/v1/audit?limit=LIMIT`
+   through the shared `ControlClient` (`self.app.control`).
+3. Normalize both sources to a common record, merge, sort **ascending
+   by timestamp** (chronological, matching the prior view), and render
+   the most recent `LIMIT` (default **200**) entries.
+
+### Display format
+
+Every row — from either trail — renders in the existing 5-column form:
+
+```
+YYYY-MM-DD HH:MM:SS | principal | action | STATUS | detail
+```
+
+### Control-path row → display line
+
+A `GET /audit` row (`AuditRow`, see `handlers/audit-query.ts`) maps as:
+
+| Column | Source field | Notes |
+|--------|--------------|-------|
+| timestamp | `timestamp` | epoch **ms** → local `YYYY-MM-DD HH:MM:SS`. An ISO-8601 string is also accepted. |
+| principal | `principal` | falls back to `unknown` when absent |
+| action | `kind` | e.g. `share.create` |
+| STATUS | `result_hash` | `FAIL` when the key is present **and** empty (`''` on failure, per `AuditEntry`); otherwise `OK` |
+| detail | `client_type` | e.g. `mcp`, `rest` — shows which client performed it |
+
+Local `audit.log` lines are parsed on ` | ` and pass through unchanged;
+the leading `YYYY-MM-DD HH:MM:SS` is interpreted as **local** time for
+sort ordering.
+
+### Degradation
+
+The screen never crashes on a missing source:
+
+- **Control API unreachable** (`ControlPathError`): show the local
+  trail only, and append one note line
+  `(control-path audit unavailable: <reason>)`.
+- **Local log missing**: show the control-path trail only.
+- **Both empty / absent**: show `Audit log is empty.`
+- A local line that cannot be parsed is preserved verbatim and sorted
+  to the end (most-recent) so no data is hidden.
+
+## Non-goals
+
+- No change to how entries are **written**. User management continues to
+  write the local trail; control-path operations continue to write the
+  hash-chained trail. This screen is read-only reconciliation.
+- No exact-lookup / filtering UI (the `GET /audit`
+  `request_id`/`kind`/`since` filters exist server-side but are not
+  surfaced here yet).
+- No de-duplication across trails. A share created **through the TUI**
+  writes both a local `nfs.add_export` line and a control-path
+  `share.create` row; both appear. (MCP/CLI-created shares appear once,
+  from the control-path trail.)

--- a/tests/test_audit_view.py
+++ b/tests/test_audit_view.py
@@ -1,0 +1,138 @@
+"""View Audit Log merge helper — unify local audit.log with control-path GET /audit.
+
+See docs/Management/audit-log-spec.md.
+"""
+
+from __future__ import annotations
+
+import time
+
+from xinas_menu.utils.audit_view import format_control_row, merge_audit
+
+
+def _epoch_ms(local_str: str) -> int:
+    """Local-time 'YYYY-MM-DD HH:MM:SS' → epoch milliseconds (TZ-agnostic test aid)."""
+    return int(time.mktime(time.strptime(local_str, "%Y-%m-%d %H:%M:%S")) * 1000)
+
+
+def _expected_ts(epoch_ms: int) -> str:
+    return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(epoch_ms / 1000))
+
+
+def test_format_control_row_maps_share_create_to_display_line():
+    ms = _epoch_ms("2026-07-05 14:15:00")
+    row = {
+        "kind": "share.create",
+        "timestamp": ms,
+        "principal": "root",
+        "client_type": "mcp",
+        "result_hash": "abc123",
+    }
+    line = format_control_row(row)
+    assert line == f"{_expected_ts(ms)} | root | share.create | OK | mcp"
+
+
+def test_format_control_row_empty_result_hash_is_fail():
+    ms = _epoch_ms("2026-07-05 14:15:00")
+    row = {
+        "kind": "share.create",
+        "timestamp": ms,
+        "principal": "root",
+        "client_type": "rest",
+        "result_hash": "",
+    }
+    assert " | FAIL | " in format_control_row(row)
+
+
+def test_format_control_row_missing_principal_falls_back_to_unknown():
+    ms = _epoch_ms("2026-07-05 14:15:00")
+    line = format_control_row({"kind": "share.delete", "timestamp": ms})
+    assert line.split(" | ")[1] == "unknown"
+
+
+def test_format_control_row_accepts_iso_timestamp():
+    row = {"kind": "share.create", "timestamp": "2026-07-05T14:15:00Z", "principal": "root"}
+    line = format_control_row(row)
+    # Renders a concrete local datetime, not the raw ISO string.
+    assert line.startswith("2026-07-05 ") or line.startswith("2026-07-0")
+    assert "T" not in line.split(" | ")[0]
+
+
+def test_merge_interleaves_by_timestamp_ascending():
+    local = [
+        "2026-07-05 11:39:11 | root | user.create | OK | rufat",
+        "2026-07-05 14:20:00 | root | user.delete | OK | bobr",
+    ]
+    control = [
+        {
+            "kind": "share.create",
+            "timestamp": _epoch_ms("2026-07-05 13:00:00"),
+            "principal": "root",
+            "client_type": "mcp",
+            "result_hash": "h",
+        }
+    ]
+    merged = merge_audit(local, control, limit=200)
+    actions = [seg[2] for seg in (line.split(" | ") for line in merged)]
+    assert actions == ["user.create", "share.create", "user.delete"]
+
+
+def test_merge_keeps_only_most_recent_when_over_limit():
+    local = [
+        "2026-07-05 10:00:00 | root | user.create | OK | a",
+        "2026-07-05 11:00:00 | root | user.create | OK | b",
+    ]
+    control = [
+        {
+            "kind": "share.create",
+            "timestamp": _epoch_ms("2026-07-05 12:00:00"),
+            "principal": "root",
+            "client_type": "mcp",
+            "result_hash": "h",
+        }
+    ]
+    merged = merge_audit(local, control, limit=2)
+    assert len(merged) == 2
+    # newest two survive: 11:00 user.create + 12:00 share.create
+    assert [line.split(" | ")[2] for line in merged] == ["user.create", "share.create"]
+
+
+def test_merge_empty_control_returns_local_only():
+    local = ["2026-07-05 11:39:11 | root | user.create | OK | rufat"]
+    assert merge_audit(local, [], limit=200) == local
+
+
+def test_merge_empty_local_returns_control_lines():
+    control = [
+        {
+            "kind": "share.create",
+            "timestamp": _epoch_ms("2026-07-05 13:00:00"),
+            "principal": "root",
+            "client_type": "mcp",
+            "result_hash": "h",
+        }
+    ]
+    merged = merge_audit([], control, limit=200)
+    assert len(merged) == 1
+    assert merged[0].split(" | ")[2] == "share.create"
+
+
+def test_merge_preserves_unparseable_local_line_at_end():
+    local = [
+        "2026-07-05 11:00:00 | root | user.create | OK | a",
+        "### corrupt line no timestamp ###",
+    ]
+    control = [
+        {
+            "kind": "share.create",
+            "timestamp": _epoch_ms("2026-07-05 12:00:00"),
+            "principal": "root",
+            "client_type": "mcp",
+            "result_hash": "h",
+        }
+    ]
+    merged = merge_audit(local, control, limit=200)
+    assert "### corrupt line no timestamp ###" in merged
+    # corrupt (unparseable) line sinks to the end, real entries stay ordered
+    assert merged[-1] == "### corrupt line no timestamp ###"
+    assert [line.split(" | ")[2] for line in merged[:2]] == ["user.create", "share.create"]

--- a/xinas_menu/screens/quick_actions.py
+++ b/xinas_menu/screens/quick_actions.py
@@ -167,13 +167,40 @@ class QuickActionsScreen(XiNASAppMixin, Screen):
 
     @work(exclusive=True)
     async def _view_audit_log(self) -> None:
+        """Unified audit view: local audit.log merged with the control-path
+        ``GET /audit`` trail (share/RAID/network/MCP activity). See
+        docs/Management/audit-log-spec.md."""
+        from xinas_menu.api.control_client import ControlPathError
         from xinas_menu.utils.audit import AUDIT_LOG
+        from xinas_menu.utils.audit_view import merge_audit
 
         view = self.query_one("#qa-content", ScrollableTextView)
+        view.set_content("  Loading audit log...")
+        loop = asyncio.get_running_loop()
+
+        # Local trail (TUI-direct actions: users, service restart, updates).
+        def _read_local() -> list[str] | None:
+            try:
+                return AUDIT_LOG.read_text().splitlines()
+            except FileNotFoundError:
+                return None
+
+        local_lines = await loop.run_in_executor(None, _read_local)
+
+        # Control-path trail (share.create, RAID, network — any client).
+        control_rows: list[dict] = []
+        control_note = ""
         try:
-            lines = AUDIT_LOG.read_text().splitlines()[-200:]
-            view.set_content("\n".join(lines) or "  Audit log is empty.")
-        except FileNotFoundError:
-            view.set_content("  Audit log not found.")
-        except Exception as exc:
-            view.set_content(f"  Error: {exc}")
+            result = await asyncio.to_thread(self.app.control.result, "/api/v1/audit?limit=200")
+            if isinstance(result, list):
+                control_rows = [r for r in result if isinstance(r, dict)]
+        except ControlPathError as exc:
+            control_note = f"  (control-path audit unavailable: {exc})"
+        except Exception as exc:  # defensive: never break the view
+            control_note = f"  (control-path audit error: {exc})"
+
+        merged = merge_audit(local_lines or [], control_rows, limit=200)
+        body = "\n".join(merged) if merged else "  Audit log is empty."
+        if control_note:
+            body = f"{body}\n\n{control_note}"
+        view.set_content(body)

--- a/xinas_menu/utils/audit_view.py
+++ b/xinas_menu/utils/audit_view.py
@@ -1,0 +1,98 @@
+"""Merge the local TUI audit.log with the control-path ``GET /audit`` trail.
+
+xiNAS keeps two disjoint audit trails: the plain-text local log written by
+``AuditLogger`` (TUI-direct actions) and the hash-chained control-path
+trail (all API/MCP/CLI operations, e.g. ``share.create``). The View Audit
+Log screen merges both so control-path activity is no longer invisible.
+
+Pure functions, no I/O — the screen stays a thin caller and the merge is
+unit-testable. See ``docs/Management/audit-log-spec.md``.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime
+from typing import Any
+
+_LOCAL_TS_FMT = "%Y-%m-%d %H:%M:%S"
+
+
+def _local_epoch(line: str) -> float | None:
+    """Epoch seconds from a local audit.log line's leading timestamp.
+
+    Local lines start with ``YYYY-MM-DD HH:MM:SS`` (local time). Returns
+    None when the prefix is not a timestamp (corrupt/torn line).
+    """
+    try:
+        return time.mktime(time.strptime(line[:19], _LOCAL_TS_FMT))
+    except (ValueError, OverflowError):
+        return None
+
+
+def _control_epoch(ts: Any) -> float | None:
+    """Epoch seconds from a control-path timestamp (epoch ms or ISO-8601)."""
+    if isinstance(ts, bool):
+        return None
+    if isinstance(ts, (int, float)):
+        return float(ts) / 1000.0
+    if isinstance(ts, str):
+        s = ts.strip()
+        if s.isdigit():
+            return float(s) / 1000.0
+        try:
+            return datetime.fromisoformat(s.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+def format_control_row(row: dict[str, Any]) -> str:
+    """Render one ``GET /audit`` row as the shared 5-column display line.
+
+    ``YYYY-MM-DD HH:MM:SS | principal | kind | STATUS | client_type``.
+    STATUS is ``FAIL`` when ``result_hash`` is present-and-empty (the
+    ``AuditEntry`` convention for a failed op), otherwise ``OK``.
+    """
+    epoch = _control_epoch(row.get("timestamp"))
+    ts = (
+        time.strftime(_LOCAL_TS_FMT, time.localtime(epoch))
+        if epoch is not None
+        else "????-??-?? ??:??:??"
+    )
+    principal = str(row.get("principal") or "unknown")
+    action = str(row.get("kind") or "?")
+    status = "FAIL" if row.get("result_hash") == "" else "OK"
+    detail = str(row.get("client_type") or "")
+    line = f"{ts} | {principal} | {action} | {status}"
+    if detail:
+        line += f" | {detail}"
+    return line
+
+
+def merge_audit(
+    local_lines: list[str],
+    control_rows: list[dict[str, Any]],
+    limit: int = 200,
+) -> list[str]:
+    """Merge both trails into one chronological (ascending) display list.
+
+    Entries are keyed by epoch seconds. A local line whose timestamp
+    cannot be parsed sinks to the end (treated as newest) so nothing is
+    hidden. Only the most recent ``limit`` entries are returned.
+    """
+    keyed: list[tuple[float, int, str]] = []
+    for order, line in enumerate(local_lines):
+        epoch = _local_epoch(line)
+        keyed.append((epoch if epoch is not None else float("inf"), order, line))
+    base = len(local_lines)
+    for order, row in enumerate(control_rows):
+        epoch = _control_epoch(row.get("timestamp"))
+        keyed.append(
+            (epoch if epoch is not None else float("inf"), base + order, format_control_row(row))
+        )
+    keyed.sort(key=lambda t: (t[0], t[1]))
+    lines = [line for _, _, line in keyed]
+    if 0 <= limit < len(lines):
+        lines = lines[-limit:]
+    return lines


### PR DESCRIPTION
## Problem

The System → Quick Actions → **View Audit Log** screen showed `user.*` entries but never share creation. Root cause: it read **only** the local plain-text `/var/log/xinas/audit.log`, which captures TUI-**direct** actions (user management runs `useradd`/`passwd` in-process, plus service restart / updates).

Share creation is a **control-path** operation applied through `POST /api/v1/shares` and recorded only in the authoritative hash-chained trail (`GET /api/v1/audit` / `audit.jsonl`) as `share.create`. Shares created via **MCP/API** never touched `audit.log`, so they were invisible in the view. The two trails were disjoint.

## Fix — merge both trails

The screen now also queries `GET /api/v1/audit?limit=200` via the shared control client and merges it with the local log into one chronological view. Control-path rows render in the same `ts | principal | action | STATUS | detail` format, with `client_type` (e.g. `mcp`) in the detail column so you can see where each action came from. Degrades gracefully when either source is missing.

## Changes

- `docs/Management/audit-log-spec.md` — new owning spec (spec-first)
- `xinas_menu/utils/audit_view.py` — pure merge/format helper
- `xinas_menu/screens/quick_actions.py` — `_view_audit_log` merges local + control-path trails
- `tests/test_audit_view.py` — 9 unit tests (TDD)
- `CLAUDE.md` — docs index updated

## Testing

- New helper unit-tested (9 tests, TDD red→green)
- Full suite: **164 passed**
- `ruff check` + `ruff format --check` clean

Python-TUI-only and reads an endpoint the api already serves — no server change, no `Requires-Rebuild` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)