### PR TITLE
fix(tui): stop acting on the retired xinas-mcp unit in menu actions

### DIFF
--- a/xinas_menu/screens/mcp.py
+++ b/xinas_menu/screens/mcp.py
@@ -293,7 +293,7 @@ class MCPScreen(XiNASAppMixin, Screen):
     @work(exclusive=True)
     async def _restart(self) -> None:
         confirmed = await self.app.push_screen_wait(
-            ConfirmDialog("Restart xinas-mcp and xinas-nfs-helper?", "Confirm")
+            ConfirmDialog("Restart xinas-nfs-helper?", "Confirm")
         )
         if not confirmed:
             return
@@ -302,10 +302,12 @@ class MCPScreen(XiNASAppMixin, Screen):
         loop = asyncio.get_running_loop()
         ctl = ServiceController()
         results = []
-        for svc in ("xinas-mcp", "xinas-nfs-helper"):
+        # xinas-mcp.service is retired — MCP runs on-demand over Streamable
+        # HTTP via xinas-api's /mcp, so only the NFS helper needs restarting.
+        for svc in ("xinas-nfs-helper",):
             ok, err = await loop.run_in_executor(None, lambda s=svc: ctl.restart(s))
             results.append(f"  {svc}: {'OK' if ok else err[:60]}")
-        self.app.audit.log("mcp.restart", "both services", "OK")
+        self.app.audit.log("mcp.restart", "xinas-nfs-helper", "OK")
         view = self.query_one("#mcp-content", ScrollableTextView)
         view.set_content(f"{_GRN}Services restarted:{_NC}\n\n" + "\n".join(results))
         self._show_status()

--- a/xinas_menu/screens/quick_actions.py
+++ b/xinas_menu/screens/quick_actions.py
@@ -39,7 +39,8 @@ _SERVICES = [
     "xiraid-server",
     "xiraid-exporter",
     "xinas-nfs-helper",
-    "xinas-mcp",
+    "xinas-api",
+    "xinas-agent",
     "nfsdcld",
     "rpcbind",
 ]


### PR DESCRIPTION
## Problem
Follow-up to #247. Two more `xinas_menu` spots still operated on the standalone **`xinas-mcp`** service, which the `xinas_mcp` role removes at install time (MCP now runs on-demand over Streamable HTTP via `xinas-api`'s `/mcp`):

1. **`screens/quick_actions.py`** — the read-only *Service Status* view (`_service_status()`) listed `xinas-mcp` in `_SERVICES`, so it always rendered **red "inactive"** on a healthy box.
2. **`screens/mcp.py`** — the *Restart NFS Helper* menu action (`_restart()`) actually restarted `("xinas-mcp", "xinas-nfs-helper")`, so every use produced a **spurious failure line** for the missing unit, and the confirm dialog named a service that no longer exists.

## Fix
- `quick_actions.py`: replace `xinas-mcp` with the real daemons **`xinas-api` + `xinas-agent`**.
- `mcp.py`: restart **only `xinas-nfs-helper`** (matching the menu label + dialog); drop the dead unit and fix the confirm text.

## Verification
- `py_compile` clean on both files.
- Applied live on a v3.2.1 node — *Service Status* now all-green; *Restart NFS Helper* no longer emits a `xinas-mcp` failure line.

## Explicitly out of scope (separate, larger reconciliation)
The **Remote Access (HTTP)** + **Token Management** flow is a deeper disconnect and is **intentionally not touched here**:
- `mcp.py:_cfg_restart_service()` restarts the retired `xinas-mcp` unit;
- `RemoteAccessScreen` / `TokenManagementScreen` read/write MCP settings via `utils/config.py` → **`/etc/xinas-mcp/config.json`** (a path that does not exist) using a **legacy schema** (`http_enabled`, `http_port`, `tokens: {tok: role}`) incompatible with the live `xinas-api` config (`/etc/xinas-api/config.json`, `tokens: {tok: {principal, role}}`, listener under `listen`/`mcp.http`);
- `mcp.py:287` prints a connect hint `ssh -T root@<ip> xinas-mcp`, but the installed binary is `xinas-mcp-stdio` (no `xinas-mcp`).

A naive repoint would clobber the API's live `config.json` with an incompatible schema, so that reconciliation needs an API-config-schema change **plus testing** and should land as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)