### PR TITLE
fix(xinas_menu): stop clobbering /var/log/xinas ownership (crash-loops xinas-api on reboot)

### DIFF
--- a/collection/roles/xinas_menu/tasks/main.yml
+++ b/collection/roles/xinas_menu/tasks/main.yml
@@ -172,8 +172,14 @@
   ansible.builtin.file:
     path: "{{ xinas_log_dir }}"
     state: directory
-    owner: root
-    group: root
+    # /var/log/xinas is the SHARED log dir. The xinas_api role (which runs
+    # earlier) owns it via tmpfiles as xinas_api_user:xinas_api_socket_group
+    # (xinas-api:xinas-admin) so the User=xinas-api service can open its
+    # audit.jsonl. Reclaiming it to root:root here locks the api out and
+    # crash-loops it (EACCES on /var/log/xinas/audit.jsonl) on the next
+    # restart/reboot, so mirror that ownership instead.
+    owner: "{{ xinas_api_user | default('xinas-api') }}"
+    group: "{{ xinas_api_socket_group | default('xinas-admin') }}"
     mode: '0750'
   tags: [xinas_menu, logs]
 


### PR DESCRIPTION
## Severity: high — a stock install's control plane does not survive a reboot

## Problem
The `xinas_menu` role's *"Ensure log directory exists"* task (`collection/roles/xinas_menu/tasks/main.yml`) hard-coded `owner: root` / `group: root` on `/var/log/xinas`.

But that directory is **shared**: the `xinas_api` role (which runs *earlier* in `site.yml`) creates and owns it via tmpfiles as `xinas_api_user:xinas_api_socket_group` = **`xinas-api:xinas-admin`, mode 0750**, so the `User=xinas-api` service can open its `audit.jsonl` (`AuditDrainer`).

Because `xinas_menu` runs *after* `xinas_api`, it reclaimed the dir to `root:root`, locking the api user out. The already-running api survives on its open fd, so the install *looks* fine — but on the **next restart/reboot** it crash-loops:

```
xinas-api failed to start: Error: EACCES: permission denied, open '/var/log/xinas/audit.jsonl'
    at AuditDrainer.appendAndMark (.../state/audit-drainer.js:100:20)
  errno: -13, code: 'EACCES', syscall: 'open', path: '/var/log/xinas/audit.jsonl'
```

`xinas-api` then sits in `activating (auto-restart)`, `/run/xinas/api.sock` never binds, and **all MCP + REST + agent control-plane traffic is dead** until an operator manually fixes the dir ownership.

## How it was found
Full uninstall → reinstall of v3.3.0. Roles `common…nfs_server`, then `xinas_api` started the api fine, then `xinas_menu` clobbered `/var/log/xinas`; the next api restart crash-looped on the EACCES above. `stat` showed `/var/log/xinas` as `drwxr-x--- root:root` while `audit.jsonl` was `xinas-api:xinas-admin`, and `systemd-tmpfiles --create` restored the intended `xinas-api:xinas-admin` — pinning the clobber to this task.

## Fix
Mirror the `xinas_api` ownership instead of overriding it, using the same vars with defensive defaults (so a standalone `--tags xinas_menu` run without `xinas_api`'s defaults in scope still resolves):

```yaml
owner: "{{ xinas_api_user | default('xinas-api') }}"
group: "{{ xinas_api_socket_group | default('xinas-admin') }}"
```

The `healthcheck/` subdir task is unchanged — it only touches the subdir, not the parent, and is root-managed.

## Verification (v3.3.0 node)
1. Reset `/var/log/xinas` to `root:root` (reproduce) → `xinas-api` crash-loops with the EACCES above.
2. Re-ran the **fixed** task (`ansible-playbook … --tags logs`) → dir returns to `xinas-api:xinas-admin`.
3. `systemctl restart xinas-api` → **stably `active/running`** (5/5 samples), `/run/xinas/api.sock` bound, MCP `tools/list` = **65 tools**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)