### PR TITLE
feat: restrict NFS shares to xiRAID-backed filesystems

### DIFF
--- a/docs/Storage/fs-shares-management-spec.md
+++ b/docs/Storage/fs-shares-management-spec.md
@@ -306,7 +306,10 @@ SOURCE is a xiRAID volume (`/dev/xi_*`) — an NFS export is allowed **only** fr
 filesystem on a xiRAID array. If no such mount exists, the wizard aborts **before
 it starts** with an OK-only dialog directing the operator to *Storage →
 Filesystems → Create Filesystem* (the former free-form `/mnt/data/` fallback is
-gone). Otherwise the xiRAID mount roots are offered in a `SelectDialog`, prepended
+gone). A `findmnt` **read failure** (the command errored, as opposed to
+succeeding with no xiRAID mounts) surfaces a distinct *"Couldn't read the mount
+table"* dialog instead, so a transient fault is not misreported as a missing
+filesystem. Otherwise the xiRAID mount roots are offered in a `SelectDialog`, prepended
 with `Custom path…` so an operator can export a subdirectory (e.g.
 `/mnt/data/share1`). A directly picked mount root is valid as-is; a custom path is
 accepted only when it is at-or-under one of the xiRAID mount roots (segment-aware

--- a/docs/Storage/fs-shares-management-spec.md
+++ b/docs/Storage/fs-shares-management-spec.md
@@ -301,7 +301,20 @@ Each step returns `CANCEL` if its dialog is dismissed with `None`, `BACK` if the
 
 **Step 1 — pick an export path.**
 
-The wizard scans `findmnt -t xfs -n -o TARGET` to list existing XFS mounts. The list is prepended with a `Custom path…` option so an operator can export a subdirectory under an existing mount (e.g. `/mnt/data/share1`). Either choice ends up as an absolute path; the wizard rejects anything that doesn't start with `/`. This is the wizard's first step, so its dialogs never render a Back button (`allow_back` is `False` here — there's no earlier step to return to); every step after it does.
+The wizard scans `findmnt -t xfs -n -o TARGET,SOURCE` and keeps only mounts whose
+SOURCE is a xiRAID volume (`/dev/xi_*`) — an NFS export is allowed **only** from a
+filesystem on a xiRAID array. If no such mount exists, the wizard aborts **before
+it starts** with an OK-only dialog directing the operator to *Storage →
+Filesystems → Create Filesystem* (the former free-form `/mnt/data/` fallback is
+gone). Otherwise the xiRAID mount roots are offered in a `SelectDialog`, prepended
+with `Custom path…` so an operator can export a subdirectory (e.g.
+`/mnt/data/share1`). A directly picked mount root is valid as-is; a custom path is
+accepted only when it is at-or-under one of the xiRAID mount roots (segment-aware
+`is_path_under`, [xfs_helpers.py](../../xinas_menu/utils/xfs_helpers.py)), otherwise
+the step re-prompts with an error. Either choice must be an absolute path (rejects
+anything that doesn't start with `/`). This is the wizard's first step, so its
+dialogs never render a Back button (`allow_back` is `False` here); every step after
+it does.
 
 **Steps 2–6.** `self._access_steps("Add Share", total=7)` — see §4.4. A Back button is available on all five.
 

--- a/docs/control-path/s3-nfs-executor-spec.md
+++ b/docs/control-path/s3-nfs-executor-spec.md
@@ -128,9 +128,16 @@ the `status.effective_files` producer (§3.4).
 - **Apply (api txn):** write `/xinas/v1/desired/Share/{id}` (prior=none → recorded for
   revert, §5.2); lease `Share/{id}`; insert task. **`spec` = the raw Share spec** (`{ id,
   path, clients, fsid, security_mode?, sync?, rdma_enabled?, nfs_versions? }`).
-- **Executor:** `snapshot_before` → `preflight` (helper reachable; `list_exports`, fail
-  `EXPORT_PATH_IN_USE` if appeared) → `apply` (`add_export(compile(spec), create_path:true)`)
-  → `verify` (`list_exports` contains it) → `snapshot_after`. Compile via lib/nfs-exports.
+- **Executor:** `snapshot_before` → `preflight` (**xiRAID-backing gate** — read live
+  mounts via the injected `readMounts()` seam; the export path must be at-or-under a
+  mount whose source is `/dev/xi_*` (longest-match wins so a nested xiRAID mount beats
+  `/`), else fail `EXPORT_PATH_NOT_ON_XIRAID`; **fail-closed** — an unreadable mount
+  table throws and refuses the create. Then: helper reachable; `list_exports`, fail
+  `EXPORT_PATH_IN_USE` if appeared) → `apply` (`add_export(compile(spec),
+  create_path:true)`) → `verify` (`list_exports` contains it) → `snapshot_after`.
+  Compile via lib/nfs-exports. The gate is **executor-side only** — there is no
+  plan-phase blocker, because the plan would read *observed* Filesystem state and a
+  degraded/stale collector could falsely block a legitimate create.
 - **Rollback:** `remove_export(path)` (idempotent). api reverts the desired Share write.
 
 ### 3.2 `share.update`

--- a/docs/plans/2026-07-10-xiraid-only-shares-design.md
+++ b/docs/plans/2026-07-10-xiraid-only-shares-design.md
@@ -1,0 +1,140 @@
+# Restrict NFS shares to xiRAID-backed filesystems — design
+
+**Date:** 2026-07-10
+**Status:** Approved (brainstorming), pending implementation plan
+**Owning specs:** [docs/Storage/fs-shares-management-spec.md](../Storage/fs-shares-management-spec.md) §4.5,
+[docs/control-path/s3-nfs-executor-spec.md](../control-path/s3-nfs-executor-spec.md) §3.1
+
+## Problem
+
+The Add Share wizard lets an operator create an NFS export on **any** absolute
+path, even when there is no filesystem on top of a xiRAID array. In the empty
+case (no XFS mounts at all) the wizard silently drops to a free-form input
+defaulting to `/mnt/data/` and validates only that the path starts with `/`
+([xinas_menu/screens/nfs.py](../../xinas_menu/screens/nfs.py) `_add_share_wizard`,
+lines 397–456). The result is a share exported from the OS root filesystem (or a
+non-existent directory that the wizard then `mkdir`s), which is never the intended
+data path. The control-path `share.create` executor does not guard against this
+either — its only preflight blocker is `EXPORT_PATH_IN_USE`.
+
+## Goal
+
+NFS shares may be created **only** from a filesystem that sits on top of a xiRAID
+array, at the mount root or any subfolder beneath it. Enforce this on both
+surfaces the operator can reach: the TUI Add Share wizard **and** the control-path
+`share.create` verb (so MCP callers are equally constrained).
+
+## The invariant
+
+> An export path is valid **iff** it is at-or-under the mountpoint of an XFS
+> filesystem whose backing block device is a xiRAID volume (`/dev/xi_*`).
+
+xiRAID Classic always exposes an array as `/dev/xi_<name>`; this convention is
+already relied on across the codebase
+([xfs_helpers.py:341](../../xinas_menu/utils/xfs_helpers.py) `find_mounts_using_raid`,
+[raid.py:298](../../xinas_menu/screens/raid.py) `volume_path`,
+[filesystem.ts:6](../../xiNAS-MCP/src/agent/collectors/filesystem.ts) `backing_device`).
+Detection is a **prefix match** on the backing device path (`startswith("/dev/xi_")`):
+xiNAS owns that namespace, so a cross-check against the live RAID array list buys
+no additional safety and is deliberately omitted.
+
+"At-or-under" means the mount root itself (`/mnt/data`) or any subfolder
+(`/mnt/data/share1`) is accepted; a sibling or unrelated path (`/srv/foo`) is not.
+
+## Surface 1 — TUI Add Share wizard
+
+File: [xinas_menu/screens/nfs.py](../../xinas_menu/screens/nfs.py) `_add_share_wizard`.
+
+1. **Candidate gathering.** Replace `findmnt -t xfs -n -o TARGET` with
+   `findmnt -t xfs -n -o TARGET,SOURCE` and keep only rows whose SOURCE starts
+   with `/dev/xi_`. This yields the list of xiRAID-backed mount roots.
+2. **Empty case.** If there are no xiRAID-backed mounts, abort **before** starting
+   the wizard with an OK-only dialog:
+   *"No xiRAID-backed filesystem found. NFS shares can only be exported from a
+   filesystem on a xiRAID array. Create one first: Storage → Filesystems → Create
+   Filesystem."* The free-form `/mnt/data/` fallback is removed entirely.
+3. **Non-empty case.** `SelectDialog` over the xiRAID mount roots plus the existing
+   `Custom path…` option.
+   - A directly picked mount root is valid as-is.
+   - A `Custom path…` entry is validated with a containment check against the
+     xiRAID mount list: accept when the entered path is at-or-under **some**
+     xiRAID mount root, otherwise re-prompt with an error notification
+     (*"Export path must be inside a xiRAID filesystem (…)."*). The existing
+     "must start with `/`" check is retained.
+
+The rest of the wizard (host, access, squash, sync, sec, confirm, `mkdir -p`, the
+`POST /api/v1/shares` submit) is unchanged.
+
+## Surface 2 — control-path `share.create`
+
+Enforced with a **single live executor preflight** (no plan-side blocker). The
+executor check gates `apply` for every caller — including MCP — and is
+authoritative because it reads live mount state. A plan-side blocker was
+considered (to mirror `EXPORT_PATH_IN_USE` and preview the rejection in `plan`
+mode) but **rejected**: it would read *observed* `Filesystem` state, so a
+momentarily degraded or not-yet-observed collector could falsely block a
+legitimate create. The live preflight has no such failure mode.
+
+### Executor preflight
+File: [xiNAS-MCP/src/agent/task/nfs-executor.ts](../../xiNAS-MCP/src/agent/task/nfs-executor.ts)
+`buildShareCreate`.
+
+Add a check at the head of the preflight stage using the existing `readMounts()`
+seam (already wired for the delete guard,
+[wiring.ts:215](../../xiNAS-MCP/src/agent/task/wiring.ts)). Select the **longest**
+mountpoint that contains the export path; if none contains it, or the containing
+mount's `source` does not start with `/dev/xi_`, throw `EXPORT_PATH_NOT_ON_XIRAID`.
+Selecting the longest match correctly ignores the root `/` mount when a nested
+xiRAID mount (e.g. `/mnt/data`) is the real backing. **Fail-closed**: if the mount
+reader throws (unreadable `/proc`), the preflight fails and the share is not
+created — no destruction risk, consistent with the delete guard's philosophy.
+
+Wiring: extend `NfsExecutorDeps` with the `readMounts` reader and thread the same
+`opts.readMounts ?? (fixture | readProcMounts)` default the delete executor uses,
+so fixture-mode e2e reads `mounts.json`.
+
+### Scope
+Only `share.create` is gated. `share.update` / `share.delete` and the TUI Edit
+Share flow operate on an already-exported (already-valid) path and are not
+re-checked. Filesystem deletion already warns about affected shares
+(fs-shares-management-spec §5).
+
+## Small consolidation
+
+Factor the "path at-or-under root" check into a shared helper
+`is_path_under(path, root)` in [xfs_helpers.py](../../xinas_menu/utils/xfs_helpers.py)
+and use it from `nfs.py`; `raid.py` currently has a private `_is_under` with
+identical semantics and switches to the shared helper. Same-area cleanup, no
+behavior change.
+
+## Rebuild marker
+
+The TypeScript control-path change ships in `dist/` and requires a rebuild on the
+host:
+
+```
+Requires-Rebuild: xinas_node_build
+```
+
+(The TUI-only Python changes do not require an Ansible re-run.)
+
+## Testing
+
+- **TUI (pytest):** the xiRAID-mount filter keeps only `/dev/xi_*` sources; the
+  empty case aborts with the guidance dialog and never opens the free-form input;
+  a custom path inside a xiRAID mount is accepted; one outside is rejected.
+- **Server executor (vitest):** preflight rejects an off-xiRAID path (no
+  containing mount and non-xiRAID containing mount); accepts an on-xiRAID path
+  (mount root and subfolder); longest-match wins over `/`; fails closed when
+  `readMounts` throws. Update the existing happy-path `share.create` tests to
+  inject a `/dev/xi_*` mount and add a `mounts.json` to the e2e fixture covering
+  the exported path.
+
+## Error taxonomy
+
+| Condition | Surface | Signal |
+|-----------|---------|--------|
+| No xiRAID-backed mount exists | TUI | OK-only guidance dialog, wizard never starts |
+| Custom path outside any xiRAID mount | TUI | Error notification, re-prompt |
+| Path off xiRAID (apply, live) | Control-path | preflight throws `EXPORT_PATH_NOT_ON_XIRAID` |
+| Mount reader unreadable | Control-path | preflight throws (fail-closed) |

--- a/docs/plans/2026-07-10-xiraid-only-shares-plan.md
+++ b/docs/plans/2026-07-10-xiraid-only-shares-plan.md
@@ -1,0 +1,702 @@
+# Restrict NFS shares to xiRAID-backed filesystems — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** NFS shares may be created only from a filesystem mounted on a xiRAID volume (`/dev/xi_*`), at the mount root or a subfolder — enforced in the TUI Add Share wizard and in the control-path `share.create` executor preflight.
+
+**Architecture:** Detection is a prefix match on the backing device path (`/dev/xi_*`). The TUI filters `findmnt` candidates to xiRAID mounts, aborts with guidance when none exist, and validates custom subfolder paths against a shared `is_path_under` helper. The server adds a live, fail-closed preflight in `buildShareCreate` using the existing `readMounts()` seam. No plan-side blocker (avoids false-blocks on stale observed state).
+
+**Tech Stack:** Python 3 / Textual (TUI, `xinas_menu/`), TypeScript / Node (control-path, `xiNAS-MCP/`), pytest, vitest.
+
+**Design doc:** [docs/plans/2026-07-10-xiraid-only-shares-design.md](2026-07-10-xiraid-only-shares-design.md)
+
+**Commit note:** This repo requires explicit user go-ahead before committing. Commit steps are written out below; batch or gate them per the operator's preference. The **server-side commit (Task 6) MUST carry the `Requires-Rebuild: xinas_node_build` trailer** — the TS change ships in `dist/` and needs the host rebuild role to re-run. The Python-only commits (Tasks 1–4) MUST NOT carry a rebuild trailer.
+
+**Pre-existing working-tree state:** `docs/Management/user-management-spec.md` and `tests/test_users_screen.py` were already modified by another session. Never `git add -A`; stage only the files each task names.
+
+---
+
+## Task 1: Specs first (spec-first rule)
+
+**Files:**
+- Modify: `docs/Storage/fs-shares-management-spec.md` (§4.5 Step 1)
+- Modify: `docs/control-path/s3-nfs-executor-spec.md` (§3.1 `share.create`)
+
+- [ ] **Step 1: Update the Storage spec, §4.5 Step 1**
+
+Replace the "Step 1 — pick an export path." paragraph (currently at
+`docs/Storage/fs-shares-management-spec.md:302-304`) with:
+
+```markdown
+**Step 1 — pick an export path.**
+
+The wizard scans `findmnt -t xfs -n -o TARGET,SOURCE` and keeps only mounts whose
+SOURCE is a xiRAID volume (`/dev/xi_*`) — an NFS export is allowed **only** from a
+filesystem on a xiRAID array. If no such mount exists, the wizard aborts **before
+it starts** with an OK-only dialog directing the operator to *Storage →
+Filesystems → Create Filesystem* (the former free-form `/mnt/data/` fallback is
+gone). Otherwise the xiRAID mount roots are offered in a `SelectDialog`, prepended
+with `Custom path…` so an operator can export a subdirectory (e.g.
+`/mnt/data/share1`). A directly picked mount root is valid as-is; a custom path is
+accepted only when it is at-or-under one of the xiRAID mount roots (segment-aware
+`is_path_under`, [xfs_helpers.py](../../xinas_menu/utils/xfs_helpers.py)), otherwise
+the step re-prompts with an error. Either choice must be an absolute path (rejects
+anything that doesn't start with `/`). This is the wizard's first step, so its
+dialogs never render a Back button (`allow_back` is `False` here); every step after
+it does.
+```
+
+- [ ] **Step 2: Update the control-path spec, §3.1 `share.create` Executor bullet**
+
+In `docs/control-path/s3-nfs-executor-spec.md`, replace the `- **Executor:**` line
+under §3.1 (currently at lines 131-133) with:
+
+```markdown
+- **Executor:** `snapshot_before` → `preflight` (**xiRAID-backing gate** — read live
+  mounts via the injected `readMounts()` seam; the export path must be at-or-under a
+  mount whose source is `/dev/xi_*` (longest-match wins so a nested xiRAID mount beats
+  `/`), else fail `EXPORT_PATH_NOT_ON_XIRAID`; **fail-closed** — an unreadable mount
+  table throws and refuses the create. Then: helper reachable; `list_exports`, fail
+  `EXPORT_PATH_IN_USE` if appeared) → `apply` (`add_export(compile(spec),
+  create_path:true)`) → `verify` (`list_exports` contains it) → `snapshot_after`.
+  Compile via lib/nfs-exports. The gate is **executor-side only** — there is no
+  plan-phase blocker, because the plan would read *observed* Filesystem state and a
+  degraded/stale collector could falsely block a legitimate create.
+```
+
+- [ ] **Step 3: Commit (on user go-ahead — no rebuild trailer)**
+
+```bash
+git add docs/Storage/fs-shares-management-spec.md docs/control-path/s3-nfs-executor-spec.md docs/plans/2026-07-10-xiraid-only-shares-design.md docs/plans/2026-07-10-xiraid-only-shares-plan.md
+git commit -m "docs(shares): spec xiRAID-only NFS export gate (TUI + executor)"
+```
+
+---
+
+## Task 2: Shared `is_path_under` helper
+
+**Files:**
+- Modify: `xinas_menu/utils/xfs_helpers.py` (add `is_path_under`)
+- Modify: `xinas_menu/screens/raid.py` (replace private `_is_under` with the shared helper)
+- Test: `tests/test_xfs_path_helpers.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_xfs_path_helpers.py`:
+
+```python
+from __future__ import annotations
+
+from xinas_menu.utils.xfs_helpers import is_path_under
+
+
+def test_exact_match():
+    assert is_path_under("/mnt/data", "/mnt/data") is True
+
+
+def test_subfolder():
+    assert is_path_under("/mnt/data/share1", "/mnt/data") is True
+
+
+def test_root_with_trailing_slash():
+    assert is_path_under("/mnt/data/share1", "/mnt/data/") is True
+
+
+def test_sibling_is_not_under():
+    assert is_path_under("/mnt/data2", "/mnt/data") is False
+
+
+def test_prefix_but_not_segment_boundary():
+    # "/mnt/database" must NOT count as under "/mnt/data".
+    assert is_path_under("/mnt/database", "/mnt/data") is False
+
+
+def test_unrelated_path():
+    assert is_path_under("/srv/foo", "/mnt/data") is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_xfs_path_helpers.py -q`
+Expected: FAIL — `ImportError: cannot import name 'is_path_under'`.
+
+- [ ] **Step 3: Add the helper**
+
+In `xinas_menu/utils/xfs_helpers.py`, add near the top of the module (after the
+imports, before `run_async_cmd`):
+
+```python
+def is_path_under(path: str, root: str) -> bool:
+    """True when *path* is at or under *root* (path-segment aware).
+
+    ``/mnt/data`` is under ``/mnt/data``; ``/mnt/data/share1`` is under
+    ``/mnt/data``; ``/mnt/database`` is NOT (segment boundary enforced).
+    """
+    if path == root:
+        return True
+    prefix = root if root.endswith("/") else root + "/"
+    return path.startswith(prefix)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_xfs_path_helpers.py -q`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Switch `raid.py` to the shared helper**
+
+In `xinas_menu/screens/raid.py`, delete the private `_is_under` definition (lines
+250-255):
+
+```python
+def _is_under(path: str, root: str) -> bool:
+    """True when ``path`` is at or under ``root`` (path-segment aware)."""
+    if path == root:
+        return True
+    prefix = root if root.endswith("/") else root + "/"
+    return path.startswith(prefix)
+```
+
+Add the import to the module-level imports at the top of `raid.py` (the file
+already imports from `xinas_menu.utils.xfs_helpers` locally at line 952; add a
+top-level import alongside the other `xinas_menu` imports):
+
+```python
+from xinas_menu.utils.xfs_helpers import is_path_under
+```
+
+Update the sole call site (line 1004) from `_is_under(...)` to `is_path_under(...)`:
+
+```python
+                if any(is_path_under(str(path), mp) for mp in mountpoints):
+```
+
+- [ ] **Step 6: Run the raid-screen tests + import check**
+
+Run: `python -m pytest tests/ -q -k "raid" && python -c "import xinas_menu.screens.raid"`
+Expected: PASS / no import error. (If `textual` is unavailable in the venv, the
+import-heavy screen tests are skipped in local runs and covered by CI — see the
+project test-env note; the `python -c import` still validates the edit.)
+
+- [ ] **Step 7: Commit (on user go-ahead — no rebuild trailer)**
+
+```bash
+git add xinas_menu/utils/xfs_helpers.py xinas_menu/screens/raid.py tests/test_xfs_path_helpers.py
+git commit -m "refactor(xfs_helpers): shared is_path_under, adopt in raid screen"
+```
+
+---
+
+## Task 3: TUI xiRAID-mount filter helper
+
+**Files:**
+- Modify: `xinas_menu/screens/nfs.py` (add pure helper `_xiraid_mount_points`)
+- Test: `tests/test_nfs_wizard_helpers.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_nfs_wizard_helpers.py`:
+
+```python
+from xinas_menu.screens.nfs import _xiraid_mount_points
+
+
+def test_xiraid_mount_points_keeps_only_xi_sources():
+    out = "/mnt/data      /dev/xi_data\n/boot          /dev/sda1\n/              /dev/sda2\n"
+    assert _xiraid_mount_points(out) == ["/mnt/data"]
+
+
+def test_xiraid_mount_points_multiple():
+    out = "/mnt/data   /dev/xi_data\n/mnt/logs   /dev/xi_logs\n"
+    assert _xiraid_mount_points(out) == ["/mnt/data", "/mnt/logs"]
+
+
+def test_xiraid_mount_points_none():
+    out = "/           /dev/sda2\n/boot       /dev/sda1\n"
+    assert _xiraid_mount_points(out) == []
+
+
+def test_xiraid_mount_points_empty_string():
+    assert _xiraid_mount_points("") == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_nfs_wizard_helpers.py -q -k xiraid_mount_points`
+Expected: FAIL — `ImportError: cannot import name '_xiraid_mount_points'`.
+
+- [ ] **Step 3: Add the helper**
+
+In `xinas_menu/screens/nfs.py`, add a module-level function next to `_path_prefill`
+(near line 45):
+
+```python
+def _xiraid_mount_points(findmnt_output: str) -> list[str]:
+    """Return the TARGET mountpoints backed by a xiRAID volume (``/dev/xi_*``).
+
+    *findmnt_output* is the raw text of ``findmnt -t xfs -n -o TARGET,SOURCE``
+    (one ``<target> <source>`` row per line). Only rows whose SOURCE begins with
+    ``/dev/xi_`` are kept — that is xiNAS's block-device namespace for xiRAID
+    arrays.
+    """
+    mounts: list[str] = []
+    for line in findmnt_output.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        parts = stripped.rsplit(None, 1)
+        if len(parts) == 2 and parts[1].startswith("/dev/xi_"):
+            mounts.append(parts[0])
+    return mounts
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_nfs_wizard_helpers.py -q -k xiraid_mount_points`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Commit (on user go-ahead — no rebuild trailer)**
+
+```bash
+git add xinas_menu/screens/nfs.py tests/test_nfs_wizard_helpers.py
+git commit -m "feat(nfs): _xiraid_mount_points helper filters findmnt to xiRAID mounts"
+```
+
+---
+
+## Task 4: Wire the xiRAID gate into the Add Share wizard
+
+**Files:**
+- Modify: `xinas_menu/screens/nfs.py` (`_add_share_wizard`, candidate gathering + `path_step`)
+
+No new automated test — the wizard's logic units (`_xiraid_mount_points`,
+`is_path_under`) are unit-tested in Tasks 2–3; the wiring is verified by the
+manual TUI check in Step 4.
+
+- [ ] **Step 1: Filter candidates to xiRAID mounts and abort when none**
+
+In `xinas_menu/screens/nfs.py`, add the shared import to the module-level imports
+(top of file):
+
+```python
+from xinas_menu.utils.xfs_helpers import is_path_under
+```
+
+In `_add_share_wizard`, replace the candidate-gathering block (currently lines
+395-400):
+
+```python
+        from xinas_menu.utils.xfs_helpers import run_async_cmd
+
+        mount_points: list[str] = []
+        ok, out, _ = await run_async_cmd("findmnt", "-t", "xfs", "-n", "-o", "TARGET", timeout=10)
+        if ok and out:
+            mount_points = [line.strip() for line in out.splitlines() if line.strip()]
+```
+
+with:
+
+```python
+        from xinas_menu.utils.xfs_helpers import run_async_cmd
+
+        mount_points: list[str] = []
+        ok, out, _ = await run_async_cmd(
+            "findmnt", "-t", "xfs", "-n", "-o", "TARGET,SOURCE", timeout=10
+        )
+        if ok and out:
+            mount_points = _xiraid_mount_points(out)
+
+        if not mount_points:
+            await self.app.push_screen_wait(
+                ConfirmDialog(
+                    "No xiRAID-backed filesystem found.\n\n"
+                    "NFS shares can only be exported from a filesystem on a "
+                    "xiRAID array. Create one first:\n"
+                    "Storage → Filesystems → Create Filesystem.",
+                    "Add Share",
+                    ok_only=True,
+                )
+            )
+            return
+```
+
+- [ ] **Step 2: Simplify `path_step` — xiRAID-only select + custom-path containment**
+
+`mount_points` is now always non-empty when `path_step` runs, so the
+no-mount-points `else` branch is dead code. Replace the entire `path_step` body
+(currently lines 402-456) with:
+
+```python
+        async def path_step(answers, allow_back, step_no):
+            stored = answers.get("path", "")
+            title = f"Add Share — Step {step_no}/7"
+            while True:
+                selected, custom_default = _path_prefill(stored, mount_points)
+                choice = await self.app.push_screen_wait(
+                    SelectDialog(
+                        mount_points + [_CUSTOM_PATH],
+                        title=title,
+                        prompt="Select filesystem to export (or choose custom for a subfolder):",
+                        selected=selected,
+                        allow_back=allow_back,
+                    )
+                )
+                if choice is None:
+                    return CANCEL
+                if choice is BACK:
+                    return BACK
+                if choice == _CUSTOM_PATH:
+                    sub = await self.app.push_screen_wait(
+                        InputDialog(
+                            "Export path:",
+                            title,
+                            default=custom_default,
+                            placeholder="/mnt/data/share1",
+                            allow_back=True,
+                        )
+                    )
+                    if sub is None:
+                        return CANCEL
+                    if sub is BACK:
+                        continue
+                    path = sub
+                else:
+                    path = choice
+                if not path.startswith("/"):
+                    self.app.notify("Export path must start with '/'.", severity="error")
+                    continue
+                path = path.rstrip("/") or "/"
+                if not any(is_path_under(path, mp) for mp in mount_points):
+                    self.app.notify(
+                        "Export path must be inside a xiRAID filesystem "
+                        f"({', '.join(mount_points)}).",
+                        severity="error",
+                    )
+                    continue
+                return path
+```
+
+- [ ] **Step 3: Byte-compile and lint**
+
+Run: `python -m py_compile xinas_menu/screens/nfs.py && ruff check xinas_menu/screens/nfs.py`
+Expected: no output / no errors.
+
+- [ ] **Step 4: Manual TUI verification (record evidence)**
+
+Drive the real screen and confirm behavior end-to-end:
+
+1. With **no** xiRAID-backed XFS mount present, open NFS Access Rights → Add
+   Share. Expected: the "No xiRAID-backed filesystem found." dialog appears and the
+   wizard does **not** proceed to the export-path input. (This is the reported bug.)
+2. With a xiRAID mount present (e.g. `/mnt/data` on `/dev/xi_data`), open Add
+   Share. Expected: `/mnt/data` is offered in the select list; `Custom path…` →
+   `/mnt/data/share1` is accepted; `Custom path…` → `/srv/foo` is rejected with the
+   "must be inside a xiRAID filesystem" notification.
+
+Capture the outcome (screenshots or a note of observed dialogs) in the PR.
+
+- [ ] **Step 5: Commit (on user go-ahead — no rebuild trailer)**
+
+```bash
+git add xinas_menu/screens/nfs.py
+git commit -m "feat(nfs): Add Share allows only xiRAID-backed filesystems and their subfolders"
+```
+
+---
+
+## Task 5: Server executor preflight — xiRAID-backing gate
+
+**Files:**
+- Modify: `xiNAS-MCP/src/agent/task/nfs-executor.ts` (`NfsExecutorDeps`, `containingMount`/`pathIsUnder` helpers, `buildShareCreate` preflight)
+- Modify: `xiNAS-MCP/src/agent/task/wiring.ts` (`buildNfsExecutorDeps` gets `readMounts`; DRY the resolved reader)
+- Test: `xiNAS-MCP/src/__tests__/agent/task/nfs-executor.test.ts` (extend `makeDeps` + new cases)
+- Create: `xiNAS-MCP/src/__tests__/e2e/__fixtures__/mounts.json`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `xiNAS-MCP/src/__tests__/agent/task/nfs-executor.test.ts`, extend `makeDeps`
+(currently lines 125-131) to inject a default xiRAID mount reader:
+
+```typescript
+/** Deps with a no-op readIdmapDomain and a default xiRAID mount at /mnt/data. */
+function makeDeps(
+  helper: NfsHelperClient,
+  readIdmapDomain: () => Promise<string | undefined> = async () => undefined,
+  readMounts: () => Promise<Array<{ source: string; mountpoint: string }>> = async () => [
+    { source: '/dev/xi_data', mountpoint: '/mnt/data' },
+  ],
+): NfsExecutorDeps {
+  return { helper, readIdmapDomain, readMounts };
+}
+```
+
+Add these cases inside `describe('share.create', ...)` (the shared `spec` there has
+`path: '/mnt/data'`):
+
+```typescript
+  it('preflight throws EXPORT_PATH_NOT_ON_XIRAID when no mount contains the path', async () => {
+    const helper = makeFakeHelper([]);
+    const deps = makeDeps(helper, undefined, async () => [
+      { source: '/dev/sda2', mountpoint: '/' },
+    ]);
+    const ex = getExecutor(deps, 'share.create');
+    await expect(stage(ex, 'preflight').run(makeCtx(spec))).rejects.toThrow(
+      'EXPORT_PATH_NOT_ON_XIRAID',
+    );
+  });
+
+  it('preflight throws EXPORT_PATH_NOT_ON_XIRAID when the containing mount is not xiRAID', async () => {
+    const helper = makeFakeHelper([]);
+    const deps = makeDeps(helper, undefined, async () => [
+      { source: '/dev/sda2', mountpoint: '/' },
+      { source: '/dev/sdb1', mountpoint: '/mnt/data' },
+    ]);
+    const ex = getExecutor(deps, 'share.create');
+    await expect(stage(ex, 'preflight').run(makeCtx(spec))).rejects.toThrow(
+      'EXPORT_PATH_NOT_ON_XIRAID',
+    );
+  });
+
+  it('preflight accepts a subfolder under a xiRAID mount (longest-match beats /)', async () => {
+    const helper = makeFakeHelper([]);
+    const deps = makeDeps(helper, undefined, async () => [
+      { source: '/dev/sda2', mountpoint: '/' },
+      { source: '/dev/xi_data', mountpoint: '/mnt/data' },
+    ]);
+    const ex = getExecutor(deps, 'share.create');
+    await expect(
+      stage(ex, 'preflight').run(makeCtx({ ...spec, path: '/mnt/data/share1' })),
+    ).resolves.toBeUndefined();
+  });
+
+  it('preflight fails closed when readMounts throws', async () => {
+    const helper = makeFakeHelper([]);
+    const deps = makeDeps(helper, undefined, async () => {
+      throw new Error('proc unreadable');
+    });
+    const ex = getExecutor(deps, 'share.create');
+    await expect(stage(ex, 'preflight').run(makeCtx(spec))).rejects.toThrow();
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd xiNAS-MCP && npx vitest run src/__tests__/agent/task/nfs-executor.test.ts`
+Expected: the four new tests FAIL (gate not implemented; a TS error on the extra
+`readMounts` arg to `makeDeps` is also acceptable as the red state).
+
+- [ ] **Step 3: Add the `readMounts` dep and the containment helpers**
+
+In `xiNAS-MCP/src/agent/task/nfs-executor.ts`, extend `NfsExecutorDeps` (lines
+37-43):
+
+```typescript
+/** Injected deps so the executors are test-hermetic (fake helper + fake reader). */
+export interface NfsExecutorDeps {
+  /** Typed nfs-helper write/read client the executors drive. */
+  helper: NfsHelperClient;
+  /** Read the current /etc/idmapd.conf Domain (undefined if unset). Injected so tests fake it. */
+  readIdmapDomain: () => Promise<string | undefined>;
+  /**
+   * Read live mounts for the share.create xiRAID-backing gate. FAIL-CLOSED: a
+   * throw refuses the create (better no export than one on the wrong device).
+   * Injected so tests fake it; wired to the same reader as the delete guard.
+   */
+  readMounts: () => Promise<Array<{ source: string; mountpoint: string }>>;
+}
+```
+
+Add these module-private helpers (e.g. just above `buildShareCreate`, near line
+177):
+
+```typescript
+/** True when `path` is at or under `root` (path-segment aware). */
+function pathIsUnder(path: string, root: string): boolean {
+  if (path === root) return true;
+  const prefix = root.endsWith('/') ? root : `${root}/`;
+  return path.startsWith(prefix);
+}
+
+/**
+ * The most specific mount containing `path` — the longest mountpoint that is a
+ * path-prefix of `path` — or null if none contains it. Longest-match ensures a
+ * nested xiRAID mount (e.g. /mnt/data) wins over the root `/`.
+ */
+function containingMount(
+  mounts: Array<{ source: string; mountpoint: string }>,
+  path: string,
+): { source: string; mountpoint: string } | null {
+  let best: { source: string; mountpoint: string } | null = null;
+  for (const m of mounts) {
+    if (pathIsUnder(path, m.mountpoint)) {
+      if (best === null || m.mountpoint.length > best.mountpoint.length) best = m;
+    }
+  }
+  return best;
+}
+```
+
+- [ ] **Step 4: Add the gate at the head of the `share.create` preflight**
+
+In `buildShareCreate`, replace the `preflight` stage `run` body (lines 184-191)
+with:
+
+```typescript
+        async run(ctx: ExecutorContext): Promise<void> {
+          const spec = readShareSpec(ctx.spec);
+          ctx.emitOutput(`share.create: preflight — checking export path ${spec.path}`);
+          // xiRAID-backing gate: the path must live on a /dev/xi_* filesystem.
+          // Live + fail-closed — an unreadable mount table throws and refuses.
+          const mounts = await deps.readMounts();
+          const backing = containingMount(mounts, spec.path);
+          if (backing === null || !backing.source.startsWith('/dev/xi_')) {
+            const where =
+              backing === null
+                ? 'no filesystem is mounted at or above it'
+                : `it is on ${backing.source} (${backing.mountpoint})`;
+            ctx.emitOutput(
+              `share.create: ${spec.path} is not on a xiRAID filesystem — ${where}`,
+            );
+            throw new Error(
+              `EXPORT_PATH_NOT_ON_XIRAID: ${spec.path} is not on a xiRAID-backed filesystem`,
+            );
+          }
+          const existing = await deps.helper.listExports();
+          if (findEntry(existing, spec.path) !== null) {
+            ctx.emitOutput(`share.create: path ${spec.path} is already exported`);
+            throw new Error(`EXPORT_PATH_IN_USE: ${spec.path} is already exported`);
+          }
+        },
+```
+
+- [ ] **Step 5: Thread `readMounts` through wiring (DRY the resolved reader)**
+
+In `xiNAS-MCP/src/agent/task/wiring.ts`, change `buildNfsExecutorDeps` (lines
+117-131) to accept the reader:
+
+```typescript
+function buildNfsExecutorDeps(
+  config: AgentConfig,
+  readMounts: () => Promise<Array<{ source: string; mountpoint: string }>>,
+): NfsExecutorDeps {
+  const helper = createNfsHelperClientFromProbe({
+    helperSocket: config.nfs_helper_socket ?? DEFAULT_NFS_HELPER_SOCKET,
+    timeoutMs: DEFAULT_NFS_HELPER_TIMEOUT_MS,
+  });
+  const readIdmapDomain = async (): Promise<string | undefined> => {
+    try {
+      const raw = await readFile(IDMAPD_CONF_PATH, 'utf8');
+      return parseIdmapConf(raw).domain;
+    } catch {
+      return undefined;
+    }
+  };
+  return { helper, readIdmapDomain, readMounts };
+}
+```
+
+At the registration site, compute the resolved reader once and reuse it for both
+the NFS deps and the xiRAID delete executor. Replace lines 202-217:
+
+```typescript
+  const resolvedReadMounts =
+    opts.readMounts ?? (fdir !== null ? makeFixtureMounts(fdir) : readProcMounts);
+  const nfsDeps = opts.nfsDeps ?? buildNfsExecutorDeps(config, resolvedReadMounts);
+  for (const ex of buildNfsExecutors(nfsDeps)) {
+    registry.register(ex);
+  }
+  // S3-xiraid T9: the create executor shares the convergence-built xiRAID
+  // client with the observe collector (one daemon connection for both).
+  if (opts.xiraidClient) {
+    registry.register(makeXiraidArrayCreateExecutor({ client: opts.xiraidClient }));
+    registry.register(makeXiraidArrayModifyExecutor({ client: opts.xiraidClient }));
+    registry.register(makeXiraidArrayImportExecutor({ client: opts.xiraidClient }));
+    registry.register(
+      makeXiraidArrayDeleteExecutor({
+        client: opts.xiraidClient,
+        readMounts: resolvedReadMounts,
+      }),
+    );
+  }
+```
+
+- [ ] **Step 6: Add the e2e mounts fixture**
+
+Create `xiNAS-MCP/src/__tests__/e2e/__fixtures__/mounts.json` so the fixture-mode
+executor sees a xiRAID mount covering the e2e export paths (`/srv/e2e-share`,
+`/srv/e2e-fail`):
+
+```json
+[
+  { "source": "/dev/xi_e2e", "mountpoint": "/srv" }
+]
+```
+
+- [ ] **Step 7: Run the executor + e2e tests to verify green**
+
+Run: `cd xiNAS-MCP && npx vitest run src/__tests__/agent/task/nfs-executor.test.ts src/__tests__/e2e/nfs-roundtrip.test.ts`
+Expected: PASS — the four new gate tests pass, the existing share.create tests
+still pass (default `/dev/xi_data`@`/mnt/data` reader), and the e2e roundtrip
+passes (mounts.json covers `/srv/*`).
+
+- [ ] **Step 8: Typecheck**
+
+Run: `cd xiNAS-MCP && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 9: Commit (on user go-ahead — WITH rebuild trailer)**
+
+```bash
+git add xiNAS-MCP/src/agent/task/nfs-executor.ts xiNAS-MCP/src/agent/task/wiring.ts \
+        xiNAS-MCP/src/__tests__/agent/task/nfs-executor.test.ts \
+        xiNAS-MCP/src/__tests__/e2e/__fixtures__/mounts.json
+git commit -m "feat(control-path): share.create preflight gates exports to xiRAID filesystems
+
+Live, fail-closed check in buildShareCreate — the export path must be at-or-under
+a /dev/xi_* mount, else EXPORT_PATH_NOT_ON_XIRAID. Threads the readMounts seam
+(shared with the delete guard) through buildNfsExecutorDeps.
+
+Requires-Rebuild: xinas_node_build"
+```
+
+---
+
+## Task 6: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Python suite + lint**
+
+Run: `python -m pytest tests/test_xfs_path_helpers.py tests/test_nfs_wizard_helpers.py -q && ruff check xinas_menu/ && ruff format --check xinas_menu/utils/xfs_helpers.py xinas_menu/screens/nfs.py`
+Expected: PASS / no lint errors. (The full `tests/` run needs `textual`; the
+targeted files above do not.)
+
+- [ ] **Step 2: TypeScript suite + typecheck**
+
+Run: `cd xiNAS-MCP && npx vitest run src/__tests__/agent/task/nfs-executor.test.ts src/__tests__/e2e/nfs-roundtrip.test.ts && npx tsc --noEmit`
+Expected: PASS / no errors.
+
+- [ ] **Step 3: Confirm the rebuild trailer is present exactly once (server commit only)**
+
+Run: `git log --format='%H %s%n%b' feat/xiraid-only-shares | grep -c 'Requires-Rebuild: xinas_node_build'`
+Expected: `1` — exactly the Task 5 commit carries it; the Python/doc commits do not.
+
+- [ ] **Step 4: Confirm no stray files were staged**
+
+Run: `git diff --stat main...feat/xiraid-only-shares -- docs/Management/user-management-spec.md tests/test_users_screen.py`
+Expected: empty output — the other session's files were never committed on this branch.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** design §"Surface 1" → Tasks 3–4; §"Surface 2" → Task 5;
+  §"Small consolidation" → Task 2; §"Rebuild marker" → Task 5 Step 9 + Task 6
+  Step 3; §"Testing" → Tasks 2,3,5. Spec-first (§owning specs) → Task 1.
+- **Detection consistency:** `/dev/xi_` prefix used identically in
+  `_xiraid_mount_points` (Task 3) and `containingMount` (Task 5). Containment uses
+  `is_path_under` (Py) / `pathIsUnder` (TS) with the same segment-boundary rule.
+- **No plan-side blocker:** deliberately omitted per the approved design; only the
+  executor preflight enforces server-side.
+- **Error strings:** `EXPORT_PATH_NOT_ON_XIRAID` (server), TUI notifications
+  fixed-string — matched between plan, tests, and spec.

--- a/tests/test_nfs_wizard_helpers.py
+++ b/tests/test_nfs_wizard_helpers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from xinas_menu.screens.nfs import _host_prefill, _path_prefill
+from xinas_menu.screens.nfs import _host_prefill, _path_prefill, _xiraid_mount_points
 
 _HOST_CHOICES = [
     "Everyone (any host on the network)",
@@ -45,3 +45,22 @@ def test_path_prefill_empty():
     sel, default = _path_prefill("", ["/mnt/data"])
     assert sel is None
     assert default == "/mnt/data/"
+
+
+def test_xiraid_mount_points_keeps_only_xi_sources():
+    out = "/mnt/data      /dev/xi_data\n/boot          /dev/sda1\n/              /dev/sda2\n"
+    assert _xiraid_mount_points(out) == ["/mnt/data"]
+
+
+def test_xiraid_mount_points_multiple():
+    out = "/mnt/data   /dev/xi_data\n/mnt/logs   /dev/xi_logs\n"
+    assert _xiraid_mount_points(out) == ["/mnt/data", "/mnt/logs"]
+
+
+def test_xiraid_mount_points_none():
+    out = "/           /dev/sda2\n/boot       /dev/sda1\n"
+    assert _xiraid_mount_points(out) == []
+
+
+def test_xiraid_mount_points_empty_string():
+    assert _xiraid_mount_points("") == []

--- a/tests/test_nfs_wizard_helpers.py
+++ b/tests/test_nfs_wizard_helpers.py
@@ -47,6 +47,12 @@ def test_path_prefill_empty():
     assert default == "/mnt/data/"
 
 
+def test_path_prefill_custom_default_uses_first_mount():
+    sel, default = _path_prefill("", ["/srv/pool1", "/mnt/log"])
+    assert sel is None
+    assert default == "/srv/pool1/"
+
+
 def test_xiraid_mount_points_keeps_only_xi_sources():
     out = "/mnt/data      /dev/xi_data\n/boot          /dev/sda1\n/              /dev/sda2\n"
     assert _xiraid_mount_points(out) == ["/mnt/data"]

--- a/tests/test_xfs_path_helpers.py
+++ b/tests/test_xfs_path_helpers.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from xinas_menu.utils.xfs_helpers import is_path_under
+
+
+def test_exact_match():
+    assert is_path_under("/mnt/data", "/mnt/data") is True
+
+
+def test_subfolder():
+    assert is_path_under("/mnt/data/share1", "/mnt/data") is True
+
+
+def test_root_with_trailing_slash():
+    assert is_path_under("/mnt/data/share1", "/mnt/data/") is True
+
+
+def test_sibling_is_not_under():
+    assert is_path_under("/mnt/data2", "/mnt/data") is False
+
+
+def test_prefix_but_not_segment_boundary():
+    # "/mnt/database" must NOT count as under "/mnt/data".
+    assert is_path_under("/mnt/database", "/mnt/data") is False
+
+
+def test_unrelated_path():
+    assert is_path_under("/srv/foo", "/mnt/data") is False

--- a/xiNAS-MCP/src/__tests__/agent/task/nfs-executor.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/task/nfs-executor.test.ts
@@ -122,12 +122,15 @@ function stage(ex: Executor, name: string) {
   return s;
 }
 
-/** Deps with a no-op readIdmapDomain unless overridden. */
+/** Deps with a no-op readIdmapDomain and a default xiRAID mount at /mnt/data. */
 function makeDeps(
   helper: NfsHelperClient,
   readIdmapDomain: () => Promise<string | undefined> = async () => undefined,
+  readMounts: () => Promise<Array<{ source: string; mountpoint: string }>> = async () => [
+    { source: '/dev/xi_data', mountpoint: '/mnt/data' },
+  ],
 ): NfsExecutorDeps {
-  return { helper, readIdmapDomain };
+  return { helper, readIdmapDomain, readMounts };
 }
 
 describe('buildNfsExecutors — registration', () => {
@@ -265,6 +268,48 @@ describe('share.create', () => {
     await expect(stage(ex, 'preflight').run(ctx)).rejects.toThrow(/helper unreachable/);
     await expect(ex.rollback(ctx)).resolves.toBeUndefined();
     expect(helper.calls.some((c) => c.op === 'removeExport')).toBe(false);
+  });
+
+  it('preflight throws EXPORT_PATH_NOT_ON_XIRAID when no mount is at or above the path', async () => {
+    const helper = makeFakeHelper([]);
+    const deps = makeDeps(helper, undefined, async () => []);
+    const ex = getExecutor(deps, 'share.create');
+    await expect(stage(ex, 'preflight').run(makeCtx(spec))).rejects.toThrow(
+      'EXPORT_PATH_NOT_ON_XIRAID',
+    );
+  });
+
+  it('preflight throws EXPORT_PATH_NOT_ON_XIRAID when the containing mount is not xiRAID', async () => {
+    const helper = makeFakeHelper([]);
+    const deps = makeDeps(helper, undefined, async () => [
+      { source: '/dev/sda2', mountpoint: '/' },
+      { source: '/dev/sdb1', mountpoint: '/mnt/data' },
+    ]);
+    const ex = getExecutor(deps, 'share.create');
+    await expect(stage(ex, 'preflight').run(makeCtx(spec))).rejects.toThrow(
+      'EXPORT_PATH_NOT_ON_XIRAID',
+    );
+  });
+
+  it('preflight accepts a subfolder under a xiRAID mount (longest-match beats /)', async () => {
+    const helper = makeFakeHelper([]);
+    const deps = makeDeps(helper, undefined, async () => [
+      { source: '/dev/sda2', mountpoint: '/' },
+      { source: '/dev/xi_data', mountpoint: '/mnt/data' },
+    ]);
+    const ex = getExecutor(deps, 'share.create');
+    await expect(
+      stage(ex, 'preflight').run(makeCtx({ ...spec, path: '/mnt/data/share1' })),
+    ).resolves.toBeUndefined();
+  });
+
+  it('preflight fails closed when readMounts throws', async () => {
+    const helper = makeFakeHelper([]);
+    const deps = makeDeps(helper, undefined, async () => {
+      throw new Error('proc unreadable');
+    });
+    const ex = getExecutor(deps, 'share.create');
+    await expect(stage(ex, 'preflight').run(makeCtx(spec))).rejects.toThrow();
   });
 });
 

--- a/xiNAS-MCP/src/__tests__/e2e/__fixtures__/mounts.json
+++ b/xiNAS-MCP/src/__tests__/e2e/__fixtures__/mounts.json
@@ -1,0 +1,3 @@
+[
+  { "source": "/dev/xi_e2e", "mountpoint": "/srv" }
+]

--- a/xiNAS-MCP/src/agent/task/nfs-executor.ts
+++ b/xiNAS-MCP/src/agent/task/nfs-executor.ts
@@ -40,6 +40,12 @@ export interface NfsExecutorDeps {
   helper: NfsHelperClient;
   /** Read the current /etc/idmapd.conf Domain (undefined if unset). Injected so tests fake it. */
   readIdmapDomain: () => Promise<string | undefined>;
+  /**
+   * Read live mounts for the share.create xiRAID-backing gate. FAIL-CLOSED: a
+   * throw refuses the create (better no export than one on the wrong device).
+   * Injected so tests fake it; wired to the same reader as the delete guard.
+   */
+  readMounts: () => Promise<Array<{ source: string; mountpoint: string }>>;
 }
 
 /** The raw Share spec the api forwards (T9b) — narrowed defensively below. */
@@ -167,13 +173,39 @@ function asPriorEntry(stashed: unknown): HelperExportEntry | null {
   return null;
 }
 
+/** True when `path` is at or under `root` (path-segment aware). */
+function pathIsUnder(path: string, root: string): boolean {
+  if (path === root) return true;
+  const prefix = root.endsWith('/') ? root : `${root}/`;
+  return path.startsWith(prefix);
+}
+
+/**
+ * The most specific mount containing `path` — the longest mountpoint that is a
+ * path-prefix of `path` — or null if none contains it. Longest-match ensures a
+ * nested xiRAID mount (e.g. /mnt/data) wins over the root `/`.
+ */
+function containingMount(
+  mounts: Array<{ source: string; mountpoint: string }>,
+  path: string,
+): { source: string; mountpoint: string } | null {
+  let best: { source: string; mountpoint: string } | null = null;
+  for (const m of mounts) {
+    if (pathIsUnder(path, m.mountpoint)) {
+      if (best === null || m.mountpoint.length > best.mountpoint.length) best = m;
+    }
+  }
+  return best;
+}
+
 /**
  * `share.create` — add a brand-new export.
  *
- * preflight blocks if the path is already exported (`EXPORT_PATH_IN_USE`, a
- * fail-before-change); apply compiles the Share and `add_export`s it
- * (creating the directory); verify confirms it is now listed; rollback removes
- * it (idempotent).
+ * preflight gates on the export path living on a xiRAID-backed filesystem
+ * (`EXPORT_PATH_NOT_ON_XIRAID`, live + fail-closed), then blocks if the path
+ * is already exported (`EXPORT_PATH_IN_USE`, a fail-before-change); apply
+ * compiles the Share and `add_export`s it (creating the directory); verify
+ * confirms it is now listed; rollback removes it (idempotent).
  */
 function buildShareCreate(deps: NfsExecutorDeps): Executor {
   return {
@@ -184,6 +216,20 @@ function buildShareCreate(deps: NfsExecutorDeps): Executor {
         async run(ctx: ExecutorContext): Promise<void> {
           const spec = readShareSpec(ctx.spec);
           ctx.emitOutput(`share.create: preflight — checking export path ${spec.path}`);
+          // xiRAID-backing gate: the path must live on a /dev/xi_* filesystem.
+          // Live + fail-closed — an unreadable mount table throws and refuses.
+          const mounts = await deps.readMounts();
+          const backing = containingMount(mounts, spec.path);
+          if (backing === null || !backing.source.startsWith('/dev/xi_')) {
+            const where =
+              backing === null
+                ? 'no filesystem is mounted at or above it'
+                : `it is on ${backing.source} (${backing.mountpoint})`;
+            ctx.emitOutput(`share.create: ${spec.path} is not on a xiRAID filesystem — ${where}`);
+            throw new Error(
+              `EXPORT_PATH_NOT_ON_XIRAID: ${spec.path} is not on a xiRAID-backed filesystem`,
+            );
+          }
           const existing = await deps.helper.listExports();
           if (findEntry(existing, spec.path) !== null) {
             ctx.emitOutput(`share.create: path ${spec.path} is already exported`);

--- a/xiNAS-MCP/src/agent/task/wiring.ts
+++ b/xiNAS-MCP/src/agent/task/wiring.ts
@@ -112,9 +112,14 @@ const IDMAPD_CONF_PATH = '/etc/idmapd.conf';
  * `readIdmapDomain` that parses `/etc/idmapd.conf` (the prior-domain rollback
  * target for `nfs-idmap.set`). On ENOENT / read / parse error the domain is
  * reported as unset (undefined), so a fresh install with no idmapd.conf
- * yields a prior-unset (no-op) rollback.
+ * yields a prior-unset (no-op) rollback. `readMounts` is passed in by the
+ * caller — the SAME resolved reader used by the xiRAID delete guard — so
+ * `share.create`'s xiRAID-backing gate sees the live mount table.
  */
-function buildNfsExecutorDeps(config: AgentConfig): NfsExecutorDeps {
+function buildNfsExecutorDeps(
+  config: AgentConfig,
+  readMounts: () => Promise<Array<{ source: string; mountpoint: string }>>,
+): NfsExecutorDeps {
   const helper = createNfsHelperClientFromProbe({
     helperSocket: config.nfs_helper_socket ?? DEFAULT_NFS_HELPER_SOCKET,
     timeoutMs: DEFAULT_NFS_HELPER_TIMEOUT_MS,
@@ -127,7 +132,7 @@ function buildNfsExecutorDeps(config: AgentConfig): NfsExecutorDeps {
       return undefined;
     }
   };
-  return { helper, readIdmapDomain };
+  return { helper, readIdmapDomain, readMounts };
 }
 
 /** What the task RPC handlers need from the wiring. */
@@ -196,10 +201,14 @@ export function buildTaskSubsystem(
 ): TaskSubsystem {
   const registry = new ExecutorRegistry();
   const fdir = fixtureDir();
+  // Resolved ONCE and shared by the xiRAID delete guard's TOCTOU check and
+  // share.create's xiRAID-backing gate — same mount table, same seam.
+  const resolvedReadMounts =
+    opts.readMounts ?? (fdir !== null ? makeFixtureMounts(fdir) : readProcMounts);
   // Register the real NFS executors (share.* + nfs-profile.update +
   // nfs-idmap.set) over the helper client; tests may inject `nfsDeps` to
   // override the helper/idmap reader.
-  const nfsDeps = opts.nfsDeps ?? buildNfsExecutorDeps(config);
+  const nfsDeps = opts.nfsDeps ?? buildNfsExecutorDeps(config, resolvedReadMounts);
   for (const ex of buildNfsExecutors(nfsDeps)) {
     registry.register(ex);
   }
@@ -212,7 +221,7 @@ export function buildTaskSubsystem(
     registry.register(
       makeXiraidArrayDeleteExecutor({
         client: opts.xiraidClient,
-        readMounts: opts.readMounts ?? (fdir !== null ? makeFixtureMounts(fdir) : readProcMounts),
+        readMounts: resolvedReadMounts,
       }),
     );
   }

--- a/xinas_menu/screens/filesystem.py
+++ b/xinas_menu/screens/filesystem.py
@@ -27,6 +27,7 @@ from textual.widgets import Footer, Label
 from xinas_menu.api.control_client import ControlPathError, TaskCancelled, TaskFailed, quote_id
 from xinas_menu.api.degraded import degraded_banner
 from xinas_menu.apptype import XiNASAppMixin
+from xinas_menu.utils.xfs_helpers import is_path_under
 from xinas_menu.widgets.confirm_dialog import ConfirmDialog
 from xinas_menu.widgets.input_dialog import InputDialog
 from xinas_menu.widgets.menu_list import MenuItem, NavigableMenu
@@ -201,14 +202,6 @@ def _volumes_in_use(fs_rows: list[dict[str, Any]]) -> set[str]:
             if isinstance(opt, str) and opt.startswith("logdev="):
                 used.add(opt[len("logdev=") :])
     return used
-
-
-def _is_under(path: str, root: str) -> bool:
-    """True when ``path`` is at or under ``root`` (path-segment aware)."""
-    if path == root:
-        return True
-    prefix = root if root.endswith("/") else root + "/"
-    return path.startswith(prefix)
 
 
 def _fmt_size(size_bytes: Any) -> str:
@@ -675,7 +668,7 @@ class FilesystemScreen(XiNASAppMixin, Screen):
                 sid = doc.get("id")
                 if not path or sid is None:
                     continue
-                if _is_under(str(path), mountpoint):
+                if is_path_under(str(path), mountpoint):
                     affected_shares.append({"id": str(sid), "path": str(path)})
 
         # ── Build warning ────────────────────────────────────────────────

--- a/xinas_menu/screens/nfs.py
+++ b/xinas_menu/screens/nfs.py
@@ -423,7 +423,18 @@ class NFSScreen(XiNASAppMixin, Screen):
         ok, out, _ = await run_async_cmd(
             "findmnt", "-t", "xfs", "-n", "-o", "TARGET,SOURCE", timeout=10
         )
-        if ok and out:
+        if not ok:
+            await self.app.push_screen_wait(
+                ConfirmDialog(
+                    "Couldn't read the mount table (findmnt failed), so the "
+                    "available xiRAID filesystems can't be determined.\n\n"
+                    "Check the system and try again.",
+                    "Add Share",
+                    ok_only=True,
+                )
+            )
+            return
+        if out:
             mount_points = _xiraid_mount_points(out)
 
         if not mount_points:

--- a/xinas_menu/screens/nfs.py
+++ b/xinas_menu/screens/nfs.py
@@ -56,6 +56,25 @@ def _path_prefill(stored: str, mount_points: list[str]) -> tuple[str | None, str
     return _CUSTOM_PATH, stored
 
 
+def _xiraid_mount_points(findmnt_output: str) -> list[str]:
+    """Return the TARGET mountpoints backed by a xiRAID volume (``/dev/xi_*``).
+
+    *findmnt_output* is the raw text of ``findmnt -t xfs -n -o TARGET,SOURCE``
+    (one ``<target> <source>`` row per line). Only rows whose SOURCE begins with
+    ``/dev/xi_`` are kept — that is xiNAS's block-device namespace for xiRAID
+    arrays.
+    """
+    mounts: list[str] = []
+    for line in findmnt_output.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        parts = stripped.rsplit(None, 1)
+        if len(parts) == 2 and parts[1].startswith("/dev/xi_"):
+            mounts.append(parts[0])
+    return mounts
+
+
 def _share_summary(
     path: str,
     host: str,

--- a/xinas_menu/screens/nfs.py
+++ b/xinas_menu/screens/nfs.py
@@ -18,6 +18,7 @@ from textual.widgets import Footer, Label
 
 from xinas_menu.api.control_client import ControlPathError, lease_conflict_message, quote_id
 from xinas_menu.apptype import XiNASAppMixin
+from xinas_menu.utils.xfs_helpers import is_path_under
 from xinas_menu.widgets.confirm_dialog import ConfirmDialog
 from xinas_menu.widgets.input_dialog import InputDialog
 from xinas_menu.widgets.menu_list import MenuItem, NavigableMenu
@@ -45,14 +46,19 @@ def _host_prefill(host: str) -> tuple[str, str]:
 def _path_prefill(stored: str, mount_points: list[str]) -> tuple[str | None, str]:
     """Map a stored path to (SelectDialog pre-selection, custom-input default).
 
-    Returns ``(mount, "/mnt/data/")`` when *stored* is one of *mount_points*,
+    The custom-input default is the first xiRAID mount root with a trailing
+    slash (falling back to ``/mnt/data/`` only when the list is empty), so the
+    custom-path field always starts inside a valid xiRAID filesystem.
+
+    Returns ``(mount, <default>)`` when *stored* is one of *mount_points*,
     ``("Custom path…", stored)`` when it is a non-empty non-mount path, and
-    ``(None, "/mnt/data/")`` when *stored* is empty (first entry).
+    ``(None, <default>)`` when *stored* is empty (first entry).
     """
+    default = (mount_points[0].rstrip("/") + "/") if mount_points else "/mnt/data/"
     if not stored:
-        return None, "/mnt/data/"
+        return None, default
     if stored in mount_points:
-        return stored, "/mnt/data/"
+        return stored, default
     return _CUSTOM_PATH, stored
 
 
@@ -414,65 +420,72 @@ class NFSScreen(XiNASAppMixin, Screen):
         from xinas_menu.utils.xfs_helpers import run_async_cmd
 
         mount_points: list[str] = []
-        ok, out, _ = await run_async_cmd("findmnt", "-t", "xfs", "-n", "-o", "TARGET", timeout=10)
+        ok, out, _ = await run_async_cmd(
+            "findmnt", "-t", "xfs", "-n", "-o", "TARGET,SOURCE", timeout=10
+        )
         if ok and out:
-            mount_points = [line.strip() for line in out.splitlines() if line.strip()]
+            mount_points = _xiraid_mount_points(out)
+
+        if not mount_points:
+            await self.app.push_screen_wait(
+                ConfirmDialog(
+                    "No xiRAID-backed filesystem found.\n\n"
+                    "NFS shares can only be exported from a filesystem on a "
+                    "xiRAID array. Create one first:\n"
+                    "Storage → Filesystems → Create Filesystem.",
+                    "Add Share",
+                    ok_only=True,
+                )
+            )
+            return
 
         async def path_step(answers, allow_back, step_no):
             stored = answers.get("path", "")
             title = f"Add Share — Step {step_no}/7"
             while True:
-                if mount_points:
-                    selected, custom_default = _path_prefill(stored, mount_points)
-                    choice = await self.app.push_screen_wait(
-                        SelectDialog(
-                            mount_points + [_CUSTOM_PATH],
-                            title=title,
-                            prompt="Select filesystem to export (or choose custom for a subfolder):",
-                            selected=selected,
-                            allow_back=allow_back,
-                        )
+                selected, custom_default = _path_prefill(stored, mount_points)
+                choice = await self.app.push_screen_wait(
+                    SelectDialog(
+                        mount_points + [_CUSTOM_PATH],
+                        title=title,
+                        prompt="Select filesystem to export (or choose custom for a subfolder):",
+                        selected=selected,
+                        allow_back=allow_back,
                     )
-                    if choice is None:
-                        return CANCEL
-                    if choice is BACK:
-                        return BACK
-                    if choice == _CUSTOM_PATH:
-                        sub = await self.app.push_screen_wait(
-                            InputDialog(
-                                "Export path:",
-                                title,
-                                default=custom_default,
-                                placeholder="/mnt/data/share1",
-                                allow_back=True,
-                            )
-                        )
-                        if sub is None:
-                            return CANCEL
-                        if sub is BACK:
-                            continue
-                        path = sub
-                    else:
-                        path = choice
-                else:
+                )
+                if choice is None:
+                    return CANCEL
+                if choice is BACK:
+                    return BACK
+                if choice == _CUSTOM_PATH:
                     sub = await self.app.push_screen_wait(
                         InputDialog(
                             "Export path:",
                             title,
-                            default=stored or "/mnt/data/",
+                            default=custom_default,
                             placeholder="/mnt/data/share1",
-                            allow_back=allow_back,
+                            allow_back=True,
                         )
                     )
                     if sub is None:
                         return CANCEL
                     if sub is BACK:
-                        return BACK
+                        continue
                     path = sub
+                else:
+                    path = choice
                 if not path.startswith("/"):
                     self.app.notify("Export path must start with '/'.", severity="error")
                     continue
-                return path.rstrip("/") or "/"
+                path = os.path.normpath(path)
+                if not any(is_path_under(path, mp) for mp in mount_points):
+                    self.app.notify(
+                        "Export path must be inside a xiRAID filesystem "
+                        f"({', '.join(mount_points)}).",
+                        severity="error",
+                    )
+                    continue
+                return path
 
         async def confirm_step(answers, allow_back, step_no):
             host = answers["host"]

--- a/xinas_menu/screens/raid.py
+++ b/xinas_menu/screens/raid.py
@@ -35,6 +35,7 @@ from xinas_menu.api.control_client import (
 )
 from xinas_menu.api.degraded import degraded_banner
 from xinas_menu.apptype import XiNASAppMixin
+from xinas_menu.utils.xfs_helpers import is_path_under
 from xinas_menu.widgets.confirm_dialog import ConfirmDialog
 from xinas_menu.widgets.drive_picker import DrivePickerScreen
 from xinas_menu.widgets.input_dialog import InputDialog
@@ -245,14 +246,6 @@ def _pool_drive_paths(pool: dict) -> list[str]:
         if path:
             paths.append(str(path))
     return paths
-
-
-def _is_under(path: str, root: str) -> bool:
-    """True when ``path`` is at or under ``root`` (path-segment aware)."""
-    if path == root:
-        return True
-    prefix = root if root.endswith("/") else root + "/"
-    return path.startswith(prefix)
 
 
 def _level_label(level: Any) -> str:
@@ -1001,7 +994,7 @@ class RAIDScreen(XiNASAppMixin, Screen):
                 sid = doc.get("id")
                 if not path or sid is None:
                     continue
-                if any(_is_under(str(path), mp) for mp in mountpoints):
+                if any(is_path_under(str(path), mp) for mp in mountpoints):
                     affected_shares.append({"id": str(sid), "path": str(path)})
 
         # ── Affected filesystems (mount units): backed by the array's

--- a/xinas_menu/utils/xfs_helpers.py
+++ b/xinas_menu/utils/xfs_helpers.py
@@ -18,6 +18,19 @@ _log = logging.getLogger(__name__)
 
 _DEVICE_RE = re.compile(r"^/dev/[a-zA-Z0-9_]+$")
 
+
+def is_path_under(path: str, root: str) -> bool:
+    """True when *path* is at or under *root* (path-segment aware).
+
+    ``/mnt/data`` is under ``/mnt/data``; ``/mnt/data/share1`` is under
+    ``/mnt/data``; ``/mnt/database`` is NOT (segment boundary enforced).
+    """
+    if path == root:
+        return True
+    prefix = root if root.endswith("/") else root + "/"
+    return path.startswith(prefix)
+
+
 # ── Async subprocess wrapper ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Fixes the reported gap where an operator could create an NFS share even with **no filesystem on top of xiRAID** (the Add Share wizard fell back to a free-form `/mnt/data/` path). An NFS export is now allowed **only** from a filesystem mounted on a xiRAID volume (`/dev/xi_*`), at the mount root or a subfolder.

- **TUI (Add Share wizard)** — lists only xiRAID-backed XFS mounts (`findmnt -t xfs -o TARGET,SOURCE` filtered by `/dev/xi_*`), aborts *before the wizard starts* with guidance when none exist (and a distinct "couldn't read the mount table" dialog when `findmnt` errors), and validates a custom path is at-or-under a xiRAID mount (`os.path.normpath` + segment-aware `is_path_under`).
- **Control-path (`share.create`)** — a live, **fail-closed** executor preflight throws `EXPORT_PATH_NOT_ON_XIRAID` when the export path isn't at-or-under a `/dev/xi_*` mount (longest-match over `/`), so MCP/API callers are equally constrained. Reuses the existing `readMounts()` seam (shared with the xiRAID delete guard). Deliberately **no plan-phase blocker** — that would read *observed* Filesystem state and could falsely block a valid create on a stale/degraded collector.
- **Consolidation** — a single `is_path_under` helper (`xfs_helpers.py`) replaces three identical private copies (`raid.py`, `filesystem.py`).
- **Specs updated in the same change** — `docs/Storage/fs-shares-management-spec.md` §4.5 and `docs/control-path/s3-nfs-executor-spec.md` §3.1.

## Rebuild

The control-path commit carries `Requires-Rebuild: xinas_node_build` — the compiled TypeScript ships in `dist/`, so the server-side gate takes effect only after the host rebuild role re-runs. The Python-TUI and docs commits carry no trailer.

## Test Plan

- [x] Python: `test_xfs_path_helpers` (6) + `test_nfs_wizard_helpers` (+5) → 17 passed; `ruff check`/`format` clean
- [x] TypeScript: `nfs-executor` 38 (4 new gate tests incl. fail-closed + longest-match), full unit suite 1375, `e2e/nfs-roundtrip` 4/4; `tsc --noEmit` clean
- [ ] Manual TUI on a host with a real xiRAID array: (a) no xiRAID FS → abort dialog; (b) `Custom path…` → `/mnt/data/share1` accepted; (c) `Custom path…` → `/srv/foo` rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)