### PR TITLE
fix(agent): omit null disk model/serial so the Disk observation batch isn't rejected (disks.list = 0)

### DIFF
--- a/xiNAS-MCP/src/agent/collectors/disk.ts
+++ b/xiNAS-MCP/src/agent/collectors/disk.ts
@@ -128,10 +128,13 @@ export class DiskCollector implements Collector<'Disk'> {
           ...(disk.status.device_path !== undefined
             ? { device_path: disk.status.device_path }
             : {}),
-          ...(disk.status.model !== undefined ? { model: disk.status.model } : {}),
-          ...(disk.status.serial !== undefined ? { serial: disk.status.serial } : {}),
-          ...(disk.status.transport !== undefined ? { transport: disk.status.transport } : {}),
-          ...(disk.status.wwn !== undefined ? { wwn: disk.status.wwn } : {}),
+          // Defense-in-depth against a null (not just undefined) slipping in
+          // from a non-lsblk disk source: the api schema requires strings, and
+          // a null fails the whole batch. `!= null` omits null and undefined.
+          ...(disk.status.model != null ? { model: disk.status.model } : {}),
+          ...(disk.status.serial != null ? { serial: disk.status.serial } : {}),
+          ...(disk.status.transport != null ? { transport: disk.status.transport } : {}),
+          ...(disk.status.wwn != null ? { wwn: disk.status.wwn } : {}),
           ...(disk.status.size_text !== undefined ? { size_text: disk.status.size_text } : {}),
           ...(disk.status.capacity_bytes !== undefined
             ? { capacity_bytes: disk.status.capacity_bytes }

--- a/xiNAS-MCP/src/lib/parse/disk.ts
+++ b/xiNAS-MCP/src/lib/parse/disk.ts
@@ -77,10 +77,16 @@ export function parseLsblkOutput(raw: string): ObservedDisk[] {
         status: {
           name: d.name,
           device_path: `/dev/${d.name}`,
-          ...(d.model !== undefined ? { model: d.model } : {}),
-          ...(d.serial !== undefined ? { serial: d.serial } : {}),
-          ...(d.tran !== undefined ? { transport: d.tran } : {}),
-          ...(d.wwn !== undefined ? { wwn: d.wwn } : {}),
+          // lsblk emits JSON `null` (not omitted) for a device that has no
+          // model/serial/transport/wwn — e.g. a device-mapper / xiRAID array
+          // device like `xi_data`. `!== undefined` lets that null through, and
+          // the api Disk schema requires these to be strings, so the whole
+          // observation batch is rejected ("status/serial must be string") and
+          // disks.list stays empty. `!= null` omits both null and undefined.
+          ...(d.model != null ? { model: d.model } : {}),
+          ...(d.serial != null ? { serial: d.serial } : {}),
+          ...(d.tran != null ? { transport: d.tran } : {}),
+          ...(d.wwn != null ? { wwn: d.wwn } : {}),
           ...(sizeText !== undefined ? { size_text: sizeText } : {}),
           ...(capacityBytes !== undefined ? { capacity_bytes: capacityBytes } : {}),
           system_disk: systemDisk,


### PR DESCRIPTION
## Severity: high — `disks.list` returns 0 on a healthy node; observed disk state is frozen

## Problem
`lsblk --json` emits JSON `null` (not an omitted key) for a device that has no model/serial/transport/wwn — e.g. a device-mapper / xiRAID array device such as **`xi_data`**. Both the lsblk parser (`lib/parse/disk.ts`) and the collector upsert (`agent/collectors/disk.ts`) guarded these fields with `!== undefined`, but **`null !== undefined` is `true`**, so `model: null` / `serial: null` were emitted.

The api Disk schema requires these to be strings, so the **entire Disk observation batch is rejected**:

```
observation_batch_rejected status=400
delta[46] (kind=Disk, id=xi_data) failed schema:
  data/status/serial must be string, data/status/model must be string
```

Consequences on a healthy 24-NVMe node:
- `disks.list` (MCP/REST) returns **0**.
- Observed disk state never advances — the agent logs the rejection every ~60s, and any consumer of observed Disk state is broken.

## Fix
Guard with `!= null` (omits both `null` and `undefined`) in the lsblk parser (root cause) and, defensively, in the collector upsert. Applies to `model`, `serial`, `transport`/`tran`, and `wwn`.

## Verification (v3.3.0 node, 24× NVMe + a `xi_data` RAID device)
| | before | after |
|---|--------|-------|
| `disks.list` count | **0** | **48** (namespaces, with real model/serial: Samsung, Kioxia KCM61RUL3T84) |
| agent `observation_batch_rejected` | every ~60s | **stopped** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)