### PR TITLE
fix(agent): RestrictNamespaces silently disabled; order agent after n…

### DIFF
--- a/tests/test_agent_unit.py
+++ b/tests/test_agent_unit.py
@@ -26,6 +26,16 @@ def _read_write_paths() -> str:
     return " ".join(ln for ln in UNIT.read_text().splitlines() if ln.startswith("ReadWritePaths="))
 
 
+def _directive(name: str) -> list[str]:
+    """Values of every ``name=`` directive, comments excluded."""
+    prefix = f"{name}="
+    return [
+        ln[len(prefix) :].strip()
+        for ln in UNIT.read_text().splitlines()
+        if ln.startswith(prefix)
+    ]
+
+
 def test_unit_file_exists():
     assert UNIT.is_file(), UNIT
 
@@ -39,3 +49,34 @@ def test_state_dir_stays_read_only():
     # ADR-0002: the api is the sole SQLite writer; the agent must NOT be granted
     # write access to /var/lib/xinas/state.
     assert "/var/lib/xinas/state" not in _read_write_paths()
+
+
+def test_restrict_namespaces_parses():
+    """A repeated ``~`` makes systemd drop the directive, unsandboxing the agent.
+
+    ``RestrictNamespaces=~cgroup ~user`` logs "Failed to parse namespace type
+    string, ignoring: cgroup ~user" and applies NO restriction at all. The
+    leading ``~`` already negates the whole list.
+    """
+    values = _directive("RestrictNamespaces")
+    assert values, "RestrictNamespaces directive is missing"
+    for value in values:
+        assert not value.lstrip("~").lstrip().startswith("~"), value
+        assert "~" not in value[1:], f"only a leading ~ is valid, got: {value!r}"
+
+    # The hardening the surrounding comment promises: deny cgroup + user ns.
+    assert values[-1].split() == ["~cgroup", "user"], values[-1]
+
+
+def test_agent_is_ordered_after_the_nfs_helper():
+    """The NfsSession initialSweep() connects to the helper's unix socket.
+
+    With no ordering the agent raced it on every boot and lost the sweep to
+    ENOENT. Soft (``Wants=``) so the agent still starts where the helper is
+    absent; ``Requires=`` would make the agent fail with it.
+    """
+    after = " ".join(_directive("After"))
+    wants = " ".join(_directive("Wants"))
+    assert "xinas-nfs-helper.service" in after
+    assert "xinas-nfs-helper.service" in wants
+    assert "xinas-nfs-helper.service" not in " ".join(_directive("Requires"))

--- a/xiNAS-MCP/xinas-agent.service
+++ b/xiNAS-MCP/xinas-agent.service
@@ -1,9 +1,14 @@
 [Unit]
 Description=xinas-agent — privileged observation and execution daemon (Phase 0)
 Documentation=https://github.com/Xinnor/xiNAS/blob/main/collection/roles/xinas_agent/README.md
-After=network-online.target xinas-api.service
+# xinas-nfs-helper is ordered-after but only Wants=: the NfsSession collector's
+# initialSweep() connects to /run/xinas-nfs-helper.sock, and without the ordering
+# it races the helper on every boot, losing that sweep to ENOENT (PollDriver
+# recovers it later, but agent.health reports error until then). Soft dep so the
+# agent still starts where the helper is not deployed.
+After=network-online.target xinas-api.service xinas-nfs-helper.service
 Requires=xinas-api.service
-Wants=network-online.target
+Wants=network-online.target xinas-nfs-helper.service
 
 [Service]
 Type=simple
@@ -119,7 +124,10 @@ RemoveIPC=true
 # perspective) but prevent the agent from creating new namespaces itself.
 # The probe subprocesses (ip, udevadm) inherit the parent's namespace — this
 # is intentional: they observe the host, not a container namespace.
-RestrictNamespaces=~cgroup ~user
+# The leading ~ negates the WHOLE list; repeating it ("~cgroup ~user") makes
+# systemd fail to parse the value and drop the directive entirely, leaving the
+# agent unrestricted.
+RestrictNamespaces=~cgroup user
 
 # --- System call filter ---
 # @system-service  — baseline for a long-running service (read/write/open/mmap etc.)


### PR DESCRIPTION
…fs-helper

`RestrictNamespaces=~cgroup ~user` does not mean "deny cgroup and user". The leading `~` already negates the whole list, so the second one is a parse error:

    xinas-agent.service:122: Failed to parse namespace type string,
                             ignoring: cgroup ~user

systemd drops the directive entirely on that path, so the agent has run with NO namespace restriction at all -- the opposite of what the comment above it promises. `systemd-analyze verify` flags it on every start. Corrected to `~cgroup user`, which denies both.

Separately, the agent's NfsSession collector connects to the helper's unix socket in initialSweep(), but the unit had no ordering against xinas-nfs-helper.service, so on boot it lost that sweep to:

    initial_sweep_failed  NfsSession  connect ENOENT /run/xinas-nfs-helper.sock

Added After= + Wants= (soft, so the agent still starts where the helper is not deployed; Requires= would couple their failures). Note this narrows the window rather than closing it: the helper is Type=simple, so ordering only guarantees it was forked, not that it has bound the socket. That residue is benign -- boot.ts deliberately skips a failed sweep and PollDriver re-sweeps once the probe recovers. Closing it fully would need socket activation or Type=notify.

Guards added to tests/test_agent_unit.py; both fail against v3.6.3.