### PR TITLE
fix(collect-logs): update default transfer server to 5.75.230.104

### DIFF
--- a/collect_data.sh
+++ b/collect_data.sh
@@ -59,7 +59,7 @@ main() {
     archive="/tmp/${cfg}.tgz"
     tar czf "$archive" -C "$tmp" .
 
-    server=${TRANSFER_SERVER:-"http://178.253.23.152:8080"}
+    server=${TRANSFER_SERVER:-"http://5.75.230.104:8080"}
 
     info_box "Uploading" "Uploading data to server..."
 

--- a/xinas_menu/screens/collect_logs.py
+++ b/xinas_menu/screens/collect_logs.py
@@ -320,7 +320,7 @@ def _create_archive(tmp: str, hostname: str) -> str:
 
 
 def _upload(archive_path: str) -> tuple[bool, str]:
-    server = os.environ.get("TRANSFER_SERVER", "http://178.253.23.152:8080")
+    server = os.environ.get("TRANSFER_SERVER", "http://5.75.230.104:8080")
     basename = Path(archive_path).name
     try:
         r = subprocess.run(


### PR DESCRIPTION
## Summary
- Point the default logs-upload transfer server from `178.253.23.152:8080` to `5.75.230.104:8080` in both collectors.

## Changes
- `collect_data.sh` — bash installer collector default (line 62)
- `xinas_menu/screens/collect_logs.py` — Python TUI "Collect Logs" screen default (line 323)

The `TRANSFER_SERVER` env override is unchanged. Code-only change; no `Requires-Rebuild:` trailer needed.

## Test
- Uploaded a test file to the new server using the same `curl --upload-file` flow the code uses → success (exit 0), and the returned URL was retrievable with matching content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)