### PR TITLE
feat(tui): break-glass control-plane restart (xinas-api + xinas-agent)

### DIFF
--- a/docs/control-path/s8-clients-spec.md
+++ b/docs/control-path/s8-clients-spec.md
@@ -282,6 +282,35 @@ with `NOT_FOUND: no such API route` on a raw slash. The TUI does this via
 array / pool ids). Regression: the un-encoded form aborted the whole
 "Delete Array" teardown on step 1.
 
+## 6b. Break-glass control-plane restart (TUI, post-S8)
+
+The MCP Server screen (`xinas_menu/screens/mcp.py`, reached via
+Integrations → MCP Server) offers a single **break-glass** action to
+restart the two control-plane daemons — `xinas-api` and `xinas-agent`.
+
+- **Menu item:** `[R] Restart Control-Plane (api+agent)` (letter key —
+  the numbered slots are full). It sits above `Back`.
+- **Order matters.** `xinas-agent` declares `Requires=`/`After=
+  xinas-api`, so restarting `xinas-api` alone stops the agent (Requires
+  propagates the stop) and nothing pulls it back up. The action restarts
+  **`xinas-api` first, then `xinas-agent`**, so the agent rebinds to a
+  healthy api. The ordering is enforced by the pure helper
+  `_restart_control_plane(restart_fn)` (dependency-ordered restart tuple
+  `_CONTROL_PLANE_SERVICES = ("xinas-api", "xinas-agent")`), which is
+  unit-tested independent of the Textual worker.
+- **Guarded, not routine.** A `ConfirmDialog` states that the restart
+  briefly interrupts the REST/MCP API, disconnects active remote MCP/API
+  sessions (including the TUI's own `control_client` UDS connection), and
+  may interrupt in-flight operations — "use only to recover a hung
+  daemon." systemd already recovers both units on failure
+  (`Restart=on-failure`), so this is a manual recovery lever, not a
+  day-2 button.
+- **No bare stop.** The action only ever *restarts*; it never stops or
+  disables either daemon, and never targets `xinas-agent` in isolation.
+- **Audit.** Emits `mcp.control_plane_restart` with target
+  `xinas-api,xinas-agent` and result `OK`/`FAILED`; per-service results
+  are rendered in the content pane.
+
 ## 7. e2e parity scenarios (T15)
 
 1. **Same plan everywhere:** one share spec via REST, MCP tool call,

--- a/docs/plans/2026-07-05-nvme-vm-fallback-plan.md
+++ b/docs/plans/2026-07-05-nvme-vm-fallback-plan.md
@@ -1,7 +1,7 @@
 # NVMe VM-Fallback Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
-
+>
 > **Commits:** This repo's owner requires **explicit approval before any commit**. Treat every `git commit` step below as "stage the change and request approval," not "commit automatically."
 
 **Goal:** Stop the mid-pipeline abort when an unattended default-preset install runs on a KVM/virtio VM, by making the `nvme_namespace` role VM-aware when NVMe detection finds zero data drives.

--- a/tests/test_mcp_screen.py
+++ b/tests/test_mcp_screen.py
@@ -1,0 +1,62 @@
+"""MCPScreen — break-glass control-plane restart helper.
+
+Headless coverage for the pure, injectable orchestration helper
+``xinas_menu.screens.mcp._restart_control_plane``: dependency-ordered
+restart of ``xinas-api`` then ``xinas-agent`` (see
+docs/control-path/s8-clients-spec.md §6b). The Textual worker that wires
+the confirm dialog + audit + view around it is not exercised here.
+"""
+
+from __future__ import annotations
+
+import xinas_menu.screens.mcp as mcp
+
+
+def _recording_restart(fail_on=None):
+    """restart_fn stub recording the service names it was asked to restart."""
+    calls: list[str] = []
+
+    def restart(name: str) -> tuple[bool, str]:
+        calls.append(name)
+        if fail_on is not None and name == fail_on:
+            return False, f"Job for {name}.service failed"
+        return True, ""
+
+    return restart, calls
+
+
+def test_control_plane_services_are_api_then_agent():
+    # api must precede agent: agent Requires=/After= api, and restarting
+    # api alone leaves agent stopped.
+    assert mcp._CONTROL_PLANE_SERVICES == ("xinas-api", "xinas-agent")
+
+
+def test_restart_control_plane_restarts_api_before_agent():
+    restart, calls = _recording_restart()
+    all_ok, results = mcp._restart_control_plane(restart)
+    assert calls == ["xinas-api", "xinas-agent"]
+    assert all_ok is True
+    assert [svc for svc, _ok, _err in results] == ["xinas-api", "xinas-agent"]
+    assert all(ok for _svc, ok, _err in results)
+
+
+def test_restart_control_plane_reports_per_service_failure():
+    # api restart fails; agent is still attempted (honest per-service report),
+    # and the aggregate result is not-ok.
+    restart, calls = _recording_restart(fail_on="xinas-api")
+    all_ok, results = mcp._restart_control_plane(restart)
+    assert calls == ["xinas-api", "xinas-agent"]
+    assert all_ok is False
+    by_svc = {svc: (ok, err) for svc, ok, err in results}
+    assert by_svc["xinas-api"][0] is False
+    assert "failed" in by_svc["xinas-api"][1]
+    assert by_svc["xinas-agent"][0] is True
+
+
+def test_restart_control_plane_agent_failure_marks_not_ok():
+    restart, _calls = _recording_restart(fail_on="xinas-agent")
+    all_ok, results = mcp._restart_control_plane(restart)
+    assert all_ok is False
+    by_svc = {svc: ok for svc, ok, _err in results}
+    assert by_svc["xinas-api"] is True
+    assert by_svc["xinas-agent"] is False

--- a/xinas_menu/screens/mcp.py
+++ b/xinas_menu/screens/mcp.py
@@ -102,6 +102,31 @@ def _get_ip() -> str:
         return "10.10.1.1"
 
 
+# Control-plane daemons, in dependency order. xinas-agent declares
+# Requires=/After= xinas-api, so xinas-api MUST be restarted first:
+# restarting the api stops the agent (Requires propagates the stop) and
+# nothing pulls it back up, so the agent is restarted explicitly after.
+_CONTROL_PLANE_SERVICES = ("xinas-api", "xinas-agent")
+
+
+def _restart_control_plane(restart_fn) -> tuple[bool, list[tuple[str, bool, str]]]:
+    """Restart the control-plane daemons in dependency order (api → agent).
+
+    ``restart_fn(name) -> (ok, err)`` is injected so this is unit-testable
+    without systemd. Returns ``(all_ok, [(service, ok, err), ...])``; every
+    service is attempted (honest per-service report) even if an earlier one
+    fails.
+    """
+    results: list[tuple[str, bool, str]] = []
+    all_ok = True
+    for svc in _CONTROL_PLANE_SERVICES:
+        ok, err = restart_fn(svc)
+        results.append((svc, ok, err))
+        if not ok:
+            all_ok = False
+    return all_ok, results
+
+
 # ── Main MCP menu ──────────────────────────────────────────────────────────
 
 _MENU = [
@@ -114,6 +139,7 @@ _MENU = [
     MenuItem("7", "View NFS Helper Logs"),
     MenuItem("8", "Check & Install Updates"),
     MenuItem("9", "Remote Access (HTTP)"),
+    MenuItem("R", "Restart Control-Plane (api+agent)"),
     MenuItem("0", "Back"),
 ]
 
@@ -158,6 +184,8 @@ class MCPScreen(XiNASAppMixin, Screen):
             self._check_updates()
         elif key == "9":
             self.app.push_screen(RemoteAccessScreen())
+        elif key == "R":
+            self._restart_control_plane_action()
 
     @work(exclusive=True)
     async def _toggle_nfs_helper(self) -> None:
@@ -310,6 +338,39 @@ class MCPScreen(XiNASAppMixin, Screen):
         self.app.audit.log("mcp.restart", "xinas-nfs-helper", "OK")
         view = self.query_one("#mcp-content", ScrollableTextView)
         view.set_content(f"{_GRN}Services restarted:{_NC}\n\n" + "\n".join(results))
+        self._show_status()
+
+    @work(exclusive=True)
+    async def _restart_control_plane_action(self) -> None:
+        """Break-glass: restart xinas-api then xinas-agent. See
+        docs/control-path/s8-clients-spec.md §6b."""
+        confirmed = await self.app.push_screen_wait(
+            ConfirmDialog(
+                "Restart the control-plane services xinas-api and xinas-agent?\n\n"
+                "This briefly interrupts the REST/MCP API, disconnects active\n"
+                "remote MCP/API sessions, and may interrupt in-flight operations.\n"
+                "Use only to recover a hung daemon.",
+                "Restart Control-Plane",
+            )
+        )
+        if not confirmed:
+            return
+        from xinas_menu.utils.service_ctl import ServiceController
+
+        loop = asyncio.get_running_loop()
+        ctl = ServiceController()
+        all_ok, results = await loop.run_in_executor(
+            None, lambda: _restart_control_plane(ctl.restart)
+        )
+        self.app.audit.log(
+            "mcp.control_plane_restart",
+            "xinas-api,xinas-agent",
+            "OK" if all_ok else "FAILED",
+        )
+        lines = [f"  {svc}: {'OK' if ok else (err[:60] or 'failed')}" for svc, ok, err in results]
+        header = _GRN if all_ok else _RED
+        view = self.query_one("#mcp-content", ScrollableTextView)
+        view.set_content(f"{header}Control-plane restart:{_NC}\n\n" + "\n".join(lines))
         self._show_status()
 
     @work(exclusive=True)

--- a/xinas_menu/screens/nfs.py
+++ b/xinas_menu/screens/nfs.py
@@ -637,7 +637,10 @@ class NFSScreen(XiNASAppMixin, Screen):
         )
         self._load_exports()
 
-    @work(exclusive=True)
+    # NOT a @work worker: callers `await` this inline to show the dialog and
+    # return. textual 8.x Workers are not awaitable (Worker has no __await__),
+    # so decorating it with @work breaks `await self._show_control_error(...)`
+    # at both type-check and runtime.
     async def _show_control_error(self, exc: ControlPathError) -> None:
         """Render a control-path failure. A transient lease conflict gets a
         calm "busy, retry" dialog (the resource is locked by another task and


### PR DESCRIPTION
## What
Adds a single **break-glass** action to the **Integrations → MCP Server** screen:

```
[R] Restart Control-Plane (api+agent)
```

Follow-up to #247/#249, which put `xinas-api` and `xinas-agent` on the service *status* boards but left them unactionable. This gives an operator a way to bounce the two control-plane daemons from the console without dropping to a shell.

## Why the order (api → agent) matters
`xinas-agent.service` declares `Requires=`/`After= xinas-api.service`. Restarting `xinas-api` alone **stops the agent** (Requires propagates the stop) and nothing pulls it back up — so the action restarts **`xinas-api` first, then `xinas-agent`**, leaving the agent rebound to a healthy api. The ordering lives in a pure, injectable helper (`_restart_control_plane`) that's unit-tested without systemd.

## Break-glass, not routine
- A `ConfirmDialog` warns that the restart briefly interrupts the REST/MCP API, disconnects active remote MCP/API sessions (including the TUI's own `control_client` UDS connection), and may interrupt in-flight operations — *"use only to recover a hung daemon."*
- systemd already recovers both units on failure (`Restart=on-failure`), so this is a manual recovery lever, not a day-2 button.
- The action only ever **restarts** — never stops/disables either daemon, never targets `xinas-agent` in isolation.
- Audit-logged as `mcp.control_plane_restart` (`OK`/`FAILED`), with per-service results in the content pane.

## Spec
`docs/control-path/s8-clients-spec.md` **§6b** documents the behavior (spec-first).

## Verification
- `pytest tests/test_mcp_screen.py` — 4 new tests (order, all-ok, per-service failure), RED→GREEN
- Full suite: **181 passed**
- `ruff check` clean · `ruff format --check` clean · `markdownlint-cli2` 0 errors

No `Requires-Rebuild:` trailer — pure Python TUI change (no unit files / roles altered).

## Out of scope
`mcp.py:_cfg_restart_service()` still restarts the retired `xinas-mcp` unit after config writes (from #249's out-of-scope note) — tracked as a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
**Bundled CI-unblock fixes (main was red repo-wide before this PR; both inherited via rebase, unrelated to the feature):**

- `fix(tui)` (`5150367`): CI's unpinned `textual>=0.71.0` resolved to 8.2.8, whose `Worker` is no longer awaitable — breaking three `await self._show_control_error(exc)` sites in `nfs.py` at both type-check and runtime. Dropped the stray `@work` decorator so the helper stays a plain awaitable.
- `fix(docs)` (`3d8eb6d`): `markdownlint` MD028 blank-line-in-blockquote in `docs/plans/2026-07-05-nvme-vm-fallback-plan.md` (from the nvme-VM-fallback PR merged to main earlier today). Joined the two callouts into one blockquote.
