### PR TITLE
fix(install): reset-failed xiNAS units so reinstall-without-reboot doesn't fail with EBUSY

### DIFF
--- a/collection/roles/xinas_api/tasks/main.yml
+++ b/collection/roles/xinas_api/tasks/main.yml
@@ -445,6 +445,21 @@
     - Restart xinas-api
   tags: [xinas_api, service]
 
+# 8b. Clear any stale `failed` unit record BEFORE the daemon-reload / restart
+#     handlers fire below. A prior uninstall (or a crashed earlier run) on the
+#     same boot can leave xinas-api.service in a failed sub-state that survives
+#     unit-file removal + daemon-reload; the enable/start then fails with
+#     "Unit xinas-api.service ... Device or resource busy" (EBUSY). reset-failed
+#     clears it. Harmless + idempotent on a clean system (no failed state = no-op).
+#     The uninstall role also does this, but the guard here makes install robust
+#     regardless of how the stale record arose.
+- name: Clear any stale failed state for xinas-api (reinstall-without-reboot guard)
+  ansible.builtin.command:
+    cmd: systemctl reset-failed xinas-api.service
+  changed_when: false
+  failed_when: false
+  tags: [xinas_api, service]
+
 # 9. Force daemon-reload before enable so systemd picks up the new
 #    unit. Without this, the next `service` task can race the reload
 #    and fail with "Unit xinas-api.service not found."

--- a/collection/roles/xinas_uninstall/tasks/50_remove_services.yml
+++ b/collection/roles/xinas_uninstall/tasks/50_remove_services.yml
@@ -40,6 +40,25 @@
   ansible.builtin.systemd:
     daemon_reload: true
 
+# A unit that was in a `failed` sub-state when its fragment was removed leaves
+# a lingering failed record that survives unit-file deletion + daemon-reload —
+# only `systemctl reset-failed` or a reboot clears it. Without this, a reinstall
+# on the SAME boot fails at the api role's "Enable and start xinas-api" with
+# "Unit xinas-api.service ... Device or resource busy" (EBUSY). Clear the
+# records here so uninstall -> reinstall-without-reboot is clean. Harmless +
+# idempotent: reset-failed on a unit with no failed state is a no-op.
+- name: "Services | clear lingering failed unit records (reinstall-without-reboot)"
+  ansible.builtin.command:
+    cmd: "systemctl reset-failed {{ item }}"
+  loop:
+    - xinas-agent.service
+    - xinas-api.service
+    - xinas-mcp.service
+    - xinas-nfs-helper.service
+    - xinas-perf-runtime.service
+  changed_when: false
+  failed_when: false
+
 - name: "Services | record removal"
   ansible.builtin.set_fact:
     uninstall_summary: >-


### PR DESCRIPTION
## Severity: medium — a full-wipe uninstall followed by a reinstall **without a reboot** fails the install

## Problem
A systemd unit that was in a `failed` sub-state when its fragment was removed leaves a lingering **failed record** that survives unit-file deletion **and** daemon-reload — only `systemctl reset-failed` or a reboot clears it. The xiNAS uninstall stops/disables/removes the units and daemon-reloads, but never `reset-failed`s them.

So after a full-wipe uninstall on a host that is **not rebooted**, a fresh install fails at the api role's *"Enable and start xinas-api"* with:

```
Unit xinas-api.service failed to load ... Device or resource busy   (EBUSY)
```

(Observed live this cycle; clearing it with `systemctl reset-failed "xinas*"` + daemon-reload unblocked the install.)

## Fix (two parts)
- **`xinas_uninstall` / `50_remove_services.yml`** — after deleting the unit files + daemon-reload, `reset-failed` all xiNAS units so no stale record is ever left. This is the root-cause fix: uninstall → reinstall on the same boot is now clean.
- **`xinas_api` role** — a defensive `reset-failed xinas-api.service` right before the daemon-reload/restart handlers fire, so install is robust regardless of how the stale record arose (a crashed earlier run, a manual removal, etc.).

Both are idempotent and harmless on a clean system: `reset-failed` on a unit with no failed state is a no-op, and `failed_when: false` tolerates an unknown unit.

## Verification
The mechanism, reproduced on a live host with a throwaway unit:

| step | `systemctl is-failed` | in `systemctl --failed` |
|------|----------------------|-------------------------|
| unit fails (`ExecStart=/bin/false`) | `failed` | yes |
| remove fragment + `daemon-reload` (mimics uninstall) | **`failed`** (the ghost) | **yes** |
| `systemctl reset-failed` (the fix) | `inactive` | **no** |

This matches the EBUSY seen on the real uninstall→reinstall-without-reboot, which `reset-failed` cleared.

## Notes
Scoped the defensive install-side guard to `xinas_api` (the first service to start and the one `Requires`d by the agent, hence where the install actually aborts). The uninstall-side fix already covers all five units, so the ghost never persists after a xiNAS uninstall; the other service roles can get the same one-line guard in a trivial follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)