### PR TITLE
fix(exporter): resolve the xiraid-exporter systemd unit name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,28 +4,45 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-xiNAS is an Ansible-based provisioning framework for high-performance NAS storage nodes. It uses interactive Bash menus (whiptail TUI) to configure and deploy Xinnor xiRAID storage with NVIDIA DOCA-OFED networking and NFS-RDMA exports.
+xiNAS is an Ansible-based provisioning framework for high-performance NAS storage nodes. Bash/whiptail menus drive the install; a Python/Textual TUI (`xinas_menu/`) and a TypeScript control path (`xiNAS-MCP/`) drive day-2 management. Deploys Xinnor xiRAID storage with NVIDIA DOCA-OFED networking and NFS-RDMA exports.
 
 **Target Platform:** Ubuntu 22.04/24.04 LTS
 
 ## Language
 
 **All repository artifacts are written in English, regardless of the
-language used in the working session.** This is binding for every
-contribution:
-
-- **Documentation** — every file under `docs/`, all READMEs, specs,
-  ADRs, plans, and changelog entries.
-- **Code comments** — inline comments, docstrings, and any explanatory
-  text embedded in source (Bash, Python, YAML, Ansible, Jinja2, etc.).
-- **Git metadata** — commit messages, branch names, tags, PR titles and
-  descriptions, and issue text.
-
-A conversation may happen in any language, but anything committed to the
-repository must be in English so the codebase stays consistent for all
-contributors.
+language used in the working session.** Binding for documentation, code
+comments and docstrings, commit messages, branch names, tags, PR titles
+and bodies, and issue text. A conversation may happen in any language;
+anything committed to the repository must be in English.
 
 ## Key Commands
+
+### Verification
+
+Run these before proposing a change is done — each mirrors a blocking CI
+job in `.github/workflows/ci.yml`. The path arguments matter: they are
+repeated verbatim across five jobs, and `ruff check .` does not give the
+same result.
+
+```bash
+pytest                                                     # or: pytest --cov=xinas_history --cov-fail-under=20
+ruff check          xinas_menu xinas_history xiNAS-MCP/nfs-helper
+ruff format --check xinas_menu xinas_history xiNAS-MCP/nfs-helper
+pyright             xinas_menu xinas_history xiNAS-MCP/nfs-helper
+ansible-lint collection/roles/     # needs: ansible-galaxy collection install community.general ansible.posix
+yamllint -c .yamllint.yml .
+npx --yes markdownlint-cli2 'docs/**/*.md'
+```
+
+TypeScript control path (from `xiNAS-MCP/`, Node ≥20):
+
+```bash
+npm run typecheck && npm run lint && npm run format:check
+npm test && npm run test:contracts
+```
+
+Dev dependencies: `pip install -e '.[dev]'`.
 
 ### Running Playbooks
 ```bash
@@ -69,27 +86,25 @@ the skill and publisher script remain for manual invocation.)
 User → Interactive Menu Scripts → Preset/Config Files → Ansible Playbooks → System
 ```
 
-### Layer Structure
-
-1. **Interactive Layer** - Bash scripts with whiptail TUI (`startup_menu.sh`, `configure_*.sh`)
-2. **Configuration Layer** - YAML presets in `/presets/{default,xinnorVM}/`
-3. **Orchestration Layer** - Ansible playbooks in `/playbooks/`
-4. **Implementation Layer** - Ansible roles in `/collection/roles/`
-
 ### Playbook Execution Order (site.yml)
-common → doca_ofed → net_controllers → xiraid_classic → nvme_namespace → raid_fs → exports → nfs_server → perf_tuning
+common → doca_ofed → net_controllers → xiraid_classic → nvme_namespace → raid_fs → exports →
+nfs_server → xinas_node_build → xinas_api → xinas_agent → xinas_nfs_helper → xinas_mcp →
+xinas_menu → xinas_history → perf_tuning → motd
 
 ### Key Directories
 
 | Directory | Purpose |
 |-----------|---------|
-| `playbooks/` | Ansible playbooks (site.yml, common.yml, doca_ofed_install.yml) |
-| `collection/roles/` | 10 Ansible roles (common, doca_ofed, xiraid_classic, nvme_namespace, raid_fs, exports, nfs_server, perf_tuning, net_controllers, xiraid_exporter) |
+| `playbooks/` | Ansible playbooks (site.yml, common.yml, doca_ofed_install.yml, uninstall.yml) |
+| `collection/roles/` | 20 Ansible roles — per-role options in `collection/roles/<role>/README.md` |
+| `xinas_menu/` | Python/Textual management TUI + health engine (day-2 management surface) |
+| `xiNAS-MCP/` | TypeScript control path — `xinas-api` (REST + `/mcp`), `xinas-agent`, `xinasctl` CLI, `xinas-mcp-stdio`. Node ≥20, biome + vitest |
+| `xinas_history/` | Configuration history & rollback library (Python) — snapshots, drift detection, transactional runner |
+| `tests/` | pytest suite — TUI screens, installer bash contracts, Ansible template rendering |
 | `presets/` | Deployment profiles with role configs and templates |
 | `inventories/` | Ansible inventory (default: localhost) |
 | `client_repo/` | Standalone NFS client package |
-| `xinas_history/` | Configuration history & rollback library (Python) — snapshots, drift detection, transactional runner |
-| `docs/` | Design docs and specs, organized by area: `Installer/`, `Storage/`, `MCP/`, `Network/`, `Notifications/`, `HealthCheck/`, `config-history/`, `control-path/`, `healthcheck-tunables/`, `troubleshooting/`, `plans/` |
+| `docs/` | Design docs and specs, organized by area (see table below) |
 
 ### Specs and design docs (`docs/`)
 
@@ -100,16 +115,17 @@ spec dump — every doc belongs to an area.
 |-----------|----------------|
 | `docs/Installer/` | Install-time / Ansible-driven behavior: `spec.md` (preset + playbook + role map), `network-spec.md`, `raid-spec.md`, `fs-exports-spec.md`, `uninstall-spec.md` (uninstaller contract), `update-spec.md` (GitHub-Releases-only install + update contract) |
 | `docs/Storage/` | Day-2 storage management surface (TUI screens, helpers, gRPC): `raid-management-spec.md`, `fs-shares-management-spec.md` |
-| `docs/Management/` | Day-2 System management screens: `user-management-spec.md` (User Management TUI — accounts, lock status, groups, quota), `audit-log-spec.md` (View Audit Log — merges the local TUI trail with the control-path `GET /audit` trail) |
-| `docs/MCP/` | MCP server spec set: `REQUIREMENTS.md`, `spec-core.md`, `spec-tools.md`, `spec-middleware.md`, `spec-config-history.md`, `spec-mail.md`, `spec-nfs-helper.md`, `spec-os.md`, `spec-server.md`, `modules.md` |
+| `docs/Management/` | Day-2 System management screens: `user-management-spec.md` (User Management TUI — accounts, lock status, groups, quota), `audit-log-spec.md` (View Audit Log — merges the local TUI trail with the control-path `GET /audit` trail), `xiraid-exporter-spec.md` (Integrations → xiRAID Exporter; the package/unit name split and the unit-name resolution contract) |
+| `docs/MCP/` | LEGACY MCP server spec set — reference only, superseded by ADR-0010 / `s8-clients-spec.md` |
 | `docs/Network/` | Cross-cutting network management (netplan ownership, PBR, day-2 IP edits): `spec-network-management.md` |
 | `docs/Notifications/` | Email / alerting pipelines (xiNAS SMTP + xiRAID sendmail): `spec-email-notifications.md` |
 | `docs/HealthCheck/` | Individual health-check designs (one file per check, e.g. `pcie-link-check.md`) |
 | `docs/config-history/` | `xinas_history` library design (`requirements.md`, `architecture.md`, `specs.md`, `grpc-api-reference.md`) |
-| `docs/control-path/` | Phase 0 Control Path foundation: `phase0-requirements.md` (live contract) and `adr/` (architecture decision records — `0001-api-surface.md`, …). The companion implementation plan lives at `docs/plans/2026-05-26-phase0-control-path-plan.md`. ADRs supersede earlier plan/spec language where they conflict |
+| `docs/control-path/` | Control Path foundation: `phase0-requirements.md`, the `sN-*-spec.md` slice specs, `api-v1.yaml` (CI-gated, see Important Notes), and `adr/` (architecture decision records `0001`–`0017`). ADRs supersede earlier plan/spec language where they conflict |
 | `docs/healthcheck-tunables/` | Reference docs for tunable parameters (sysctl, filesystem, perf) |
 | `docs/troubleshooting/` | Postmortems / known-issue writeups (one file per incident) |
 | `docs/plans/` | Dated implementation plans (`YYYY-MM-DD-<topic>-plan.md`, `-design.md`). Append-only history of intent — do **not** edit landed plans to reflect later changes; the live spec in the topic subfolder is the source of truth |
+| `docs/superpowers/` | Dated design/plan/test artifacts from skill-driven work, split into `plans/`, `specs/`, `tests/`. Same append-only rule as `docs/plans/` |
 
 #### Spec-first rule
 
@@ -140,44 +156,31 @@ test-only changes). When in doubt, write the spec.
 
 ### Configuration History (`xinas_history/`)
 
-Python library providing snapshot-based configuration tracking and rollback for xiNAS:
+Snapshot-based configuration tracking and rollback: captures config files
+plus runtime state (RAID, mounts, exports, services) before and after a
+change, classifies rollback risk (`destroying_data` > `changing_access` >
+`non_disruptive`), and wraps changes in a transactional
+lock → preflight → snapshot → execute → validate → auto-rollback → release
+sequence. Store: `/var/lib/xinas/config-history/`. CLI:
+`python3 -m xinas_history snapshot list|show|create|diff`, `gc run`,
+`status` (JSON output). Design docs: `docs/config-history/`.
 
-- **Snapshots**: Captures config files + runtime state (RAID, mounts, exports, services) before/after changes
-- **Rollback classification**: Three risk levels — `destroying_data` > `changing_access` > `non_disruptive`
-- **Transactional runner**: 8-step sequence (lock → preflight → snapshot → execute → validate → mark → auto-rollback → release)
-- **Drift detection**: Checksum comparison of `/etc/exports`, `/etc/nfs.conf`, netplan against last applied snapshot
-- **Store**: `/var/lib/xinas/config-history/` with atomic writes, `baseline/` + `snapshots/{id}/`
-- **CLI**: `python3 -m xinas_history snapshot list|show|create|diff`, `gc run`, `status` (JSON output for MCP bridge)
-- **Consumers**: Textual TUI screens (`xinas_menu/screens/config_history.py`, `snapshot_detail.py`), MCP tools (`config.*`), installer hooks
-- **Deployment**: Ansible role `collection/roles/xinas_history/` — copies package, installs PyYAML, creates CLI wrapper
+### MCP surface
 
-### MCP Server Documentation
+**The standalone MCP server was retired (ADR-0010, S8.)** The MCP transport
+now lives inside `xinas-api.service` — the `/mcp` endpoint plus the
+`xinas-mcp-stdio` adapter, catalog-generated tools, apply gated by
+`mcp.allow_apply`. Live contract:
+`docs/control-path/adr/0010-clients-mcp-cli-tui.md` and
+`docs/control-path/s8-clients-spec.md`. The spec set under `docs/MCP/`
+describes the legacy server and is kept for reference only — do not treat
+it as current.
 
-> **Superseded (S8, ADR-0010):** the standalone MCP server was retired.
-> The MCP transport now lives inside `xinas-api.service`
-> (`/mcp` endpoint + the `xinas-mcp-stdio` adapter; catalog-generated
-> tools; apply gated by `mcp.allow_apply`). The docs below describe the
-> LEGACY server and are kept for reference; see
-> `docs/control-path/adr/0010-clients-mcp-cli-tui.md` and
-> `docs/control-path/s8-clients-spec.md` for the live contract.
+### Presets
 
-MCP (Model Context Protocol) server specification and design docs live under `docs/MCP/`.
-
-| File | Purpose |
-|------|---------|
-| `docs/MCP/REQUIREMENTS.md` | Functional requirements — 9 tool namespaces (system, network, health, disk, RAID, share, auth, job, config) |
-| `docs/MCP/spec-tools.md` | Tool summary table (55 tools), preflight logic, health profiles, error scenarios |
-| `docs/MCP/spec-middleware.md` | RBAC permission matrix, audit logging, locking, idempotency, plan/apply |
-| `docs/MCP/spec-config-history.md` | Config-history tools spec (6 tools), subprocess protocol for `xinas_history` backend |
-| `docs/MCP/spec-core.md` | Core server architecture, transport, error model |
-| `docs/MCP/modules.md` | Module map, dependency graph, file count summary (42 files) |
-
-### Preset Structure
-Each preset directory (`presets/default/`, `presets/xinnorVM/`) contains:
-- `playbook.yml` - Role execution order and preset-specific variables
-- `raid_fs.yml` - RAID array and XFS filesystem definitions
-- `nfs_exports.yml` - NFS export rules
-- `netplan.yaml.j2` - Network interface template
+Each preset directory (`presets/default/`, `presets/xinnorVM/`) holds
+`playbook.yml` (role order + preset variables), `raid_fs.yml`,
+`nfs_exports.yml`, and `netplan.yaml.j2`.
 
 ## Update rebuild markers (`Requires-Rebuild:` trailer)
 
@@ -186,36 +189,18 @@ The in-TUI update flow (`u` shortcut, Management → Check for Updates, MCP/Adva
 If a commit changes anything that requires an Ansible role to re-run on the host to take effect (systemd unit files, package installs, sysctl/perf tuning, kernel module config, NFS server flags, RAID layout, network config that needs `net_controllers` to re-apply, etc.), **add a Git trailer to the commit message**:
 
 ```
-Requires-Rebuild: <ansible_tag>[, <ansible_tag>...]
-```
-
-- `<ansible_tag>` is a tag accepted by `ansible-playbook playbooks/site.yml --tags <tag>` — usually the role name (`nfs_server`, `perf_tuning`, `net_controllers`, `xinas_mcp`, `xinas_menu`, …).
-- Comma-separate multiple tags. Multiple trailers across multiple commits are aggregated by the TUI.
-- The special value `all` means run the full `site.yml` with no `--tags` filter; use it only when the change spans many roles.
-- **Do not add this trailer for code-only changes** (Python TUI logic, MCP server Python code, docs, plan/spec updates, test fixtures). The plain release-tag checkout + `xinas-nfs-helper` restart that already runs on every update is sufficient — adding a trailer here just trains users to click past an unnecessary Ansible warning.
-- Parsed case-insensitively from the **release notes** (the release body aggregates the trailers from the commits it ships). Backfilling old commit messages has no effect.
-- Tags are **unioned across every published release newer than the installed version**, not just the latest one — a host jumping 3.6.0 → 3.6.2 still runs the roles 3.6.1 asked for.
-- The trailer must **start a line** (leading `>` blockquote markers, `*`/`_` emphasis, backticks and whitespace are tolerated and stripped). A trailer that fails to parse is indistinguishable from no trailer, so the Ansible step is silently skipped — that regression shipped in v3.6.0 and v3.6.1. Prefer a bare, column-0 line. See `docs/Installer/update-spec.md` §*Rebuild trailers*.
-
-Examples:
-
-```
 fix(nfs_server): bump RPC thread count to 64
 
 Requires-Rebuild: nfs_server
 ```
 
-```
-feat(net): add lossless RoCE tuning
-
-Requires-Rebuild: net_controllers, perf_tuning
-```
-
-```
-chore: re-template every role after defaults overhaul
-
-Requires-Rebuild: all
-```
+- `<ansible_tag>` is a tag accepted by `ansible-playbook playbooks/site.yml --tags <tag>` — usually the role name (`nfs_server`, `perf_tuning`, `net_controllers`, `xinas_mcp`, `xinas_menu`, …).
+- Comma-separate multiple tags (`Requires-Rebuild: net_controllers, perf_tuning`). Multiple trailers across multiple commits are aggregated by the TUI.
+- The special value `all` means run the full `site.yml` with no `--tags` filter; use it only when the change spans many roles.
+- **Do not add this trailer for code-only changes** (Python TUI logic, MCP server code, docs, plan/spec updates, test fixtures). The plain release-tag checkout + `xinas-nfs-helper` restart that already runs on every update is sufficient — adding a trailer here just trains users to click past an unnecessary Ansible warning.
+- Parsed case-insensitively from the **release notes** (the release body aggregates the trailers from the commits it ships). Backfilling old commit messages has no effect.
+- Tags are **unioned across every published release newer than the installed version**, not just the latest one — a host jumping 3.6.0 → 3.6.2 still runs the roles 3.6.1 asked for.
+- The trailer must **start a line** (leading `>` blockquote markers, `*`/`_` emphasis, backticks and whitespace are tolerated and stripped). A trailer that fails to parse is indistinguishable from no trailer, so the Ansible step is silently skipped — that regression shipped in v3.6.0 and v3.6.1. Prefer a bare, column-0 line. See `docs/Installer/update-spec.md` §*Rebuild trailers*.
 
 Runtime behaviour of the update flow:
 1. When a rebuild is required, the confirm dialog names the role(s) that will run before the user accepts.
@@ -267,8 +252,7 @@ To cut a release (see also `CHANGELOG.md`):
    `pyproject.toml` derives from it). Pick the next patch for
    backward-compatible changes, minor/major otherwise.
 2. Update the changelog / release notes (`CHANGELOG.md`).
-3. Run the tests, linters, and basic checks (`pytest`,
-   `ruff check`, `ruff format --check`).
+3. Run the tests, linters, and basic checks (see [Verification](#verification)).
 4. Create a git tag in `vX.Y.Z` form.
 5. Create a GitHub Release from that tag (`gh release create vX.Y.Z`).
 6. Attach the release assets the project uses (`install.sh`,
@@ -284,13 +268,22 @@ user-facing install or production-update path. If you add a
 dev/nightly path, keep it explicitly separated from the production
 flow and off by default.
 
+## Repo Etiquette
+
+- **Commits** follow Conventional Commits — `type(scope): subject`, e.g.
+  `fix(installer): validate the tag before the bootstrap clone`,
+  `docs(plans): WS3 landed`. Common types: `feat`, `fix`, `refactor`,
+  `test`, `docs`, `chore`. Releases are `chore(release): vX.Y.Z`.
+- **Branches** are `<type>/<slug>` — `fix/doca-ofed-flush-handlers`,
+  `feat/xiraid-only-shares`, `docs/…`.
+
 ## Important Notes
 
 - **Shell vs. Python TUI scope** — There are two distinct user surfaces. Treat them differently:
   - **Installer / bootstrap (bash, still active):** `prepare_system.sh`, `startup_menu.sh`, `simple_menu.sh`, and the shared `lib/menu_lib.sh`. These run before the Python TUI is installed and remain the supported install path. Bug fixes, polish, and improvements to the install flow itself are welcome here.
   - **Post-install management (Python only):** `post_install_menu.sh`, `configure_*.sh`, and any other day-2 management/configuration UI. These are deprecated. Do NOT add new features, settings screens, or configuration UIs to these shell scripts — implement them in the Python-based `xinas_menu/` package (Textual TUI) instead.
   - When a feature touches both surfaces (e.g. how `ansible-playbook` output is presented during install), it is acceptable — and expected — to update both the bash installer side and the Python TUI side so they stay in feel-parity.
-- **No build/test system** - This is infrastructure-as-code; validation occurs through Ansible modules
+- **`docs/control-path/api-v1.yaml` is CI-gated** — it looks like a doc but is not. Spectral lints it against `.spectral.yaml`, and `oasdiff` fails the PR on any **breaking** schema change relative to the base branch. Edit it deliberately, and expect a red PR if you remove or tighten an existing field.
 - **yq v4 required** - Shell scripts use mikefarah/yq (not the Python jq wrapper). Ensure `/usr/local/bin/yq` is in PATH
 - **Roles are idempotent by default** - Re-running `site.yml` over a healthy array converges (no reformat, no namespace rebuild). Destroying and rebuilding storage requires the explicit `xinas_storage_reset: true` (with an interactive `YES`, or `nvme_skip_cleanup_confirmation: true` for automation). The legacy `xfs_force_mkfs` / `nvme_use_existing_namespaces` knobs are disarmed and no longer trigger wipes on their own. See [docs/Installer/raid-spec.md](docs/Installer/raid-spec.md) §11.
 - **License stored at `/tmp/license`** - Cleared on reboot; enter via menu before deployment
@@ -300,25 +293,19 @@ flow and off by default.
 
 ## Automatic NVMe Namespace Management
 
-The `nvme_namespace` role provides automatic device discovery and namespace configuration:
+The `nvme_namespace` role detects and excludes the system drive, rebuilds
+namespaces on every other NVMe controller (n1: small namespace, 500 MB by
+default, for the XFS log device; n2: remaining capacity for data), and
+generates the `xiraid_arrays` / `xfs_filesystems` facts consumed by
+`raid_fs` — RAID 10 from the small namespaces, RAID 5 from the large ones.
 
-1. Detects system drive (root/boot/EFI partitions) and excludes it
-2. Enumerates all other NVMe controllers as data drives
-3. Rebuilds namespaces on data drives:
-   - n1: Small namespace (500MB default) for XFS log device
-   - n2: Large namespace (remaining capacity) for data
-4. Generates `xiraid_arrays` and `xfs_filesystems` facts for `raid_fs` role:
-   - RAID 10 from small namespaces (log array)
-   - RAID 5 from large namespaces (data array)
-
-Enable/disable via `nvme_auto_namespace: true/false` in `collection/roles/nvme_namespace/defaults/main.yml` or use the "Auto-Detect" option in `configure_raid.sh`.
+Toggle via `nvme_auto_namespace: true/false` in
+`collection/roles/nvme_namespace/defaults/main.yml`, or the "Auto-Detect"
+option in `configure_raid.sh`. Full behavior:
+[docs/Installer/raid-spec.md](docs/Installer/raid-spec.md).
 
 ## Variable Priority
 
 1. CLI/inventory variables (highest)
 2. Preset YAML files (loaded by menu scripts)
 3. Role `defaults/main.yml` (lowest)
-
-## Role Documentation
-
-Each role has its own README at `collection/roles/<role>/README.md` with configuration options and examples.

--- a/collection/roles/xinas_uninstall/tasks/91_optional_xiraid.yml
+++ b/collection/roles/xinas_uninstall/tasks/91_optional_xiraid.yml
@@ -2,11 +2,17 @@
 # Optional phase 91 — remove the xiRAID package, repo, and DKMS module.
 # Gated by uninstall_remove_xiraid in tasks/main.yml.
 
+# The exporter .deb installs `xiraid_exporter.service` (underscore); older
+# builds shipped the hyphenated unit. Sweep both — a name that does not exist
+# is tolerated by failed_when: false, so teardown never depends on guessing.
 - name: "XiRAID | stop and disable xiraid-exporter"
   ansible.builtin.systemd:
-    name: xiraid-exporter.service
+    name: "{{ item }}"
     state: stopped
     enabled: false
+  loop:
+    - xiraid_exporter.service
+    - xiraid-exporter.service
   register: _xiraid_exp_stop
   failed_when: false
   changed_when: _xiraid_exp_stop.changed | default(false)

--- a/collection/roles/xiraid_exporter/defaults/main.yml
+++ b/collection/roles/xiraid_exporter/defaults/main.yml
@@ -16,3 +16,11 @@ xiraid_exporter_download_url: >-
 
 # Metrics listen port
 xiraid_exporter_port: 9827
+
+# Candidate systemd unit names, most likely first. The .deb installs
+# `xiraid_exporter.service` (underscore) even though the package and binary
+# are hyphenated; older builds shipped the hyphenated unit. The role resolves
+# which one is actually present instead of assuming.
+xiraid_exporter_unit_candidates:
+  - xiraid_exporter.service
+  - xiraid-exporter.service

--- a/collection/roles/xiraid_exporter/handlers/main.yml
+++ b/collection/roles/xiraid_exporter/handlers/main.yml
@@ -1,5 +1,5 @@
 - name: Reload xiraid_exporter
   ansible.builtin.systemd:
     daemon_reload: yes
-    name: xiraid-exporter
+    name: "{{ xiraid_exporter_unit | default(xiraid_exporter_unit_candidates[0]) }}"
     state: restarted

--- a/collection/roles/xiraid_exporter/tasks/main.yml
+++ b/collection/roles/xiraid_exporter/tasks/main.yml
@@ -13,9 +13,20 @@
     state: present
   tags: [xiraid_exporter, install]
 
+- name: Gather service facts to resolve the exporter unit name
+  ansible.builtin.service_facts:
+  tags: [xiraid_exporter, service]
+
+- name: Resolve the xiraid-exporter systemd unit name
+  ansible.builtin.set_fact:
+    xiraid_exporter_unit: >-
+      {{ (xiraid_exporter_unit_candidates | select('in', ansible_facts.services) | list
+          + [xiraid_exporter_unit_candidates[0]]) | first }}
+  tags: [xiraid_exporter, service]
+
 - name: Enable and start xiraid-exporter service
   ansible.builtin.service:
-    name: xiraid-exporter
+    name: "{{ xiraid_exporter_unit }}"
     enabled: true
     state: started
   tags: [xiraid_exporter, service]

--- a/docs/Management/xiraid-exporter-spec.md
+++ b/docs/Management/xiraid-exporter-spec.md
@@ -1,0 +1,131 @@
+# xiRAID Exporter integration (spec)
+
+**Owns:** the Management → Integrations → **xiRAID Exporter** screen
+(`xinas_menu/screens/exporter.py`), the systemd unit-name resolver
+(`xinas_menu/utils/service_ctl.py::xiraid_exporter_unit`), and the
+`xiraid_exporter` Ansible role. Also governs how every other xiNAS surface
+refers to the exporter service: the health engines
+(`xinas_menu/health/engine.py`, `healthcheck.sh`), Quick Actions → Service
+Status, and the `xinas_uninstall` teardown.
+
+**Status:** active (2026-07-24).
+
+## Component
+
+The xiRAID Prometheus exporter is a third-party component from
+[E4 Computer Engineering](https://github.com/E4-Computer-Engineering/xiraid-exporter),
+distributed as a `.deb` and installed from its GitHub Releases. It scrapes
+xiRAID state and serves Prometheus metrics on **port 9827**
+(`http://localhost:9827/metrics`). xiNAS installs, updates, restarts, reports
+on, and removes it, but does not vendor or build it.
+
+It is **not** part of `site.yml`. The `xiraid_exporter` role exists for
+explicit invocation (`--tags xiraid_exporter`); the normal path is the TUI
+screen, which downloads the release asset and installs it with `apt`.
+
+## The package/unit name split
+
+This is the contract every call site must respect.
+
+| Identifier | Spelling | Example |
+|-----------|----------|---------|
+| Debian package | **hyphen** | `xiraid-exporter` (`dpkg-query -W xiraid-exporter`) |
+| Binary | **hyphen** | `/usr/bin/xiraid-exporter` |
+| GitHub repo / release asset | **hyphen** | `xiraid-exporter_1.1.1_linux_amd64.deb` |
+| **systemd unit** | **underscore** | `/usr/lib/systemd/system/xiraid_exporter.service` |
+
+The unit is the odd one out. Older builds of the package shipped the
+hyphenated unit (`xiraid-exporter.service`), so **both spellings exist in the
+field** and the unit name must not be hardcoded.
+
+### Why hardcoding fails silently
+
+`systemctl show <unknown-unit> --property=ActiveState` exits **0** and reports
+`ActiveState=inactive`, not an error. A wrong unit name is therefore
+indistinguishable from a stopped service:
+
+```console
+$ systemctl is-active xiraid_exporter.service   # real unit
+active
+$ systemctl is-active xiraid-exporter.service   # does not exist
+inactive
+$ systemctl is-enabled xiraid-exporter.service
+Failed to get unit file state: No such file or directory   # exit 4
+```
+
+Every affected surface reported a healthy, metrics-serving exporter as down,
+and `systemctl restart` on the nonexistent unit returned success while doing
+nothing — so the screen's Restart action could never clear the false
+"inactive". See the regression test
+`tests/test_xiraid_exporter_unit.py` for the full failure description.
+
+## Resolution contract
+
+**Every systemd operation on the exporter MUST resolve the unit name at
+runtime.** No surface may embed a literal unit name.
+
+Resolution probes `LoadState`, which distinguishes an installed-but-stopped
+unit (`loaded`) from an unknown one (`not-found`) — unlike `ActiveState`,
+which conflates them:
+
+1. Try `xiraid_exporter.service` (current packaging, preferred).
+2. Fall back to `xiraid-exporter.service` (older packaging).
+3. If neither resolves — the exporter is not installed — return the **first**
+   candidate, so callers still have a stable name to display and to attribute
+   errors to.
+
+Order is pinned by `service_ctl.XIRAID_EXPORTER_UNITS` and, for Ansible, by
+`xiraid_exporter_unit_candidates` in the role defaults. When both units are
+present (upgrade leftovers), the preferred spelling wins.
+
+### Consumers
+
+| Surface | Mechanism |
+|---------|-----------|
+| `xinas_menu/screens/exporter.py` | `xiraid_exporter_unit()` before each `state()` / `restart()` |
+| `xinas_menu/screens/quick_actions.py` | `_services()` resolves at call time; the Service Status list is built per invocation, not at import |
+| `xinas_menu/health/engine.py` | local `xiraid_exporter_unit()` helper, resolved when `check_services` builds `service_map` |
+| `healthcheck.sh` | byte-identical copy of that helper — the embedded Python runs standalone and cannot import `xinas_menu` |
+| `collection/roles/xiraid_exporter` | `service_facts` + `set_fact` → `xiraid_exporter_unit`, consumed by the `service:` task and the reload handler |
+| `collection/roles/xinas_uninstall` | loops **both** candidates with `failed_when: false`, so teardown never depends on guessing |
+
+The two health-engine copies are kept byte-identical and enforced by
+`tests/test_xiraid_exporter_unit.py::test_health_engine_copies_are_identical`.
+
+## Screen behavior
+
+Management → Integrations → xiRAID Exporter offers:
+
+| Action | Behavior |
+|--------|----------|
+| **Status** | Installed version via `dpkg-query -W -f='${Version}' xiraid-exporter` (package name — hyphen), service state via the **resolved** unit. Shows the metrics URL. When the package is absent, shows "Not installed" and does not query systemd |
+| **Install / Update** | Resolves the latest release from the GitHub API, downloads the `.deb` matching `xiraid.exporter.*\.deb`, installs with `apt`. Reports "already latest" when versions match |
+| **Restart** | Confirms, then restarts the **resolved** unit. Refuses when the package is not installed |
+| **Uninstall** | Confirms, then `apt-get purge -y xiraid-exporter` (package name — hyphen) |
+
+Install, update, restart, and uninstall are audited (`exporter.install`,
+`exporter.restart`, `exporter.uninstall`).
+
+## Rebuild semantics
+
+Changes confined to the TUI, the resolver, or the health engines are
+**code-only** — they take effect on the next TUI start and need no
+`Requires-Rebuild:` trailer.
+
+Role changes need no trailer either, for a different reason: `xiraid_exporter`
+is **not** listed in `playbooks/site.yml`, so the trailer's
+`ansible-playbook playbooks/site.yml --tags xiraid_exporter` would match no
+tasks and silently do nothing. Role changes here take effect only when the
+role is invoked explicitly, and must not carry the trailer — adding one would
+train users to click through an Ansible warning that cannot help them.
+
+## Known constraints
+
+- The role pins `xiraid_exporter_version` (currently `1.1.0`) while the TUI
+  installs whatever the GitHub API reports as latest. The two paths can
+  therefore land different versions on the same host; the TUI is the
+  supported route and wins in practice.
+- `post_install_menu.sh` carries its own copy of the exporter menu and still
+  uses the hyphenated unit name. It is a deprecated day-2 surface (see
+  CLAUDE.md, *Shell vs. Python TUI scope*) and is intentionally not fixed —
+  use the Python TUI.

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1172,6 +1172,21 @@ def check_nfs(exp, checks):
 
     return results
 
+def xiraid_exporter_unit():
+    """Resolve the xiRAID exporter systemd unit name.
+
+    The .deb installs `xiraid_exporter.service` (underscore) while the package
+    and binary are hyphenated; older builds shipped the hyphen. Probing
+    LoadState keeps a healthy exporter from being reported as down.
+    """
+    for unit in ("xiraid_exporter.service", "xiraid-exporter.service"):
+        if run_cmd(f"systemctl show {unit} --property=LoadState 2>/dev/null") == (
+            "LoadState=loaded"
+        ):
+            return unit
+    return "xiraid_exporter.service"
+
+
 def check_services(exp, checks):
     results = []
 
@@ -1181,7 +1196,7 @@ def check_services(exp, checks):
         "nfs_server": ("nfs-server", "NFS server"),
         "rpcbind": ("rpcbind", "RPC port mapper"),
         "nfsdcld": ("nfsdcld", "NFS client tracking daemon"),
-        "xiraid_exporter": ("xiraid-exporter", "xiRAID Prometheus exporter"),
+        "xiraid_exporter": (xiraid_exporter_unit(), "xiRAID Prometheus exporter"),
         "chrony": ("chrony", "NTP time synchronization"),
     }
 

--- a/tests/test_xiraid_exporter_unit.py
+++ b/tests/test_xiraid_exporter_unit.py
@@ -1,0 +1,170 @@
+"""The xiRAID exporter systemd unit name must never be hardcoded.
+
+The upstream `.deb` (E4 Computer Engineering) is hyphenated as a *package*
+(`xiraid-exporter`, `/usr/bin/xiraid-exporter`) but installs its systemd unit
+with an *underscore*: `/usr/lib/systemd/system/xiraid_exporter.service`. Older
+builds shipped the hyphenated unit.
+
+Every xiNAS call site used to assume the hyphen, so on a current install:
+
+  * the Integrations → xiRAID Exporter screen reported "inactive" for a
+    healthy, metrics-serving exporter,
+  * its Restart action was a silent no-op — it restarted a unit that does not
+    exist, reported success, then re-read "inactive",
+  * the health engine flagged the exporter as down,
+  * the Ansible role's `service:` task failed outright with "Could not find the
+    requested service".
+
+The fix resolves the unit name at runtime. These tests pin that no call site
+regresses to a hardcoded spelling, and that the two copies of the health-engine
+helper (`xinas_menu/health/engine.py` and the standalone Python embedded in
+`healthcheck.sh`, which cannot import it) stay in sync.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from xinas_menu.utils import service_ctl
+
+REPO = Path(__file__).resolve().parents[1]
+
+UNDERSCORE = "xiraid_exporter.service"
+HYPHEN = "xiraid-exporter.service"
+
+
+def _stub_run(loaded: set[str]):
+    """Fake ServiceController._run answering `systemctl show --property=LoadState`."""
+
+    def _run(*args: str, check: bool = False) -> subprocess.CompletedProcess:
+        name = args[1]
+        state = "loaded" if name in loaded else "not-found"
+        return subprocess.CompletedProcess(
+            args=list(args), returncode=0, stdout=f"LoadState={state}\n", stderr=""
+        )
+
+    return _run
+
+
+# ── resolver behaviour ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("loaded", "expected"),
+    [
+        # Current .deb: only the underscore unit exists.
+        ({UNDERSCORE}, UNDERSCORE),
+        # Older build: only the hyphenated unit exists.
+        ({HYPHEN}, HYPHEN),
+        # Both present (upgrade leftovers) — the preferred spelling wins.
+        ({UNDERSCORE, HYPHEN}, UNDERSCORE),
+    ],
+)
+def test_resolves_whichever_unit_is_installed(monkeypatch, loaded, expected):
+    monkeypatch.setattr(service_ctl.ServiceController, "_run", staticmethod(_stub_run(loaded)))
+    assert service_ctl.xiraid_exporter_unit() == expected
+
+
+def test_falls_back_to_first_candidate_when_nothing_resolves(monkeypatch):
+    """Exporter not installed: callers still get a stable name to display."""
+    monkeypatch.setattr(service_ctl.ServiceController, "_run", staticmethod(_stub_run(set())))
+    assert service_ctl.xiraid_exporter_unit() == UNDERSCORE
+
+
+def test_a_not_found_unit_is_never_accepted(monkeypatch):
+    """The exact bug: `systemctl show` succeeds (rc=0) for an unknown unit.
+
+    Resolution must key off LoadState, not the exit code — rc=0 with
+    LoadState=not-found is what made the hyphen look like a usable unit.
+    """
+    monkeypatch.setattr(service_ctl.ServiceController, "_run", staticmethod(_stub_run(set())))
+    assert service_ctl.resolve_unit(HYPHEN, UNDERSCORE) == HYPHEN  # fallback, not a match
+
+    monkeypatch.setattr(
+        service_ctl.ServiceController, "_run", staticmethod(_stub_run({UNDERSCORE}))
+    )
+    assert service_ctl.resolve_unit(HYPHEN, UNDERSCORE) == UNDERSCORE
+
+
+def test_candidate_order_is_the_documented_preference():
+    assert service_ctl.XIRAID_EXPORTER_UNITS == (UNDERSCORE, HYPHEN)
+
+
+# ── drift guards ───────────────────────────────────────────────────────────
+
+# Call sites that must go through the resolver, and the literals that would
+# reintroduce the bug. The bare package name is legitimate elsewhere in these
+# files (dpkg queries, apt purge, download URLs, display strings), so each
+# entry pins the specific *systemd* usage rather than banning the word.
+_FORBIDDEN = {
+    "xinas_menu/screens/exporter.py": [
+        'ctl.state("xiraid-exporter")',
+        'ctl.restart("xiraid-exporter")',
+    ],
+    "xinas_menu/screens/quick_actions.py": [
+        '"xiraid-exporter",',
+    ],
+    "xinas_menu/health/engine.py": [
+        '("xiraid-exporter", "xiRAID Prometheus exporter")',
+    ],
+    "healthcheck.sh": [
+        '("xiraid-exporter", "xiRAID Prometheus exporter")',
+    ],
+    "collection/roles/xiraid_exporter/tasks/main.yml": [
+        "name: xiraid-exporter\n",
+    ],
+    "collection/roles/xiraid_exporter/handlers/main.yml": [
+        "name: xiraid-exporter\n",
+    ],
+}
+
+
+@pytest.mark.parametrize(("rel", "literals"), sorted(_FORBIDDEN.items()))
+def test_no_call_site_hardcodes_the_hyphenated_unit(rel, literals):
+    text = (REPO / rel).read_text()
+    for literal in literals:
+        assert literal not in text, (
+            f"{rel} hardcodes the hyphenated exporter unit ({literal!r}). "
+            f"Resolve it instead — the .deb installs {UNDERSCORE}."
+        )
+
+
+def test_uninstall_sweeps_both_unit_spellings():
+    """Teardown must not depend on guessing which unit the .deb installed."""
+    text = (REPO / "collection/roles/xinas_uninstall/tasks/91_optional_xiraid.yml").read_text()
+    assert UNDERSCORE in text and HYPHEN in text
+
+
+def test_role_defaults_list_both_candidates():
+    text = (REPO / "collection/roles/xiraid_exporter/defaults/main.yml").read_text()
+    assert "xiraid_exporter_unit_candidates:" in text
+    assert UNDERSCORE in text and HYPHEN in text
+
+
+# ── engine.py / healthcheck.sh parity ──────────────────────────────────────
+
+# healthcheck.sh embeds a standalone Python program via a `<< 'PYEOF'` heredoc.
+# It runs before/independently of the xinas_menu package and cannot import the
+# resolver, so it carries its own copy. If one drifts, the shell health engine
+# and the TUI health engine disagree about whether the exporter is up.
+_HELPER_RE = re.compile(
+    r"def xiraid_exporter_unit\(\):.*?return \"xiraid_exporter\.service\"",
+    re.S,
+)
+
+
+@pytest.mark.parametrize("rel", ["xinas_menu/health/engine.py", "healthcheck.sh"])
+def test_both_health_engines_carry_the_helper(rel):
+    assert _HELPER_RE.search((REPO / rel).read_text()), f"{rel} lost its resolver helper"
+
+
+def test_health_engine_copies_are_identical():
+    engine = _HELPER_RE.search((REPO / "xinas_menu/health/engine.py").read_text())
+    shell = _HELPER_RE.search((REPO / "healthcheck.sh").read_text())
+    assert engine and shell
+    assert engine.group(0) == shell.group(0), (
+        "the xiraid_exporter_unit() helper drifted between engine.py and "
+        "healthcheck.sh; keep the two copies byte-identical"
+    )

--- a/xinas_menu/health/engine.py
+++ b/xinas_menu/health/engine.py
@@ -2144,6 +2144,21 @@ def check_nfs(exp, checks):
     return results
 
 
+def xiraid_exporter_unit():
+    """Resolve the xiRAID exporter systemd unit name.
+
+    The .deb installs `xiraid_exporter.service` (underscore) while the package
+    and binary are hyphenated; older builds shipped the hyphen. Probing
+    LoadState keeps a healthy exporter from being reported as down.
+    """
+    for unit in ("xiraid_exporter.service", "xiraid-exporter.service"):
+        if run_cmd(f"systemctl show {unit} --property=LoadState 2>/dev/null") == (
+            "LoadState=loaded"
+        ):
+            return unit
+    return "xiraid_exporter.service"
+
+
 def check_services(exp, checks):
     results = []
 
@@ -2153,7 +2168,7 @@ def check_services(exp, checks):
         "nfs_server": ("nfs-server", "NFS server"),
         "rpcbind": ("rpcbind", "RPC port mapper"),
         "nfsdcld": ("nfsdcld", "NFS client tracking daemon"),
-        "xiraid_exporter": ("xiraid-exporter", "xiRAID Prometheus exporter"),
+        "xiraid_exporter": (xiraid_exporter_unit(), "xiRAID Prometheus exporter"),
         "chrony": ("chrony", "NTP time synchronization"),
     }
 

--- a/xinas_menu/screens/exporter.py
+++ b/xinas_menu/screens/exporter.py
@@ -78,10 +78,11 @@ class ExporterScreen(XiNASAppMixin, Screen):
         loop = asyncio.get_running_loop()
         installed = await loop.run_in_executor(None, _get_installed_version)
 
-        from xinas_menu.utils.service_ctl import ServiceController
+        from xinas_menu.utils.service_ctl import ServiceController, xiraid_exporter_unit
 
         ctl = ServiceController()
-        state = await loop.run_in_executor(None, lambda: ctl.state("xiraid-exporter"))
+        unit = await loop.run_in_executor(None, xiraid_exporter_unit)
+        state = await loop.run_in_executor(None, lambda: ctl.state(unit))
 
         GRN, YLW, RED, CYN, BLD, DIM, NC = (
             "\033[32m",
@@ -182,10 +183,11 @@ class ExporterScreen(XiNASAppMixin, Screen):
         )
         if not confirmed:
             return
-        from xinas_menu.utils.service_ctl import ServiceController
+        from xinas_menu.utils.service_ctl import ServiceController, xiraid_exporter_unit
 
         ctl = ServiceController()
-        ok, err = await loop.run_in_executor(None, lambda: ctl.restart("xiraid-exporter"))
+        unit = await loop.run_in_executor(None, xiraid_exporter_unit)
+        ok, err = await loop.run_in_executor(None, lambda: ctl.restart(unit))
         if ok:
             self.app.audit.log("exporter.restart", "", "OK")
             view.set_content(f"{_GRN}Service restarted.{_NC}")

--- a/xinas_menu/screens/quick_actions.py
+++ b/xinas_menu/screens/quick_actions.py
@@ -34,16 +34,25 @@ _MENU = [
     MenuItem("0", "Back"),
 ]
 
-_SERVICES = [
-    "nfs-server",
-    "xiraid-server",
-    "xiraid-exporter",
-    "xinas-nfs-helper",
-    "xinas-api",
-    "xinas-agent",
-    "nfsdcld",
-    "rpcbind",
-]
+
+def _services() -> list[str]:
+    """Units listed on the Service Status view.
+
+    The xiRAID exporter unit is resolved at call time rather than hardcoded —
+    the .deb spells it with an underscore, older builds with a hyphen.
+    """
+    from xinas_menu.utils.service_ctl import xiraid_exporter_unit
+
+    return [
+        "nfs-server",
+        "xiraid-server",
+        xiraid_exporter_unit(),
+        "xinas-nfs-helper",
+        "xinas-api",
+        "xinas-agent",
+        "nfsdcld",
+        "rpcbind",
+    ]
 
 
 class QuickActionsScreen(XiNASAppMixin, Screen):
@@ -141,7 +150,7 @@ class QuickActionsScreen(XiNASAppMixin, Screen):
             "\033[0m",
         )
         lines = [f"{BLD}{CYN}=== Service Status ==={NC}", ""]
-        for svc in _SERVICES:
+        for svc in await loop.run_in_executor(None, _services):
             state = await loop.run_in_executor(None, lambda s=svc: ctl.state(s))
             if state.is_active:
                 icon = f"{GRN}*{NC}"

--- a/xinas_menu/utils/service_ctl.py
+++ b/xinas_menu/utils/service_ctl.py
@@ -87,3 +87,32 @@ def service_state(name: str) -> ServiceState:
 
 def service_restart(name: str) -> tuple[bool, str]:
     return _svc.restart(name)
+
+
+# The xiraid-exporter .deb installs its systemd unit as
+# `xiraid_exporter.service` (underscore) even though the package, the binary
+# and the upstream project all spell the name with a hyphen. Older builds
+# shipped the hyphenated unit. Resolve at runtime instead of hardcoding a
+# spelling — asking systemd about the wrong name reports a healthy exporter
+# as "inactive" and makes restart a silent no-op.
+XIRAID_EXPORTER_UNITS = ("xiraid_exporter.service", "xiraid-exporter.service")
+
+
+def resolve_unit(*candidates: str) -> str:
+    """Return the first candidate systemd has a unit file for.
+
+    Probes ``LoadState``: an installed unit reports ``loaded`` even when it is
+    stopped or disabled, while an unknown unit reports ``not-found``. When no
+    candidate resolves, the first is returned so callers still have a stable
+    name to display and to attribute errors to.
+    """
+    for name in candidates:
+        r = ServiceController._run("show", name, "--property=LoadState", "--no-pager")
+        if r.returncode == 0 and "LoadState=loaded" in r.stdout:
+            return name
+    return candidates[0]
+
+
+def xiraid_exporter_unit() -> str:
+    """Resolve the installed xiRAID exporter systemd unit name."""
+    return resolve_unit(*XIRAID_EXPORTER_UNITS)


### PR DESCRIPTION
## Problem

The xiRAID exporter appeared **inactive in the TUI while actually running**, and the screen's Restart action never cleared it.

The upstream `.deb` is hyphenated as a *package* (`xiraid-exporter`, `/usr/bin/xiraid-exporter`, the release asset) but installs its systemd unit with an **underscore**:

```console
$ dpkg -L xiraid-exporter | grep systemd
/usr/lib/systemd/system/xiraid_exporter.service
```

Older builds shipped the hyphenated unit, so both spellings exist in the field. Every xiNAS call site assumed the hyphen.

The breakage was silent because `systemctl show` **exits 0** and reports `ActiveState=inactive` for a unit that does not exist — indistinguishable from a stopped service:

```console
$ systemctl is-active xiraid_exporter.service   # real unit
active
$ systemctl is-active xiraid-exporter.service   # does not exist
inactive
```

Observed impact:

- Management → Integrations → **xiRAID Exporter** reported `inactive` for an exporter that was serving metrics on `:9827`.
- Its **Restart** action restarted a nonexistent unit, reported success, then re-read `inactive` — the false status could never be cleared from the UI.
- Both health engines (`xinas_menu/health/engine.py`, `healthcheck.sh`) flagged the exporter as down.
- The `xiraid_exporter` role's `service:` task would fail outright with *"Could not find the requested service"*.
- `xinas_uninstall` silently no-oped its stop/disable step.

## Fix

Resolve the unit name at runtime instead of hardcoding a spelling.

Resolution probes **`LoadState`**, which distinguishes an installed-but-stopped unit (`loaded`) from an unknown one (`not-found`) — `ActiveState` conflates the two, which is what made this silent. Prefer the underscore, fall back to the hyphen, and when neither resolves return the first candidate so callers keep a stable name to display and to attribute errors to.

| Surface | Mechanism |
|---------|-----------|
| `xinas_menu/screens/exporter.py` | `xiraid_exporter_unit()` before each `state()` / `restart()` |
| `xinas_menu/screens/quick_actions.py` | `_services()` resolves at call time, not at import |
| `xinas_menu/health/engine.py` | local resolver helper, used when `check_services` builds `service_map` |
| `healthcheck.sh` | byte-identical copy — the embedded Python runs standalone and cannot import the resolver |
| `collection/roles/xiraid_exporter` | `service_facts` + `set_fact` → `xiraid_exporter_unit` |
| `collection/roles/xinas_uninstall` | loops **both** candidates with `failed_when: false` |

## Verification

- **17 new tests** in `tests/test_xiraid_exporter_unit.py`, all passing. Each of the 7 drift guards was checked against `git show HEAD:<file>` and confirmed to match the pre-fix code — none are vacuous.
- **Full suite: 562 passed, 5 failed.** The 5 are `test_installer_exit_code_contract.py`, which runs `prepare_system.sh` end-to-end and fails on `apt-get update` in the test sandbox; zero references to the exporter. Pre-existing and unrelated.
- `ruff check` / `ruff format --check` clean on all touched files.
- `ansible-lint` **0 failures** on both roles (the `production` profile passes, not just `basic`).
- `yamllint` and `markdownlint-cli2` clean.
- **Live check on a real node:** resolver returns `xiraid_exporter.service` → `active/running/loaded`, `curl localhost:9827/metrics` serving.

## Spec

New: `docs/Management/xiraid-exporter-spec.md` — owns the Integrations → xiRAID Exporter screen, documents the package/unit name split, and states the resolution contract that every surface must follow. Indexed in the CLAUDE.md docs table.

## Rebuild trailer

**None**, deliberately. The user-visible fix is TUI code, and `xiraid_exporter` is not listed in `playbooks/site.yml` — so a `Requires-Rebuild: xiraid_exporter` trailer would resolve to zero tasks and just train users to click through an Ansible warning that cannot help them. This reasoning is recorded in the spec.

## Not included

`post_install_menu.sh` still uses the hyphenated name in ~12 places. It is a deprecated day-2 surface per CLAUDE.md (*Shell vs. Python TUI scope*); the Python TUI is the supported route. Recorded as a known constraint in the spec.

## Second commit

`d6eda15 docs(claude): refresh CLAUDE.md against the current tree` — independent of the fix, included here for convenience since it indexes the new spec. Corrects facts that had gone stale: *"No build/test system"* (there are 15 blocking CI jobs), a playbook order missing 8 roles, *"10 Ansible roles"* (there are 20), and a Key Directories table omitting `xinas_menu/`, `xiNAS-MCP/` and `tests/`. Adds a Verification section with the exact CI-mirroring commands, the `api-v1.yaml` CI-gate warning, and repo etiquette. Compresses ~70 lines that duplicated `docs/`. All binding policy left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
