### PR TITLE
fix(agent): grant config-history RW so apply tasks don't hang at snapshot_before (control plane read+plan only)

### DIFF
--- a/collection/roles/xinas_agent/tasks/main.yml
+++ b/collection/roles/xinas_agent/tasks/main.yml
@@ -58,6 +58,24 @@
   notify: Restart xinas-agent
   tags: [xinas_agent, config]
 
+# --- config-history store (agent must write it) ---
+# The task runner's snapshot_before/after steps shell out to
+# `xinas_history snapshot create`, which writes DEFAULT_STORE_PATH
+# (/var/lib/xinas/config-history). That dir is normally created by the
+# xinas_history role — but that role runs AFTER this one (see the preset
+# playbook order), so it does not exist when the unit below first starts.
+# The unit lists this path in ReadWritePaths as NON-optional, so a namespace
+# bind of a missing dir would fail unit start with 226/NAMESPACE. Create it
+# here first (idempotent; xinas_history re-asserts it + its subdirs later).
+- name: Ensure config-history store directory exists (agent writes snapshots here)
+  ansible.builtin.file:
+    path: /var/lib/xinas/config-history
+    state: directory
+    owner: root
+    group: root
+    mode: '0700'
+  tags: [xinas_agent, unit]
+
 # --- Systemd unit ---
 
 - name: Install xinas-agent.service systemd unit

--- a/xiNAS-MCP/xinas-agent.service
+++ b/xiNAS-MCP/xinas-agent.service
@@ -50,15 +50,27 @@ ProtectHome=true
 #                          are delegated to PID1 over dbus; mountpoint dirs
 #                          are PID1-created; /dev stays writable under
 #                          ProtectSystem=strict (PrivateDevices unset).
+#   /var/lib/xinas/config-history — the task runner's snapshot_before/after
+#                          steps shell out to `xinas_history snapshot create`,
+#                          which WRITES DEFAULT_STORE_PATH
+#                          (/var/lib/xinas/config-history). Without this, every
+#                          apply throws EROFS at snapshot_before, the runner
+#                          rejection is swallowed, no terminal event is emitted,
+#                          and the task hangs in `running` forever, holding its
+#                          worker-pool slot. The xinas_agent role creates this
+#                          dir before starting the unit (xinas_history, which
+#                          normally owns it, runs later in the playbook), so the
+#                          non-optional bind below always finds it.
 # NOTE: /var/lib/xinas/state is deliberately NOT writable here. Per ADR-0002
 # the api is the SOLE SQLite writer; the agent reports observations via the
-# api's /internal/v1/observed. /var/lib/xinas is read-only below (the agent
-# only reads /var/lib/xinas/controller-id). Listing /var/lib/xinas/state in
-# both ReadWritePaths and under a ReadOnlyPaths parent was contradictory.
+# api's /internal/v1/observed. The rest of /var/lib/xinas is read-only below
+# (the agent only reads /var/lib/xinas/controller-id and writes config-history).
+# Listing /var/lib/xinas/state in both ReadWritePaths and under a ReadOnlyPaths
+# parent was contradictory.
 # Finding #29: /run/netplan (and /etc/netplan on netplan-less hosts) may not
 # exist; a non-optional ReadWritePaths entry fails namespace setup with
 # 226/NAMESPACE and the agent restart-loops. '-' makes them optional.
-ReadWritePaths=/run/xinas /var/log/xinas /etc/systemd/system -/etc/netplan -/run/netplan /run/systemd
+ReadWritePaths=/run/xinas /var/log/xinas /var/lib/xinas/config-history /etc/systemd/system -/etc/netplan -/run/netplan /run/systemd
 #   /etc/netplan         — S6 network executors (ADR-0008 §Sandbox): the
 #                          full-file 99-xinas.yaml render + the audited
 #                          cleanup of managed-iface stanzas in foreign files.


### PR DESCRIPTION
## Severity: CRITICAL — the MCP/REST control plane is read+plan only; no mutation can be applied

## Symptom
Every `mode=apply` (share / array / filesystem / pool / network create/modify/delete) dispatches a task that sits in `running` forever — `last_event_sequence: 1`, `stages: []`, no host change, and **nothing logged** by the api or agent. After 4 hangs the worker pool (`maxInflight=4`) is saturated and all further applies stay `queued`.

## Root cause
The xinas-agent sandbox (`ProtectSystem=strict` + `ReadOnlyPaths=/var/lib/xinas`) leaves `/var/lib/xinas/config-history` **read-only**. But the task runner's `snapshot_before` / `snapshot_after` steps shell out to `xinas_history snapshot create`, which writes `DEFAULT_STORE_PATH` = `/var/lib/xinas/config-history` (`xinas_history/store.py:36`). So the very first execution step throws:

```
snapshotCreate(before) THREW Error: xinas_history snapshot create exited with code 1:
  Error: [Errno 30] Read-only file system: '/var/lib/xinas/config-history'
    at XinasHistoryBridge.snapshotCreate (dist/agent/task/xinas-history-bridge.js:76)
    at async TaskRunner.run (dist/agent/task/runner.js:85)
```

The runner rejection is swallowed by `task.begin`'s fire-and-forget `.catch(() => {})` (`agent/rpc/methods/task.ts`), so **no terminal event is ever emitted** → the task hangs in `running` forever, holding its lease/pool slot.

The sandbox was tuned for the **observe** side (the ConfigSnapshot *collector* only READS history) and missed that the **execute** side (the task runner) WRITES it.

## Fix
- **`xinas-agent.service`** — add `/var/lib/xinas/config-history` to `ReadWritePaths` (non-optional). `/var/lib/xinas/state` stays read-only, so the api remains the sole SQLite writer (ADR-0002).
- **`xinas_agent` role** — create that directory *before* the unit starts. `xinas_history` normally owns it but runs **later** in the playbook (preset order: `xinas_agent` at 16, `xinas_history` at 20), so without this the non-optional bind mount would fail unit start with `226/NAMESPACE` (the Finding #29 class the unit already guards `/run/netplan` against).

## How it was found
Live file-based instrumentation of the agent runner. The probe log had to be read from the service's `PrivateTmp` namespace (`/tmp/systemd-private-*xinas-agent*/tmp/`) — `console.error` and a plain `/tmp` file were both invisible from outside the sandbox, which is part of why this failed silently.

## Verification (v3.3.0 node, 24× NVMe)
| | before | after |
|---|--------|-------|
| `share.create` apply | hangs in `running` (seq 1, 0 stages, no export) | **success** (seq 10, 5 stages) |
| snapshot_before | `EROFS` throw (swallowed) | writes snapshot id `…Z-share.create` |
| NFS export | never created | `/mnt/data/<share>` **live in `exportfs`** |

Full lifecycle now observed: `accepted → snapshot_before → preflight → apply → verify → snapshot_after → terminal(success)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)