### PR TITLE
fix(history): microsecond-resolution snapshot ids so same-second snapshot_before/after don't collide

### DIFF
--- a/xinas_history/models.py
+++ b/xinas_history/models.py
@@ -315,15 +315,25 @@ class DiffResult:
 def generate_snapshot_id(operation: str) -> str:
     """Generate a snapshot ID from the current UTC time and operation name.
 
-    Format: ``YYYYMMDDTHHMMSSZ-<operation>`` where *operation* has
-    underscores replaced with hyphens for readability.
+    Format: ``YYYYMMDDTHHMMSSffffffZ-<operation>`` (microsecond-resolution
+    timestamp) where *operation* has underscores replaced with hyphens for
+    readability.
+
+    The timestamp carries microseconds because a single task takes two
+    snapshots in quick succession (``snapshot_before`` then ``snapshot_after``);
+    a fast operation completes them within the same wall-clock SECOND, so a
+    second-resolution id collided and ``write_snapshot`` raised
+    ``FileExistsError: Snapshot path already exists``. That aborted
+    ``snapshot_after`` and (via the agent task runner) wedged the whole apply.
+    Microseconds keep the id unique for any sequential creates while remaining
+    lexicographically sortable (chronological order is preserved).
 
     Examples::
 
-        generate_snapshot_id("raid_create")   -> "20260316T145500Z-raid-create"
-        generate_snapshot_id("install")       -> "20260316T145500Z-install"
+        generate_snapshot_id("raid_create")   -> "20260316T145500123456Z-raid-create"
+        generate_snapshot_id("install")       -> "20260316T145500123456Z-install"
     """
     now = datetime.datetime.utcnow()
-    ts = now.strftime("%Y%m%dT%H%M%SZ")
+    ts = now.strftime("%Y%m%dT%H%M%S%fZ")
     slug = operation.replace("_", "-")
     return f"{ts}-{slug}"


### PR DESCRIPTION
## Severity: high — intermittently hangs/fails every apply whose two snapshots land in the same second

## Problem
`generate_snapshot_id` (`xinas_history/models.py`) stamped snapshot ids at **1-second** resolution (`%Y%m%dT%H%M%SZ`). Every task takes **two** snapshots in quick succession — `snapshot_before` then `snapshot_after` — and a fast operation completes both within the same wall-clock second. The second id is then identical to the first, so `write_snapshot` raises:

```
FileExistsError: Snapshot path already exists:
  /var/lib/xinas/config-history/snapshots/20260707T185954Z-share.create
```

That aborts `snapshot_after`. Via the agent task runner (whose pre/post-stage rejection was swallowed — companion PR) the whole apply then wedges in `running`. It's **intermittent** — it only bites when before/after fall in the same second (~1 in 4 in a quick reproduction), which makes it especially nasty to diagnose.

Reproduction (5 back-to-back creates):
```
run 1: {"id": "…185952Z-share.create"}
run 2: {"id": "…185953Z-share.create"}
run 3: {"id": "…185954Z-share.create"}
run 4: EXIT 1 — Snapshot path already exists: …185954Z-share.create   ← collided with run 3
run 5: {"id": "…185955Z-share.create"}
```

## Fix
Stamp ids with **microseconds** (`%Y%m%dT%H%M%S%fZ`). Two sequential `utcnow()` calls always differ by ≥1 µs, so ids are unique for any back-to-back creates, and the format stays lexicographically sortable (chronological ordering preserved). No consumer parses a fixed-width timestamp.

## Verification (live v3.3.0 node)
| | before | after |
|---|--------|-------|
| 5 rapid `generate_snapshot_id()` (same second) | a duplicate → `FileExistsError` | **5 distinct ids** |
| fast `share.create` apply | `snapshot_after` fails → task wedged / manual-recovery | **terminal success** (seq 10, 5 stages, both snapshots written) |

## Related
Part of the apply-hang investigation. #254 fixed the config-history read-only mount (made *every* apply hang); #255 makes the runner fail loudly instead of hanging on any pre/post-stage throw; this PR removes the underlying intermittent snapshot collision so fast applies reliably reach `success`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)