### PR TITLE
fix(agent): settle observed state after a successful apply (Delete-Array false fs_mounted block)

### DIFF
--- a/docs/control-path/s2-task-envelope-spec.md
+++ b/docs/control-path/s2-task-envelope-spec.md
@@ -153,6 +153,27 @@ The agent (root, TS) calls `python3 -m xinas_history` (subprocess, JSON) for **s
 
 **Rollback is executor-provided**, not a generic snapshot-restore (xinas_history has no arbitrary restore — only `reset-to-baseline` + an internal `_auto_rollback`). Each `Executor` declares `rollback(ctx)` that undoes its own change; the **reference executor's** is a trivial inverse (it is inert). Snapshots are captured for audit/diff and as the basis for file-level rollback when a file-based executor (S5 nfs) later needs it — at which point xinas_history gains an arbitrary-restore capability. S2 builds neither arbitrary-restore nor `reset-to-baseline` use.
 
+### 7.1 Post-apply observed settle (agent runner)
+
+The runner's success emission order is `… → snapshot_after → terminal(success)`. Between `snapshot_after` and `terminal`, **on success only**, the runner performs a **best-effort observed settle**: it re-runs the collectors for the observed kinds the operation mutated and `await`s a `flushWithSnapshot([kinds])` into the api's `/internal/v1/observed` writer **before** emitting `terminal`.
+
+**The race it closes.** Observed rows (`/xinas/v1/observed/<kind>/<id>`, ADR-0003) are refreshed *only* by the collectors — event streams plus a poll backstop; `Filesystem` is poll-only at 60 s (its mount-unit watch is a no-op in production). A client that chains two plan/apply calls back-to-back — the Delete-Array / Delete-Filesystem teardown issues `fs.unmount` then `fs.unmanage` — would have the second call's **plan/apply preflight read the pre-apply observed snapshot**: `fs.unmanage`'s provider re-checks `validateFsUnmanage({ mounted })` against the observed row, which still reads `mounted: true`, and returns the `fs_mounted` blocker ("unmount the filesystem before removing it from management"; s5-filesystem-spec §Blocker codes). The unmount apply's own executor `verify` stage already confirmed the host is truly unmounted, so this block is a stale-read artifact, not a real precondition — the teardown stops mid-sequence with the filesystem unmounted but still "managed". Settling the affected observed rows **before** `terminal` — the event a client's `plan_apply_wait` blocks on (§6; s8-clients-spec) — guarantees the next plan reads post-apply state.
+
+**Scope (`operation_kind` → observed kinds).** A static table (`REOBSERVE_KINDS`) maps each mutating operation kind to the observed kinds whose rows it changes. The settle reuses the poll sweep verbatim (`initialSweep()` → `enqueue` → `flushWithSnapshot([kinds])`):
+
+| operation_kind | settled kinds |
+|---|---|
+| `fs.create`, `fs.mount`, `fs.unmount`, `fs.grow`, `fs.set_quota_mode`, `fs.unmanage` | `Filesystem` |
+| `xiraid.array.create`, `xiraid.array.modify`, `xiraid.array.import`, `xiraid.array.delete` | `XiraidArray` |
+| `pool.create`, `pool.modify`, `pool.delete` | `Pool` |
+| `share.create`, `share.update`, `share.delete` | `NfsSession`, `ExportRule` |
+
+Operation kinds not in the table skip the settle (unchanged behavior; the poll backstop still reconciles within one interval).
+
+**Table invariant + multi-kind reconcile.** Every kind in a table entry is (co-)emitted by a collector whose `kind` is also in that entry, so sweeping the entry's collector-kind collectors yields a **complete snapshot of every listed kind**. The NFS collector's `kind` is `NfsSession` but its one sweep also emits `ExportRule`, so `share.*` lists both — settling `ExportRule` is what lets a chained `fs.unmount` see a just-removed export gone (`validateFsUnmount`'s `mountpoint_exported`, closing the second stale-read in the Delete-Array chain: `share.delete → fs.unmount → fs.unmanage → xiraid.array.delete`), **even when the LAST export is removed** and the sweep carries zero `ExportRule` rows — the complete-snapshot flush then reconciles the stale row away. To keep that flush safe, the settle runs the complete-snapshot flush only when **every** collector-kind in the entry swept cleanly; a failed sweep skips the flush entirely (the poll backstop reconciles), so a complete-snapshot flush never deletes a kind's rows against an empty batch.
+
+**Best-effort / non-blocking.** The settle NEVER fails or delays the task outcome: a collector sweep or an observed-flush error is logged and swallowed, the runner proceeds to `terminal`, and the ordinary poll backstop remains the durable reconcile. It runs only on the success path (a failed/rolled-back task leaves observed state for the poll to reconcile). It adds one collector sweep + one observed flush of latency to a successful apply's terminal — the same work the poll driver already does each interval. The runner receives the settle as an injected `reobserve(operation_kind)` callback (default no-op), wired from the convergence `registry` + `publisher`; unit/fixture builds that construct a runner without it are unaffected.
+
 ---
 
 ## 8. Reference executor

--- a/xiNAS-MCP/src/__tests__/agent/task/reobserve.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/task/reobserve.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Collector, Kind, ObservationDelta } from '../../../agent/collectors/base.js';
+import { CollectorRegistry } from '../../../agent/collectors/base.js';
+import { REOBSERVE_KINDS, makeReobserve } from '../../../agent/task/reobserve.js';
+
+/** A minimal in-memory collector whose initialSweep returns fixed deltas. */
+function fakeCollector(kind: Kind, sweep: () => Promise<ObservationDelta[]>): Collector {
+  return {
+    kind,
+    initialSweep: sweep,
+    async start(): Promise<void> {},
+    async stop(): Promise<void> {},
+    health() {
+      return { state: 'running' as const };
+    },
+  };
+}
+
+/** A fake publisher recording enqueues + flushWithSnapshot calls. */
+function fakePublisher() {
+  const enqueued: ObservationDelta[] = [];
+  const flushed: Kind[][] = [];
+  return {
+    enqueued,
+    flushed,
+    enqueue(delta: ObservationDelta): void {
+      enqueued.push(delta);
+    },
+    async flushWithSnapshot(kinds: Kind[]): Promise<void> {
+      flushed.push(kinds);
+    },
+  };
+}
+
+describe('makeReobserve', () => {
+  it('sweeps only the collectors mapped for the operation kind and flushes them', async () => {
+    const fsSweep = vi.fn(
+      async (): Promise<ObservationDelta[]> => [
+        {
+          kind: 'Filesystem',
+          id: 'mnt-data.mount',
+          op: 'upsert',
+          value: { status: { mounted: false } },
+        },
+      ],
+    );
+    const arraySweep = vi.fn(async (): Promise<ObservationDelta[]> => []);
+    const registry = new CollectorRegistry();
+    registry.register(fakeCollector('Filesystem', fsSweep));
+    registry.register(fakeCollector('XiraidArray', arraySweep));
+    const pub = fakePublisher();
+
+    const reobserve = makeReobserve(registry, pub);
+    await reobserve('fs.unmount');
+
+    // Only the Filesystem collector was swept.
+    expect(fsSweep).toHaveBeenCalledTimes(1);
+    expect(arraySweep).not.toHaveBeenCalled();
+    // Its delta was enqueued and the kind flushed with complete-snapshot semantics.
+    expect(pub.enqueued).toHaveLength(1);
+    expect(pub.enqueued[0]?.id).toBe('mnt-data.mount');
+    expect(pub.flushed).toEqual([['Filesystem']]);
+  });
+
+  it('is a no-op for an operation kind not in the settle table', async () => {
+    const fsSweep = vi.fn(async (): Promise<ObservationDelta[]> => []);
+    const registry = new CollectorRegistry();
+    registry.register(fakeCollector('Filesystem', fsSweep));
+    const pub = fakePublisher();
+
+    await makeReobserve(registry, pub)('reference.echo');
+
+    expect(fsSweep).not.toHaveBeenCalled();
+    expect(pub.enqueued).toHaveLength(0);
+    expect(pub.flushed).toHaveLength(0);
+  });
+
+  it('flushes with complete-snapshot semantics even when the sweep returns no rows', async () => {
+    // A filesystem removed from the host yields an empty sweep; the kind must
+    // still be flushed so the reconcile deletes the stale observed row.
+    const registry = new CollectorRegistry();
+    registry.register(fakeCollector('Filesystem', async () => []));
+    const pub = fakePublisher();
+
+    await makeReobserve(registry, pub)('fs.unmanage');
+
+    expect(pub.flushed).toEqual([['Filesystem']]);
+  });
+
+  it('swallows a collector sweep error and still resolves (poll backstop recovers)', async () => {
+    const registry = new CollectorRegistry();
+    registry.register(
+      fakeCollector('Filesystem', async () => {
+        throw new Error('probe blew up');
+      }),
+    );
+    const pub = fakePublisher();
+
+    await expect(makeReobserve(registry, pub)('fs.unmount')).resolves.toBeUndefined();
+    // Sweep failed → nothing to flush.
+    expect(pub.flushed).toHaveLength(0);
+  });
+
+  it('swallows a flush error and still resolves', async () => {
+    const registry = new CollectorRegistry();
+    registry.register(fakeCollector('Filesystem', async () => []));
+    const pub = {
+      enqueue(): void {},
+      async flushWithSnapshot(): Promise<void> {
+        throw new Error('api unreachable');
+      },
+    };
+
+    await expect(makeReobserve(registry, pub)('fs.unmount')).resolves.toBeUndefined();
+  });
+
+  it('maps every fs / xiraid.array / pool / share mutation to its observed kinds', () => {
+    expect(REOBSERVE_KINDS['fs.create']).toEqual(['Filesystem']);
+    expect(REOBSERVE_KINDS['fs.unmount']).toEqual(['Filesystem']);
+    expect(REOBSERVE_KINDS['fs.unmanage']).toEqual(['Filesystem']);
+    expect(REOBSERVE_KINDS['xiraid.array.create']).toEqual(['XiraidArray']);
+    expect(REOBSERVE_KINDS['xiraid.array.delete']).toEqual(['XiraidArray']);
+    expect(REOBSERVE_KINDS['pool.delete']).toEqual(['Pool']);
+    // share.* settles BOTH the NFS collector's kinds so a chained fs.unmount
+    // sees a just-removed export gone.
+    expect(REOBSERVE_KINDS['share.delete']).toEqual(['NfsSession', 'ExportRule']);
+    expect(REOBSERVE_KINDS['share.create']).toEqual(['NfsSession', 'ExportRule']);
+    // Non-mutating / unmapped kinds are absent.
+    expect(REOBSERVE_KINDS['reference.echo']).toBeUndefined();
+  });
+
+  // ── share.* : multi-kind NFS collector (kind NfsSession, also emits ExportRule) ──
+
+  it('share.delete: sweeps the NFS collector and flushes BOTH NfsSession + ExportRule', async () => {
+    const nfsSweep = vi.fn(
+      async (): Promise<ObservationDelta[]> => [
+        { kind: 'NfsSession', id: 'sess-1', op: 'upsert', value: {} },
+        { kind: 'ExportRule', id: 'srv-data', op: 'upsert', value: {} },
+      ],
+    );
+    const registry = new CollectorRegistry();
+    registry.register(fakeCollector('NfsSession', nfsSweep));
+    const pub = fakePublisher();
+
+    await makeReobserve(registry, pub)('share.delete');
+
+    expect(nfsSweep).toHaveBeenCalledTimes(1);
+    expect(pub.enqueued.map((d) => d.kind)).toEqual(['NfsSession', 'ExportRule']);
+    expect(pub.flushed).toEqual([['NfsSession', 'ExportRule']]);
+  });
+
+  it('share.delete: flushes ExportRule complete-snapshot even when the LAST export is gone (zero-export sweep)', async () => {
+    // The critical hazard: removing the last export yields a sweep with no
+    // ExportRule rows. The stale observed ExportRule must still reconcile away,
+    // so the complete-snapshot flush MUST include ExportRule.
+    const registry = new CollectorRegistry();
+    registry.register(fakeCollector('NfsSession', async () => []));
+    const pub = fakePublisher();
+
+    await makeReobserve(registry, pub)('share.delete');
+
+    expect(pub.flushed).toEqual([['NfsSession', 'ExportRule']]);
+  });
+
+  it('share.delete: a failed NFS sweep flushes NOTHING (no complete-snapshot delete of ExportRule)', async () => {
+    const registry = new CollectorRegistry();
+    registry.register(
+      fakeCollector('NfsSession', async () => {
+        throw new Error('nfs helper down');
+      }),
+    );
+    const pub = fakePublisher();
+
+    await expect(makeReobserve(registry, pub)('share.delete')).resolves.toBeUndefined();
+    expect(pub.flushed).toHaveLength(0);
+  });
+});

--- a/xiNAS-MCP/src/__tests__/agent/task/runner.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/task/runner.test.ts
@@ -459,9 +459,9 @@ describe('TaskRunner.run — uncaught throw always terminates (#255)', () => {
     );
 
     // Executor stages DID run (the host may have converged) ...
-    expect(
-      events.some((e) => e.event_type === 'stage_succeeded' && e.stage_name === 'apply'),
-    ).toBe(true);
+    expect(events.some((e) => e.event_type === 'stage_succeeded' && e.stage_name === 'apply')).toBe(
+      true,
+    );
     // ... so the terminal escalates to manual recovery, not a plain failure.
     const terminal = events.at(-1);
     expect(terminal?.event_type).toBe('terminal');
@@ -470,6 +470,104 @@ describe('TaskRunner.run — uncaught throw always terminates (#255)', () => {
     expect(terminal?.error_message).toMatch(/code 1/);
     expect(events.map((e) => e.sequence)).toEqual(events.map((_e, i) => i + 1));
     expect(runner.getInflight().has('ta')).toBe(false);
+  });
+});
+
+// ── Post-apply observed settle (§7.1): reobserve fires before terminal ───────
+
+describe('TaskRunner.run — post-apply observed settle (§7.1)', () => {
+  function makeRunnerWithReobserve(
+    bridge: XinasHistoryBridge,
+    reobserve: (operationKind: string) => Promise<void>,
+  ): TaskRunner {
+    let n = 0;
+    return new TaskRunner({
+      bridge,
+      now: () => new Date(1_700_000_000_000 + n++ * 1000).toISOString(),
+      reobserve,
+    });
+  }
+
+  it('invokes reobserve(operation_kind) once, BEFORE the terminal event, on success', async () => {
+    const order: string[] = [];
+    const events: TaskProgressEvent[] = [];
+    const publish = vi.fn(async (e: TaskProgressEvent) => {
+      events.push(e);
+      order.push(`emit:${e.event_type}`);
+    });
+    const reobserve = vi.fn(async (kind: string) => {
+      order.push(`reobserve:${kind}`);
+    });
+    const runner = makeRunnerWithReobserve(makeBridge(['b', 'a']), reobserve);
+
+    await runner.run(
+      { task_id: 'tr', operation_kind: 'fs.unmount', spec: {} },
+      referenceExecutor,
+      publish,
+    );
+
+    expect(reobserve).toHaveBeenCalledTimes(1);
+    expect(reobserve).toHaveBeenCalledWith('fs.unmount');
+    // The settle happens strictly between snapshot_after and terminal.
+    const reIdx = order.indexOf('reobserve:fs.unmount');
+    const termIdx = order.indexOf('emit:terminal');
+    expect(reIdx).toBeGreaterThanOrEqual(0);
+    expect(termIdx).toBeGreaterThan(reIdx);
+    expect(events.at(-1)?.status).toBe('success');
+  });
+
+  it('does NOT invoke reobserve on the failure/rollback path', async () => {
+    const events: TaskProgressEvent[] = [];
+    const publish = vi.fn(async (e: TaskProgressEvent) => {
+      events.push(e);
+    });
+    const reobserve = vi.fn(async () => {});
+    const runner = makeRunnerWithReobserve(makeBridge(['b', 'a']), reobserve);
+
+    await runner.run(
+      { task_id: 'trf', operation_kind: 'fs.unmount', spec: { fail_at_stage: 'apply' } },
+      referenceExecutor,
+      publish,
+    );
+
+    expect(reobserve).not.toHaveBeenCalled();
+    expect(events.at(-1)?.status).toBe('failed');
+  });
+
+  it('is best-effort: a reobserve rejection does not block the terminal(success)', async () => {
+    const events: TaskProgressEvent[] = [];
+    const publish = vi.fn(async (e: TaskProgressEvent) => {
+      events.push(e);
+    });
+    const reobserve = vi.fn(async () => {
+      throw new Error('settle exploded');
+    });
+    const runner = makeRunnerWithReobserve(makeBridge(['b', 'a']), reobserve);
+
+    await runner.run(
+      { task_id: 'trb', operation_kind: 'fs.unmount', spec: {} },
+      referenceExecutor,
+      publish,
+    );
+
+    expect(reobserve).toHaveBeenCalledTimes(1);
+    const terminal = events.at(-1);
+    expect(terminal?.event_type).toBe('terminal');
+    expect(terminal?.status).toBe('success');
+  });
+
+  it('runs unchanged when no reobserve is injected (default no-op)', async () => {
+    const events: TaskProgressEvent[] = [];
+    const publish = vi.fn(async (e: TaskProgressEvent) => {
+      events.push(e);
+    });
+    const runner = makeRunner(makeBridge(['b', 'a']));
+    await runner.run(
+      { task_id: 'trn', operation_kind: 'fs.unmount', spec: {} },
+      referenceExecutor,
+      publish,
+    );
+    expect(events.at(-1)?.status).toBe('success');
   });
 });
 

--- a/xiNAS-MCP/src/agent-server.ts
+++ b/xiNAS-MCP/src/agent-server.ts
@@ -31,6 +31,7 @@ import { STUB_METHODS } from './agent/rpc/methods/stubs.js';
 import { makeTaskHandlers } from './agent/rpc/methods/task.js';
 import { makeVersionHandler } from './agent/rpc/methods/version.js';
 import { createAgentRpcServer } from './agent/rpc/server.js';
+import { makeReobserve } from './agent/task/reobserve.js';
 import { buildTaskSubsystem } from './agent/task/wiring.js';
 
 const VERSION = process.env['XINAS_AGENT_VERSION'] ?? '0.0.0-dev';
@@ -92,7 +93,14 @@ async function main(): Promise<void> {
   // `task.list_inflight` into it. T0 removed the four task.* from
   // STUB_METHODS, so registering the real handlers after the
   // ...STUB_METHODS spread shadows nothing.
-  const taskSubsystem = buildTaskSubsystem(config, { xiraidClient: convergence.xiraidClient });
+  // §7.1: the post-apply observed settle re-runs the convergence collectors
+  // (via the same registry the poll driver uses) and flushes through the
+  // convergence publisher, so a chained follow-up plan (unmount→unmanage)
+  // reads post-apply observed state before the terminal event.
+  const taskSubsystem = buildTaskSubsystem(config, {
+    xiraidClient: convergence.xiraidClient,
+    reobserve: makeReobserve(convergence.registry, convergence.publisher),
+  });
   const taskHandlers = makeTaskHandlers({
     runner: taskSubsystem.runner,
     registry: taskSubsystem.registry,

--- a/xiNAS-MCP/src/agent/task/reobserve.ts
+++ b/xiNAS-MCP/src/agent/task/reobserve.ts
@@ -1,0 +1,120 @@
+/**
+ * Post-apply observed settle (s2-task-envelope-spec §7.1).
+ *
+ * Observed rows (`/xinas/v1/observed/<kind>/<id>`) are refreshed only by the
+ * collectors — event streams plus a poll backstop (Filesystem is poll-only,
+ * 60 s). A client that chains two plan/apply calls back-to-back (the
+ * Delete-Array / Delete-Filesystem teardown issues `fs.unmount` then
+ * `fs.unmanage`) would have the second call's preflight read the PRE-apply
+ * observed snapshot — e.g. `fs.unmanage` sees the just-unmounted filesystem
+ * still `mounted: true` and returns the `fs_mounted` blocker. This module
+ * re-runs the affected collectors and flushes them BEFORE the runner emits
+ * `terminal` (the event `plan_apply_wait` blocks on), so the next plan reads
+ * post-apply state. It reuses the exact `initialSweep → enqueue →
+ * flushWithSnapshot` the poll driver uses, so reconcile semantics are
+ * identical.
+ */
+import type { Collector, Kind, ObservationDelta } from '../collectors/base.js';
+import { log } from '../log.js';
+
+/** The minimal publisher surface the settle needs (Publisher implements it). */
+export interface ReobservePublisher {
+  enqueue(delta: ObservationDelta): void;
+  flushWithSnapshot(kinds: Kind[]): Promise<void>;
+}
+
+/** The minimal registry surface the settle needs (CollectorRegistry implements it). */
+export interface ReobserveRegistry {
+  list(): readonly Collector[];
+}
+
+/**
+ * `operation_kind` → observed kinds to settle after a successful apply (§7.1).
+ * Operation kinds absent here skip the settle (the poll backstop still
+ * reconciles within one interval).
+ *
+ * INVARIANT: every kind in an entry is (co-)emitted by a collector whose `kind`
+ * is ALSO in that entry — so sweeping the entry's collector-kind collectors
+ * yields a complete snapshot of every listed kind. The NFS collector's `kind`
+ * is `NfsSession` but its one sweep also emits `ExportRule`, so `share.*`
+ * lists both: settling `ExportRule` is what lets a chained `fs.unmount` see a
+ * just-removed export gone (`validateFsUnmount`'s `mountpoint_exported`) — even
+ * when the LAST export is removed and the sweep carries zero `ExportRule` rows
+ * (the complete-snapshot flush then reconciles the stale row away).
+ */
+export const REOBSERVE_KINDS: Record<string, Kind[]> = {
+  'fs.create': ['Filesystem'],
+  'fs.mount': ['Filesystem'],
+  'fs.unmount': ['Filesystem'],
+  'fs.grow': ['Filesystem'],
+  'fs.set_quota_mode': ['Filesystem'],
+  'fs.unmanage': ['Filesystem'],
+  'xiraid.array.create': ['XiraidArray'],
+  'xiraid.array.modify': ['XiraidArray'],
+  'xiraid.array.import': ['XiraidArray'],
+  'xiraid.array.delete': ['XiraidArray'],
+  'pool.create': ['Pool'],
+  'pool.modify': ['Pool'],
+  'pool.delete': ['Pool'],
+  'share.create': ['NfsSession', 'ExportRule'],
+  'share.update': ['NfsSession', 'ExportRule'],
+  'share.delete': ['NfsSession', 'ExportRule'],
+};
+
+/**
+ * The settle callback injected into the {@link TaskRunner}. Resolves ALWAYS
+ * (best-effort); it never rejects and never blocks the task's terminal event.
+ */
+export type Reobserve = (operationKind: string) => Promise<void>;
+
+/**
+ * Build the post-apply observed settle (§7.1). Best-effort: every collector
+ * sweep or flush error is logged and swallowed, and the promise always
+ * resolves so the runner can proceed to `terminal` — the poll backstop
+ * remains the durable reconcile.
+ */
+export function makeReobserve(
+  registry: ReobserveRegistry,
+  publisher: ReobservePublisher,
+): Reobserve {
+  return async (operationKind: string): Promise<void> => {
+    const kinds = REOBSERVE_KINDS[operationKind];
+    if (kinds === undefined || kinds.length === 0) return;
+    const wanted = new Set<Kind>(kinds);
+    // The entry's kinds that a registered collector produces directly (its
+    // `kind`); the remaining kinds (e.g. ExportRule) are co-emitted by one of
+    // these collectors' sweeps. Only when EVERY collector-kind swept cleanly do
+    // we run the complete-snapshot flush — otherwise a failed sweep could
+    // reconcile a kind's rows away against an empty batch.
+    const registeredKinds = new Set<Kind>(registry.list().map((c) => c.kind));
+    const collectorKinds = kinds.filter((k) => registeredKinds.has(k));
+    const sweptOk = new Set<Kind>();
+    for (const collector of registry.list()) {
+      if (!wanted.has(collector.kind)) continue;
+      try {
+        const deltas = await collector.initialSweep();
+        for (const delta of deltas) publisher.enqueue(delta);
+        sweptOk.add(collector.kind);
+      } catch (err) {
+        log('error', 'reobserve', 'reobserve_sweep_failed', {
+          kind: collector.kind,
+          operation_kind: operationKind,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    if (collectorKinds.length === 0 || !collectorKinds.every((k) => sweptOk.has(k))) return;
+    // Complete-snapshot flush of the FULL settle set — including a kind whose
+    // sweep produced zero rows (the last export removed), so its stale observed
+    // row reconciles away. Safe because every collector-kind swept cleanly and
+    // each such sweep carries a complete snapshot of every kind it owns.
+    try {
+      await publisher.flushWithSnapshot(kinds);
+    } catch (err) {
+      log('error', 'reobserve', 'reobserve_flush_failed', {
+        operation_kind: operationKind,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+}

--- a/xiNAS-MCP/src/agent/task/runner.ts
+++ b/xiNAS-MCP/src/agent/task/runner.ts
@@ -26,12 +26,22 @@ import type {
   TaskProgressEvent,
   TaskProgressEventType,
 } from './types.js';
+import type { Reobserve } from './reobserve.js';
 import type { XinasHistoryBridge } from './xinas-history-bridge.js';
 
 export interface TaskRunnerOptions {
   bridge: XinasHistoryBridge;
   /** Clock for `observed_at`. Default: `() => new Date().toISOString()`. */
   now?: () => string;
+  /**
+   * Post-apply observed settle (§7.1). Called on the SUCCESS path between
+   * `snapshot_after` and `terminal` to refresh the observed rows the operation
+   * mutated, so a chained follow-up plan (unmount→unmanage) reads post-apply
+   * state instead of the pre-apply snapshot. Best-effort — it resolves always
+   * and never blocks the terminal event. Default: no settle (unit/fixture
+   * builds and the reference executor need none).
+   */
+  reobserve?: Reobserve;
 }
 
 /** Bookkeeping for a task the runner is currently executing. */
@@ -50,11 +60,13 @@ const ROLLBACK_STAGE = 'rollback';
 export class TaskRunner {
   readonly #bridge: XinasHistoryBridge;
   readonly #now: () => string;
+  readonly #reobserve: Reobserve | undefined;
   readonly #inflight = new Map<string, InflightTask>();
 
   constructor(opts: TaskRunnerOptions) {
     this.#bridge = opts.bridge;
     this.#now = opts.now ?? (() => new Date().toISOString());
+    this.#reobserve = opts.reobserve;
   }
 
   /** The in-flight registry (read by T7's `task.list_inflight`). */
@@ -206,6 +218,20 @@ export class TaskRunner {
         status: 'succeeded',
         snapshot_id: after.snapshot_id,
       });
+      // Post-apply observed settle (§7.1): refresh the observed rows this
+      // operation mutated BEFORE the terminal event the client's
+      // plan_apply_wait blocks on, so a chained follow-up plan (e.g.
+      // unmount→unmanage) reads post-apply state instead of the pre-apply
+      // snapshot. Best-effort — the callback absorbs its own errors and
+      // resolves always; this guard covers a defensive throw so a settle
+      // failure can never wedge the terminal (the poll backstop reconciles).
+      if (this.#reobserve) {
+        try {
+          await this.#reobserve(begin.operation_kind);
+        } catch {
+          /* best-effort; poll backstop remains the durable reconcile */
+        }
+      }
       await emit('terminal', { status: 'success', snapshot_id: after.snapshot_id });
     } catch (err) {
       // A throw that escapes the per-stage try/catch above — the

--- a/xiNAS-MCP/src/agent/task/wiring.ts
+++ b/xiNAS-MCP/src/agent/task/wiring.ts
@@ -43,6 +43,7 @@ import { makeNetIfaceUpdateExecutor, makeNetPoolApplyExecutor } from './net-exec
 import { buildNfsExecutors, type NfsExecutorDeps } from './nfs-executor.js';
 import { createNfsHelperClientFromProbe } from './nfs-helper-client.js';
 import { createProgressPublisher } from './progress-publisher.js';
+import type { Reobserve } from './reobserve.js';
 import { ExecutorRegistry } from './registry.js';
 import { TaskRunner } from './runner.js';
 import type { PublishProgress } from './types.js';
@@ -188,6 +189,9 @@ export function buildTaskSubsystem(
     /** Host-command seam override; default: fake in fixture mode, real otherwise. */
     fsHost?: FsHost;
     netHost?: NetHost;
+    /** Post-apply observed settle (§7.1), built from the convergence registry +
+     *  publisher. Omitted in unit/fixture builds → the runner does no settle. */
+    reobserve?: Reobserve;
   } = {},
 ): TaskSubsystem {
   const registry = new ExecutorRegistry();
@@ -241,7 +245,10 @@ export function buildTaskSubsystem(
   }
   // S9 T5: the baseline-reset executor shares the runner's bridge.
   registry.register(makeConfigRollbackExecutor({ bridge }));
-  const runner = new TaskRunner({ bridge });
+  const runner = new TaskRunner({
+    bridge,
+    ...(opts.reobserve ? { reobserve: opts.reobserve } : {}),
+  });
   const publish = createProgressPublisher({
     apiSocketPath: config.api_socket,
     agentToken: config.agent_token,


### PR DESCRIPTION
## Problem

The **Delete Array** (and Delete Filesystem) teardown chains `fs.unmount` then `fs.unmanage` back-to-back. `fs.unmanage`'s preflight gates on the KV **observed** `mounted` flag ([filesystem.ts](../blob/main/xiNAS-MCP/src/api/plan/providers/filesystem.ts)), which is refreshed only by the collector poll — `Filesystem` is poll-only at 60 s (its mount-unit watch is a no-op in production). The `DELETE` fires faster than the collector re-observes, so it reads the pre-unmount `mounted: true` and returns the `fs_mounted` blocker:

> Failed to unmanage 'mnt-data.mount': plan blocked: unmount the filesystem before removing it from management

…even though the unmount apply's own executor `verify` stage already confirmed the host is unmounted. The teardown stops mid-sequence (shares removed, fs unmounted, but the unit still "managed" and the array intact). Any client chaining two plan/apply calls hits this — MCP and CLI too.

## Fix — post-apply observed settle (`s2-task-envelope-spec` §7.1)

The agent `TaskRunner`, **on the success path**, re-runs the collectors for the observed kinds the operation mutated and `await`s a `flushWithSnapshot([kinds])` into the api KV **between `snapshot_after` and `terminal`** — the event a client's `plan_apply_wait` blocks on. So the next chained plan reads post-apply state.

- Reuses the poll driver's exact `initialSweep → enqueue → flushWithSnapshot` (identical reconcile semantics).
- **Best-effort:** a sweep/flush error is logged and swallowed; the poll backstop remains the durable reconcile; a settle failure can never wedge the terminal.
- **Success-path only.**

### Settle table (`REOBSERVE_KINDS`)

| operation_kind | settled kinds |
|---|---|
| `fs.*` | `Filesystem` |
| `xiraid.array.*` | `XiraidArray` |
| `pool.*` | `Pool` |
| `share.*` | `NfsSession`, `ExportRule` |

The `share.*` entry also closes the Delete-Array chain's `share.delete → fs.unmount` stale-`ExportRule` hazard (`validateFsUnmount`'s `mountpoint_exported`), **including the last-export-removed case** — the complete-snapshot flush reconciles the stale row away. **Invariant:** every kind in an entry is co-emitted by a collector whose `kind` is in that entry; the complete-snapshot flush runs only when every collector-kind swept cleanly, so a failed sweep never deletes rows against an empty batch.

## Verification

- `tsc --noEmit` clean; `biome` format clean; no new lint warnings.
- Full unit suite: **1336 passed** (13 new: settle mapping/sweep/flush/best-effort + runner ordering).
- e2e roundtrips (real agent↔api, fixture mode): fs, xiraid-array, pool, task-engine, **nfs**, agent-api — all pass, no regression.
- **Limitation (honest):** CI's fixture filesystem probe is static (decoupled from the fake host), so it proves the settle logic/ordering + no-regression but can't demonstrate the stale→fresh transition — that needs the real `/proc/self/mountinfo` probe on a systemd host, already routed to the hardware smoke runbook per `s5-filesystem-spec`.

## Rebuild

Touches `xiNAS-MCP/src/agent/*` (compiled into `dist/agent-server.js`), so the commit carries `Requires-Rebuild: xinas_node_build` — the default release-tag update won't rebuild `dist/` otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)