### PR TITLE
fix(agent): always emit a terminal event so a pre/post-stage throw can't silently hang a task

### DIFF
--- a/xiNAS-MCP/src/agent/task/runner.ts
+++ b/xiNAS-MCP/src/agent/task/runner.ts
@@ -130,6 +130,10 @@ export class TaskRunner {
     let stageOrdinal = 0;
     const nextStageIndex = (): number => stageOrdinal++;
 
+    // True once an executor stage has begun mutating the host — decides the
+    // terminal state if an OTHERWISE-uncaught throw reaches the catch below.
+    let hostMayHaveChanged = false;
+
     try {
       // 1. accepted (seq 1).
       await emit('accepted');
@@ -161,6 +165,7 @@ export class TaskRunner {
           status: 'running',
         });
         try {
+          hostMayHaveChanged = true;
           await stage.run(ctx);
         } catch (err) {
           // Stage failed → report, run executor rollback, terminate. A throw
@@ -202,6 +207,37 @@ export class TaskRunner {
         snapshot_id: after.snapshot_id,
       });
       await emit('terminal', { status: 'success', snapshot_id: after.snapshot_id });
+    } catch (err) {
+      // A throw that escapes the per-stage try/catch above — the
+      // snapshot_before/after bridge calls, or an accepted/stage/terminal emit —
+      // would otherwise reject run(), be SWALLOWED by task.begin's
+      // fire-and-forget `.catch(() => {})`, and leave the task wedged in
+      // `running` forever, holding its worker-pool lease until the lease
+      // expires (§9 sweep). Emit a terminal so the failure is durable and the
+      // slot is freed promptly. No executor stage started → no host change
+      // (`failed`/FAILED_BEFORE_CHANGE); a stage had begun → the host may have
+      // converged but post-stage bookkeeping (snapshot_after) failed, so a human
+      // should verify (`requires_manual_recovery`). Best-effort: if this emit
+      // ALSO throws, the api's lease-sweep reconciler remains the durable
+      // backstop — we must not rethrow into task.begin's silent catch.
+      const error_message = err instanceof Error ? err.message : String(err);
+      try {
+        if (hostMayHaveChanged) {
+          await emit('terminal', {
+            status: 'requires_manual_recovery',
+            error_code: 'FAILED_MANUAL_RECOVERY_REQUIRED',
+            error_message,
+          });
+        } else {
+          await emit('terminal', {
+            status: 'failed',
+            error_code: 'FAILED_BEFORE_CHANGE',
+            error_message,
+          });
+        }
+      } catch {
+        /* lease-sweep reconciler recovers a task left with no terminal (§9) */
+      }
     } finally {
       this.#inflight.delete(begin.task_id);
     }


### PR DESCRIPTION
## Severity: medium (robustness) — turns any pre/post-stage throw into a silent permanent hang

## Problem
The task runner catches per-**stage** failures and reports them (`stage_failed` → rollback → terminal). But a throw **outside** that inner try/catch — the `snapshot_before` / `snapshot_after` bridge calls, or an `accepted` / `terminal` emit — rejects `run()`. `task.begin` invokes the runner fire-and-forget with `.catch(() => {})` (`agent/rpc/methods/task.ts`), so that rejection is **swallowed**: no terminal event is ever emitted, and the task wedges in `running` forever, holding its worker-pool lease until lease expiry. Four such wedges saturate the pool (`maxInflight=4`) and every further apply stays `queued`.

This was the exact failure mode behind the config-history EROFS hang (#254), but it's a **general** gap: any unexpected pre-first-stage throw silently wedges a slot instead of failing loudly.

## Fix
Wrap the `run()` body in a `catch` that always emits a terminal:
- **no executor stage started** → `failed` / `FAILED_BEFORE_CHANGE` (no host change happened)
- **a stage had begun** → `requires_manual_recovery` / `FAILED_MANUAL_RECOVERY_REQUIRED` (the host may have converged but post-stage bookkeeping failed; a human should verify)

The terminal emit is itself best-effort (its own inner try/catch) — if even that fails, the api's lease-sweep reconciler (§9) remains the durable backstop. The runner never rethrows into `task.begin`'s silent catch.

## Verification (live node)
Forced `xinas_history snapshot create` to exit 1 (`XINAS_HISTORY_PYTHON=/bin/false`):

| | before | after |
|---|--------|-------|
| snapshot_before throws | task hangs in `running` (seq 1) forever | task → **`failed` (FAILED_BEFORE_CHANGE)**, seq 2, slot freed |

The success path is unaffected (a normal apply still runs all stages). This safety net also surfaced a real **intermittent** snapshot-id collision — a same-second `snapshot_before`/`snapshot_after` — that previously would have hung; now it's a loud terminal. (That collision is a separate `xinas_history` bug, fixed in a follow-up PR.)

## Related
- #254 fixes the specific config-history EROFS that made this fire on *every* apply. This PR is the defense-in-depth so the *next* unexpected throw fails loudly instead of wedging the pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)