### PR TITLE
fix(nvme_namespace): strip lsblk -s tree glyphs when resolving OS disks

### DIFF
--- a/collection/roles/nvme_namespace/files/resolve_system_disks.sh
+++ b/collection/roles/nvme_namespace/files/resolve_system_disks.sh
@@ -24,7 +24,13 @@ resolve() {
   src="${src%%[*}"   # strip btrfs subvolume annotation: /dev/sda2[/@] -> /dev/sda2
   case "$src" in
     /dev/*)
-      lsblk -s -npo NAME,TYPE "$src" 2>/dev/null | awk '$2 == "disk" { print $1 }'
+      # `lsblk -s` renders an inverse *tree*: the NAME column carries box-drawing
+      # glyphs even with -n -p. A linear chain glues them to the name
+      # ("└─/dev/nvme0n1"); a branching tree (e.g. an MD mirror) also prepends a
+      # "│ " continuation field. So TYPE is the last field and NAME is $(NF-1);
+      # strip everything before "/dev/" so the caller's '^/dev/' filter keeps
+      # every backing disk. See §2.
+      lsblk -s -npo NAME,TYPE "$src" 2>/dev/null | awk '$NF == "disk" { print substr($(NF-1), index($(NF-1), "/dev/")) }'
       ;;
     *:/*)
       return 0   # nfs / network root: nothing local to protect
@@ -37,7 +43,7 @@ resolve() {
         | awk '{ for (i = 1; i <= NF; i++) if ($i ~ /^\/dev\//) print $i }' \
         | while IFS= read -r member; do
             lsblk -s -npo NAME,TYPE "$member" 2>/dev/null \
-              | awk '$2 == "disk" { print $1 }'
+              | awk '$NF == "disk" { print substr($(NF-1), index($(NF-1), "/dev/")) }'
           done
       ;;
     *)

--- a/tests/test_nvme_resolve_system_disks.py
+++ b/tests/test_nvme_resolve_system_disks.py
@@ -15,15 +15,20 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[1]
 RESOLVE = REPO / "collection/roles/nvme_namespace/files/resolve_system_disks.sh"
 
-# lsblk --inverse output per mount source (TYPE column drives the disk filter).
+# `lsblk -s` (inverse) output per mount source (TYPE column drives the disk
+# filter). Real lsblk renders a *tree* — even with -n -p the NAME column is
+# prefixed with box-drawing glyphs, and a branching tree (MD mirror) also emits a
+# "│ " continuation field. These stubs reproduce that so the resolver's glyph
+# stripping is actually exercised (a clean-name stub silently hid the bug where
+# "└─/dev/nvme0n1" failed the caller's '^/dev/' filter).
 LSBLK_INVERSE = {
-    "/dev/mapper/ubuntu--vg-ubuntu--lv": "/dev/mapper/ubuntu--vg-ubuntu--lv lvm\n/dev/nvme0n1p3 part\n/dev/nvme0n1 disk\n",
-    "/dev/md0": "/dev/md0 raid1\n/dev/nvme0n1p3 part\n/dev/nvme0n1 disk\n/dev/nvme1n1p3 part\n/dev/nvme1n1 disk\n",
-    "/dev/sda2": "/dev/sda2 part\n/dev/sda disk\n",
-    "/dev/nvme0n1p1": "/dev/nvme0n1p1 part\n/dev/nvme0n1 disk\n",
-    "/dev/nvme1n1p1": "/dev/nvme1n1p1 part\n/dev/nvme1n1 disk\n",
-    "/dev/nvme0n1p2": "/dev/nvme0n1p2 part\n/dev/nvme0n1 disk\n",
-    "/dev/nvme1n1p2": "/dev/nvme1n1p2 part\n/dev/nvme1n1 disk\n",
+    "/dev/mapper/ubuntu--vg-ubuntu--lv": "/dev/mapper/ubuntu--vg-ubuntu--lv lvm\n└─/dev/nvme0n1p3 part\n  └─/dev/nvme0n1 disk\n",
+    "/dev/md0": "/dev/md0 raid1\n├─/dev/nvme0n1p3 part\n│ └─/dev/nvme0n1 disk\n└─/dev/nvme1n1p3 part\n  └─/dev/nvme1n1 disk\n",
+    "/dev/sda2": "/dev/sda2 part\n└─/dev/sda disk\n",
+    "/dev/nvme0n1p1": "/dev/nvme0n1p1 part\n└─/dev/nvme0n1 disk\n",
+    "/dev/nvme1n1p1": "/dev/nvme1n1p1 part\n└─/dev/nvme1n1 disk\n",
+    "/dev/nvme0n1p2": "/dev/nvme0n1p2 part\n└─/dev/nvme0n1 disk\n",
+    "/dev/nvme1n1p2": "/dev/nvme1n1p2 part\n└─/dev/nvme1n1 disk\n",
 }
 
 


### PR DESCRIPTION
resolve_system_disks.sh walks each OS mount down to its physical disk with `lsblk -s`, which renders an inverse *tree*: even with -n -p the NAME column carries box-drawing glyphs (e.g. "└─/dev/nvme0n1"), and a branching tree such as an MD-mirror root also prepends a "│ " continuation field. The awk read a fixed field and emitted it verbatim, so callers got "└─/dev/nvme0n1" (and lost mirror members entirely). resolve_system_disks.yml then filters select('match', '^/dev/'), discarding the glyph-prefixed entries — leaving the protected set empty and aborting every guided-LVM / MD install with "CRITICAL: Could not detect the OS system drive" (a fail-closed guard, so no data is wiped, but the install cannot proceed).

Key TYPE off the last field ($NF) and take the name from $(NF-1), stripping everything before "/dev/". This tolerates arbitrary tree indentation and the "│ " continuation field, so linear (LVM) and branching (MD mirror) roots both resolve to every backing disk.

The unit test stubbed lsblk with clean, glyph-free output, so it never exercised the real format. Update LSBLK_INVERSE to emit the actual tree glyphs (including the branching MD case) so the resolver's stripping is covered.