### PR TITLE
fix(net_controllers): data NICs never got an IP from the pool

### DIFF
--- a/collection/roles/doca_ofed/defaults/main.yml
+++ b/collection/roles/doca_ofed/defaults/main.yml
@@ -10,7 +10,8 @@ doca_pkgs:
 
 doca_ofed_auto_reboot: false
 
-# Netplan template containing desired InfiniBand names
-ib_netplan_template: "/opt/provision/collection/roles/net_controllers/templates/netplan.yaml.j2"
+# Netplan template containing desired InfiniBand names. Resolved relative to the
+# playbook so it follows the repo wherever it is checked out.
+ib_netplan_template: "{{ playbook_dir }}/../collection/roles/net_controllers/templates/netplan.yaml.j2"
 # Location of generated udev rules for InfiniBand
 ib_udev_rules_file: "/etc/udev/rules.d/70-ib-names.rules"

--- a/collection/roles/doca_ofed/files/configure_ib_udev.sh
+++ b/collection/roles/doca_ofed/files/configure_ib_udev.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
-CONFIG_FILE="${1:-/opt/provision/collection/roles/net_controllers/templates/netplan.yaml.j2}"
+CONFIG_FILE="${1:-/opt/xiNAS/collection/roles/net_controllers/templates/netplan.yaml.j2}"
 RULES_FILE="${2:-/etc/udev/rules.d/70-ib-names.rules}"
 
+# Renaming is opt-in: it only happens when the netplan config pins literal ibN
+# names. A pool-allocated config keeps the kernel's predictable names, so every
+# "noop:" below is a legitimate outcome, not a failure. They are printed so the
+# caller can tell "did nothing" apart from "renamed something".
 if [ ! -f "$CONFIG_FILE" ]; then
+    echo "noop: config file not found: $CONFIG_FILE" >&2
     exit 0
 fi
 
@@ -21,7 +26,13 @@ done
 num_names=${#names[@]}
 num_ifaces=${#ib_ifaces[@]}
 
-if [ "$num_names" -eq 0 ] || [ "$num_ifaces" -eq 0 ]; then
+if [ "$num_names" -eq 0 ]; then
+    echo "noop: no literal ibN names in $CONFIG_FILE; keeping predictable names"
+    exit 0
+fi
+
+if [ "$num_ifaces" -eq 0 ]; then
+    echo "noop: no InfiniBand interfaces present"
     exit 0
 fi
 
@@ -39,7 +50,14 @@ for ((i=0; i<max; i++)); do
     echo "SUBSYSTEM==\"net\", ACTION==\"add\", ATTR{address}==\"$addr\", NAME=\"$name\"" >> "$tmp"
 done
 
+if cmp -s "$tmp" "$RULES_FILE"; then
+    rm -f "$tmp"
+    echo "unchanged: $max rule(s) already current in $RULES_FILE"
+    exit 0
+fi
+
 install -m 0644 "$tmp" "$RULES_FILE"
 rm -f "$tmp"
 
 udevadm control --reload
+echo "changed: wrote $max rule(s) to $RULES_FILE"

--- a/collection/roles/doca_ofed/tasks/main.yml
+++ b/collection/roles/doca_ofed/tasks/main.yml
@@ -109,7 +109,12 @@
     {{ ib_netplan_template }}
     {{ ib_udev_rules_file }}
   register: ib_udev_result
-  changed_when: ib_udev_result.rc == 0
+  changed_when: ib_udev_result.stdout is search('^changed:')
+  tags: [ofed, udev]
+
+- name: Report InfiniBand UDEV rename outcome
+  ansible.builtin.debug:
+    msg: "{{ ib_udev_result.stdout | default(ib_udev_result.stderr) | default('(no output)') }}"
   tags: [ofed, udev]
 
 - name: Reboot if kernel modules built and reboot requested

--- a/configure_network.sh
+++ b/configure_network.sh
@@ -231,8 +231,15 @@ configure_manual() {
         done
     done
 
+    # Nothing was configured. Overwriting the role template with a guessed
+    # interface name would silently strand every NIC without an address, so
+    # leave it alone and hand the box back to pool mode.
     if [[ ${#configs[@]} -eq 0 ]]; then
-        configs=("ib0:100.100.100.1/24")
+        if [[ -f "$ROLE_DEFAULTS" ]]; then
+            yq -i '.net_ip_pool_enabled = true' "$ROLE_DEFAULTS"
+        fi
+        msg_box "No Changes" "No interfaces were configured.\n\nThe netplan template was left untouched and IP pool mode is still enabled."
+        return
     fi
 
     tmp_file=$(mktemp)

--- a/presets/default/netplan.yaml.j2
+++ b/presets/default/netplan.yaml.j2
@@ -1,7 +1,0 @@
-network:
-  version: 2
-  renderer: networkd
-  ethernets:
-    ib0:
-      dhcp4: no
-      addresses: [ 100.100.100.1/24 ]

--- a/presets/xinnorVM/netplan.yaml.j2
+++ b/presets/xinnorVM/netplan.yaml.j2
@@ -1,7 +1,0 @@
-network:
-  version: 2
-  renderer: networkd
-  ethernets:
-    ib0:
-      dhcp4: no
-      addresses: [ 100.100.100.1/24 ]

--- a/tests/test_net_controllers_template.py
+++ b/tests/test_net_controllers_template.py
@@ -1,0 +1,102 @@
+"""Regression guard for netplan IP assignment on the data interfaces.
+
+`net_controllers` detects high-speed NICs and allocates each one an address from
+`net_ip_pool_*`, rendering them through `templates/netplan.yaml.j2`. Two bugs
+used to defeat that end to end:
+
+1. `presets/{default,xinnorVM}/netplan.yaml.j2` were static snapshots taken back
+   when the template had no Jinja in it. `autoinstall.sh` copies preset files
+   over role files, so the dynamic template was replaced by a literal config for
+   an interface named `ib0`. The pool was computed and then thrown away.
+
+2. Those snapshots pinned `ib0`, which only exists if `doca_ofed` renames the
+   ports via udev. Its `ib_netplan_template` default pointed at `/opt/provision`
+   — a path this repo never installs to — so `configure_ib_udev.sh` bailed at its
+   `[ ! -f ]` guard and no rename ever happened. netplan then emitted a
+   `[Match] Name=ib0` stanza matching nothing, `netplan generate` returned 0, and
+   every data NIC came up with no address and no error anywhere.
+
+These are structural assertions over the repo, matching the approach in
+tests/test_nvme_namespace_fallback.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[1]
+TEMPLATE = REPO / "collection/roles/net_controllers/templates/netplan.yaml.j2"
+OFED_DEFAULTS = REPO / "collection/roles/doca_ofed/defaults/main.yml"
+PRESETS = ("default", "xinnorVM")
+
+
+def test_presets_do_not_ship_a_netplan_template():
+    """A preset netplan.yaml.j2 clobbers the role's dynamic template."""
+    for preset in PRESETS:
+        assert not (REPO / f"presets/{preset}/netplan.yaml.j2").exists(), (
+            f"presets/{preset}/netplan.yaml.j2 would overwrite the role template "
+            "and strand every data NIC without an IP"
+        )
+
+
+def test_role_template_renders_the_allocated_pool():
+    """The template must consume net_allocated_ips, not hardcode a name."""
+    body = TEMPLATE.read_text()
+    assert "net_allocated_ips" in body
+    assert "{% for iface, ip in net_allocated_ips.items() %}" in body
+
+
+def test_role_template_hardcodes_no_interface_or_address():
+    """No literal ibN: stanza or address outside of comments."""
+    for lineno, line in enumerate(TEMPLATE.read_text().splitlines(), 1):
+        code = line.split("#", 1)[0]
+        assert "100.100.100" not in code, f"hardcoded address at line {lineno}"
+        stripped = code.strip()
+        if stripped.startswith("ib") and stripped.endswith(":"):
+            raise AssertionError(f"hardcoded interface {stripped!r} at line {lineno}")
+
+
+def test_ib_netplan_template_points_at_this_repo():
+    """/opt/provision never exists, so the udev rename silently no-ops."""
+    defaults = yaml.safe_load(OFED_DEFAULTS.read_text())
+    path = defaults["ib_netplan_template"]
+    assert "/opt/provision" not in path
+    assert "playbook_dir" in path, "path must resolve relative to the playbook"
+    assert path.endswith("collection/roles/net_controllers/templates/netplan.yaml.j2")
+
+
+def test_udev_rename_reports_whether_it_changed_anything():
+    """changed_when must key off the script's marker, not its exit code.
+
+    The script exits 0 on every no-op path, so `rc == 0` reported "changed" even
+    when it wrote nothing.
+    """
+    tasks = yaml.safe_load(
+        (REPO / "collection/roles/doca_ofed/tasks/main.yml").read_text()
+    )
+    task = next(
+        t for t in tasks if t.get("name") == "Generate UDEV rules for InfiniBand interfaces"
+    )
+    assert "rc == 0" not in str(task["changed_when"])
+    assert "changed:" in str(task["changed_when"])
+
+
+def test_udev_script_emits_outcome_markers():
+    script = (
+        REPO / "collection/roles/doca_ofed/files/configure_ib_udev.sh"
+    ).read_text()
+    assert "/opt/provision" not in script
+    for marker in ("noop:", "changed:", "unchanged:"):
+        assert marker in script, f"missing {marker!r} outcome marker"
+
+
+def test_manual_network_config_has_no_guessed_fallback():
+    """configure_manual() must not invent an ib0 config when nothing was set."""
+    body = (REPO / "configure_network.sh").read_text()
+    for lineno, line in enumerate(body.splitlines(), 1):
+        code = line.split("#", 1)[0]
+        assert "ib0:100.100.100.1/24" not in code, (
+            f"guessed fallback config at configure_network.sh:{lineno}"
+        )


### PR DESCRIPTION
The default and xinnorVM presets each shipped a netplan.yaml.j2 that contained no Jinja at all -- a static snapshot taken in 6b6819f, when the role template was still a literal file. autoinstall.sh copies preset files over role files, so every install replaced the dynamic template with a config for a single interface named ib0. net_controllers still detected the NICs and still computed net_allocated_ips; the render then discarded it.

ib0 only exists if doca_ofed renames the ports, and that path was dead too: ib_netplan_template pointed at /opt/provision, which this repo never installs to, so configure_ib_udev.sh returned at its `[ ! -f ]` guard. Its exit code is 0 on that path, and `changed_when: rc == 0` dutifully reported "changed".

The result was a netplan stanza matching no interface. netplan generate accepts that and exits 0, so nothing failed anywhere -- the data interfaces simply came up unaddressed and unbrought-up.

- drop the two preset snapshots so the role's dynamic template survives, as done for nvme_namespace.yml in the same situation
- resolve ib_netplan_template via playbook_dir, per the common role
- make configure_ib_udev.sh print noop:/changed:/unchanged: and key changed_when off the marker; echo the outcome so a no-op is visible
- stop configure_manual() from inventing ib0:100.100.100.1/24 when the operator configures nothing -- it had already disabled the IP pool by then, so cancelling out stranded every NIC

With the preset snapshots gone the three IB ports render as ibp65s0/ibp9s0f0/ibp9s0f1 on 10.10.{1,2,3}.1/24, MTU 4092, each with its own routing table.