### PR TITLE
feat(raid): render NA for tuning a RAID level does not have

### DIFF
--- a/docs/Storage/raid-management-spec.md
+++ b/docs/Storage/raid-management-spec.md
@@ -256,6 +256,9 @@ rendered as a placeholder:
 spells "no limit" and "prealloc off" — so the unknown case keys off
 `is None`, never off falsiness.
 
+The `unknown` column above is the default. Where the array's RAID **level**
+does not have the knob at all, the placeholder narrows to `NA` — see §3.3.
+
 This is the array-detail case of the same rule as §3.1: **an unobserved
 value must never render as a plausible default.** Printing `unlimited`,
 `all`, or `Disabled` for a knob nobody read tells the operator the array
@@ -266,6 +269,50 @@ same array was rejected with `Unable to set memory limit to '1028' MiBs.
 RAID already has '2048' reserved MiBs.` The Priorities block, which had
 no plausible default to fall back on, showed `-%` throughout and was the
 only visible symptom.
+
+### 3.3 Knobs the RAID level does not have render as NA
+
+`unknown` and "does not exist" are different facts, and §3.2 collapsed
+them. A RAID 10 array showed `Merge Read | unknown`, `Merge Write |
+unknown`, `Adaptive Merge | unknown` and `SDC Priority | -` — sending the
+operator looking for four values that cannot exist on a mirror.
+
+Eight tuning knobs are **parity-only**. A mirror or a plain stripe has no
+parity: nothing for the merge machinery to amortise (there is no
+read-modify-write) and no parity to check silent corruption against. The
+daemon agrees — `raid_show(extended)` omits all eight on a non-parity
+array. Verified against xiRAID 4.3.1 on a node carrying both levels: the
+RAID 5 array reports all eight *including the ones sitting at `0`*, the
+RAID 10 array reports none of them.
+
+| | |
+|---|---|
+| Parity-only knobs | `sdc_prio`, `adaptive_merge`, `merge_read_enabled`, `merge_write_enabled`, `merge_read_max`, `merge_read_wait`, `merge_write_max`, `merge_write_wait` |
+| Non-parity levels | `0`, `1`, `10` (as `_level_label` spells them) |
+
+When a knob is parity-only **and** the array's level is non-parity, the
+placeholder narrows from `unknown` to **`NA`** — and, for `sdc_prio`,
+from the Priorities block's `-` to `NA`. Everything else is untouched:
+`sched_enabled`, the priorities other than SDC, and the whole Performance
+block apply at every level and keep rendering exactly as §3.2 says.
+
+Three properties make this safe to state as a claim rather than a guess:
+
+- **Whitelist, not "everything that is not 5/6/50/60".** An unrecognised
+  level — a new xiRAID level, `n+m`, a spelling change — is not in
+  `_NON_PARITY_LEVELS`, so it keeps the honest `unknown`. A level this
+  code has never seen never becomes a claim that a knob cannot exist.
+- **It only ever narrows a placeholder.** An OBSERVED value is rendered
+  whatever the level says, so a daemon that starts reporting one of these
+  on a mirror shows the real value rather than `NA`.
+- **The merge timing rows keep the §3.2 omission rule** — dropped when all
+  four are unobserved, which on a non-parity array they always are. Four
+  more `NA` rows under a merge feature already marked `NA` would be noise,
+  not information.
+
+This does not weaken §3.2's rule; it sharpens it. `NA` is not a plausible
+default standing in for an unread value — it is a statement about the
+array's level, which *is* observed (`spec.level`).
 
 ---
 

--- a/tests/test_raid_overview.py
+++ b/tests/test_raid_overview.py
@@ -23,13 +23,21 @@ def test_no_banner_keeps_empty_state():
 # "RAID already has '2048' reserved MiBs".
 
 
-def _api_row(spec_extra: dict | None = None, status_extra: dict | None = None) -> list[dict]:
+def _api_row(
+    spec_extra: dict | None = None,
+    status_extra: dict | None = None,
+    level: str = "raid5",
+) -> list[dict]:
+    # A PARITY level by default, so the unobserved-tuning tests below exercise
+    # the `unknown` path for every knob — including the eight that exist only
+    # on parity arrays. On a non-parity level those narrow to `NA` instead
+    # (§3.3), which is what the tests further down pin with level="raid10".
     return [
         {
             "id": "data",
             "spec": {
                 "name": "data",
-                "level": "raid10",
+                "level": level,
                 "member_disk_ids": ["disk-1", "disk-2"],
                 "strip_size_kib": 16,
                 **(spec_extra or {}),
@@ -196,6 +204,75 @@ def test_observed_empty_cpu_mask_means_all():
     rows = _api_row(spec_extra={"tuning": {"cpu_allowed": ""}})
     out = _format_raid_overview(_arrays_from_api(rows), extended=True)
     assert "all" in _row(out, "CPU Affinity")
+
+
+# ---- parity-only knobs on a non-parity level (raid-management-spec §3.3) ----
+#
+# `unknown` and "does not exist" are different facts. A RAID 10 array showed
+# Merge Read / Merge Write / Adaptive Merge as `unknown` and SDC Priority as
+# `-`, sending the operator looking for four values a mirror cannot have.
+
+
+def test_parity_only_knobs_render_na_on_a_mirror():
+    out = _format_raid_overview(_arrays_from_api(_api_row(level="raid10")), extended=True)
+
+    for label in ("Merge Read", "Merge Write", "Adaptive Merge"):
+        assert "NA" in _row(out, label), label
+        assert "unknown" not in _row(out, label), label
+    # SDC narrows from the Priorities block's dash, not from `unknown`.
+    assert "NA" in _row(out, "SDC Priority")
+
+
+def test_na_does_not_leak_to_knobs_every_level_has():
+    # Only the eight parity-only knobs narrow. Everything else keeps `unknown`
+    # — NA there would claim a value cannot exist when it merely was not read.
+    out = _format_raid_overview(_arrays_from_api(_api_row(level="raid10")), extended=True)
+
+    for label in ("Memory Limit", "Memory Pre-alloc", "Request Limit", "CPU Affinity", "Scheduler"):
+        assert "unknown" in _row(out, label), label
+        assert "NA" not in _row(out, label), label
+    # ...and the priorities that exist at every level keep their dash.
+    for label in ("Init Priority", "Recon Priority", "Restripe Priority"):
+        assert "-" in _row(out, label), label
+        assert "NA" not in _row(out, label), label
+
+
+def test_parity_level_keeps_unknown_for_the_same_knobs():
+    out = _format_raid_overview(_arrays_from_api(_api_row(level="raid5")), extended=True)
+
+    for label in ("Merge Read", "Merge Write", "Adaptive Merge"):
+        assert "unknown" in _row(out, label), label
+        assert "NA" not in _row(out, label), label
+    assert "-" in _row(out, "SDC Priority")
+
+
+def test_unrecognised_level_keeps_unknown_rather_than_claiming_na():
+    # The non-parity set is a whitelist. A level this code has never seen
+    # must not become a claim that a knob cannot exist for it.
+    for level in ("raidn+m", "raid7", "raid60", "", "raid-who-knows"):
+        out = _format_raid_overview(_arrays_from_api(_api_row(level=level)), extended=True)
+        assert "unknown" in _row(out, "Adaptive Merge"), level
+        assert "NA" not in _row(out, "Adaptive Merge"), level
+
+
+def test_na_never_overrides_an_observed_value():
+    # If the daemon ever does report one of these on a mirror, show the real
+    # value. NA only ever narrows a PLACEHOLDER.
+    rows = _api_row(
+        level="raid10",
+        spec_extra={"tuning": {"adaptive_merge": True, "sdc_prio": 40}},
+    )
+    out = _format_raid_overview(_arrays_from_api(rows), extended=True)
+    assert "Enabled" in _row(out, "Adaptive Merge")
+    assert "NA" not in _row(out, "Adaptive Merge")
+    assert "40%" in _row(out, "SDC Priority")
+
+
+def test_merge_timing_rows_stay_omitted_on_a_non_parity_level():
+    # They are unobserved, so §3.2's omission rule already covers them; four
+    # more NA rows under a merge feature already marked NA is noise.
+    out = _format_raid_overview(_arrays_from_api(_api_row(level="raid10")), extended=True)
+    assert "Merge Read Max" not in _plain(out)
 
 
 def test_merge_max_edit_params_are_labelled_microseconds_not_kb():

--- a/xinas_menu/screens/raid.py
+++ b/xinas_menu/screens/raid.py
@@ -1229,6 +1229,49 @@ _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 # docs/Storage/raid-management-spec.md §3.2.
 _UNKNOWN = f"{_DIM}unknown{_NC}"
 
+# What a knob the array's RAID level does not HAVE renders as. Distinct from
+# _UNKNOWN on purpose: "unknown" says the control path failed to read a value
+# that exists, and sends the operator looking for it. "NA" says there is
+# nothing to read. See _tuning_not_applicable and raid-management-spec §3.2.
+_NA = f"{_DIM}NA{_NC}"
+
+# Tuning knobs xiRAID implements only on PARITY arrays. A mirror or a plain
+# stripe has no parity: there is no read-modify-write for the merge machinery
+# to amortise, and no parity to check silent corruption against. The daemon
+# reflects that — `raid_show(extended)` omits these eight entirely on a
+# non-parity array. Verified against xiRAID 4.3.1 on a node carrying both:
+# the RAID 5 array reports all eight (including the ones sitting at 0), the
+# RAID 10 array reports none of them.
+_PARITY_ONLY_TUNING = frozenset(
+    {
+        "sdc_prio",
+        "adaptive_merge",
+        "merge_read_enabled",
+        "merge_write_enabled",
+        "merge_read_max",
+        "merge_read_wait",
+        "merge_write_max",
+        "merge_write_wait",
+    }
+)
+
+# Levels with no parity, spelled the way _level_label renders them. This is
+# deliberately a whitelist of the levels we know rather than "anything that
+# is not 5/6/50/60": an unrecognised level (a new xiRAID level, `n+m`, a
+# spelling change) keeps the honest `unknown` instead of being told a knob
+# cannot exist for it.
+_NON_PARITY_LEVELS = frozenset({"0", "1", "10"})
+
+
+def _tuning_not_applicable(level: Any, key: str | None) -> bool:
+    """True when *key* is a knob this array's RAID level does not have.
+
+    Only ever narrows a placeholder from `unknown` to `NA` — an OBSERVED
+    value is always rendered, whatever this returns, so a daemon that starts
+    reporting one of these on a mirror still shows the real value.
+    """
+    return key in _PARITY_ONLY_TUNING and str(level).strip() in _NON_PARITY_LEVELS
+
 
 def _visible_len(s: str) -> int:
     """Length of string after stripping ANSI escape codes."""
@@ -1386,11 +1429,22 @@ def _format_raid_overview(arrays: dict, extended: bool = False, banner: str | No
             # nobody read tells the operator the array is unconstrained while
             # the daemon rejects their edit with "RAID already has '2048'
             # reserved MiBs". See raid-management-spec §3.2.
-            def _opt(value, render):
-                return _UNKNOWN if value is None else render(value)
+            def _na_or(placeholder, key, _level=level):
+                # A knob this RAID level does not have reads NA, not the
+                # generic placeholder — `unknown` (or the priorities' dash)
+                # sends the operator hunting for a value that cannot exist.
+                # Passing no key keeps the old behaviour. `_level` is bound at
+                # definition time because `level` belongs to the enclosing
+                # per-array loop (ruff B023).
+                return _NA if _tuning_not_applicable(_level, key) else placeholder
 
-            def _on_off(v):
-                return _opt(v, lambda x: f"{_GRN}Enabled{_NC}" if x else f"{_DIM}Disabled{_NC}")
+            def _opt(value, render, key=None):
+                return _na_or(_UNKNOWN, key) if value is None else render(value)
+
+            def _on_off(v, key=None):
+                return _opt(
+                    v, lambda x: f"{_GRN}Enabled{_NC}" if x else f"{_DIM}Disabled{_NC}", key
+                )
 
             def _usecs(v):
                 return _opt(v, lambda x: f"{x} us")
@@ -1401,15 +1455,19 @@ def _format_raid_overview(arrays: dict, extended: bool = False, banner: str | No
             lines.append(_box_line(f" {_BLD}{_CYN}PRIORITIES{_NC}"))
             lines.append(_box_sep())
 
-            def _pct(v):
+            def _pct(v, key=None):
                 # Priorities keep the dash they always had — the one block
-                # with no plausible default to fall back on.
-                return "-" if v is None else f"{v}%"
+                # with no plausible default to fall back on. A priority the
+                # level does not have is still NA, not a dash: the dash says
+                # "not read", NA says "does not exist here".
+                if v is not None:
+                    return f"{v}%"
+                return _na_or("-", key)
 
             init_p = _pct(arr.get("init_prio"))
             recon_p = _pct(arr.get("recon_prio"))
             restripe_p = _pct(arr.get("restripe_prio"))
-            sdc_p = _pct(arr.get("sdc_prio"))
+            sdc_p = _pct(arr.get("sdc_prio"), "sdc_prio")
             lines.append(_box_line(f"  {_DIM}Init Priority{_NC}       |  {init_p}"))
             lines.append(_box_line(f"  {_DIM}Recon Priority{_NC}      |  {recon_p}"))
             lines.append(_box_line(f"  {_DIM}Restripe Priority{_NC}   |  {restripe_p}"))
@@ -1453,9 +1511,19 @@ def _format_raid_overview(arrays: dict, extended: bool = False, banner: str | No
             mw_en = arr.get("merge_write_enabled")
             adapt = arr.get("adaptive_merge")
             lines.append(_box_line(f"  {_DIM}Scheduler{_NC}           |  {_on_off(sched)}"))
-            lines.append(_box_line(f"  {_DIM}Merge Read{_NC}          |  {_on_off(mr_en)}"))
-            lines.append(_box_line(f"  {_DIM}Merge Write{_NC}         |  {_on_off(mw_en)}"))
-            lines.append(_box_line(f"  {_DIM}Adaptive Merge{_NC}      |  {_on_off(adapt)}"))
+            lines.append(
+                _box_line(
+                    f"  {_DIM}Merge Read{_NC}          |  {_on_off(mr_en, 'merge_read_enabled')}"
+                )
+            )
+            lines.append(
+                _box_line(
+                    f"  {_DIM}Merge Write{_NC}         |  {_on_off(mw_en, 'merge_write_enabled')}"
+                )
+            )
+            lines.append(
+                _box_line(f"  {_DIM}Adaptive Merge{_NC}      |  {_on_off(adapt, 'adaptive_merge')}")
+            )
             mr_max = arr.get("merge_read_max")
             mr_wait = arr.get("merge_read_wait")
             mw_max = arr.get("merge_write_max")


### PR DESCRIPTION
> **Stacked on #270** (base is `fix/cpu-allowed-array-shape`, not `main`) — both edit `docs/Storage/raid-management-spec.md` §3.2, and adjacent rows of the same table would conflict. GitHub retargets this to `main` automatically once #270 merges. The code change itself is independent.

## Problem

`unknown` and "does not exist" are different facts, and the Extended view collapsed them. The `log` array (RAID 10) shows:

```
|  PRIORITIES                              |
|   SDC Priority        |  -               |
|  I/O SCHEDULER & MERGE                   |
|   Scheduler           |  Disabled        |
|   Merge Read          |  unknown         |
|   Merge Write         |  unknown         |
|   Adaptive Merge      |  unknown         |
```

Four values an operator can go hunting for, none of which a mirror can have.

## Why these four

Eight tuning knobs are **parity-only** — `sdc_prio`, `adaptive_merge`, the two `merge_*_enabled` flags, and the four merge timing windows. A mirror or a plain stripe has no parity: nothing for the merge machinery to amortise (there is no read-modify-write) and no parity to check silent corruption against.

The daemon agrees. `raid_show(extended)` omits all eight on a non-parity array — verified against xiRAID 4.3.1 on a node carrying both levels:

| field | `data` (RAID 5) | `log` (RAID 10) |
|---|---|---|
| `sdc_prio` | `50` | **absent** |
| `adaptive_merge` | `0` | **absent** |
| `merge_read_enabled` / `merge_write_enabled` | `0` / `0` | **absent** |
| `merge_{read,write}_{max,wait}_usecs` | `1000` / `300` | **absent** |
| `init_prio`, `recon_prio`, `restripe_prio`, `sched_enabled`, `memory_*`, `request_limit`, `cpu_allowed` | present | present |

Note RAID 5 reports them *including the ones sitting at `0`* — the daemon emits every knob it has, so omission means "not applicable", not "unset".

## Change

When a knob is parity-only **and** the level is non-parity, the placeholder narrows from `unknown` to `NA`; for `sdc_prio`, from the Priorities block's `-` to `NA`. `sched_enabled`, the other priorities, and the whole Performance block apply at every level and are untouched.

After, on the same array:

```
|   SDC Priority        |  NA              |
|   Scheduler           |  Disabled        |
|   Merge Read          |  NA              |
|   Merge Write         |  NA              |
|   Adaptive Merge      |  NA              |
```

`data` (RAID 5) renders exactly as before.

Three properties keep this a claim rather than a guess:

- **The non-parity set is a whitelist** (`0`, `1`, `10`) — not "anything that is not 5/6/50/60". An unrecognised level (a new xiRAID level, `n+m`, a spelling change) keeps the honest `unknown`, so a level this code has never seen never becomes a claim that a knob cannot exist.
- **It only ever narrows a placeholder.** An observed value is rendered whatever the level says, so a daemon that starts reporting one of these on a mirror shows the real value rather than `NA`.
- **The merge timing rows keep the existing omit-when-all-unobserved rule.** Four more `NA` rows under a merge feature already marked `NA` is noise, not information.

This sharpens `raid-management-spec` §3.2 rather than weakening it. `NA` is not a plausible default standing in for an unread value — it is a statement about the array's **level**, which is itself observed (`spec.level`).

## Spec

New §3.3 *Knobs the RAID level does not have render as NA* — the parity-only set, the non-parity levels, the daemon evidence, and the three safety properties. §3.2's table gains a pointer to it.

## Tests

The shared `_api_row` fixture now takes a `level`, defaulting to a **parity** level. That keeps every existing unobserved-tuning test exercising the `unknown` path for *all* knobs including the parity-only ones — coverage that would otherwise have been lost, since the fixture was previously `raid10` and those rows now render `NA`. No existing assertion was weakened or deleted.

Six new tests pin: parity-only knobs render `NA` on a mirror; `NA` does not leak to knobs every level has; a parity level keeps `unknown` for the same knobs; an unrecognised level (`n+m`, `raid7`, `raid60`, `""`, a nonsense string) keeps `unknown`; an observed value always wins over `NA`; and the timing rows stay omitted.

## Verification

- `pytest` — 608 passed. The 5 failures in `test_installer_exit_code_contract.py` are pre-existing and environmental (that test shells out to `apt update`)
- `ruff check` / `ruff format --check` — clean on both changed files. Repo-wide noise (53 errors, 18 unformatted) is entirely the untracked generated `xinas_menu/api/proto/*_pb2*.py`
- `pyright` — **zero** diagnostics in `screens/raid.py`; the remaining errors are the same untracked proto files, which CI never sees
- `markdownlint-cli2` on the spec — 0 errors
- Rendered against the **live** `GET /api/v1/arrays` on a node with both levels: `log` shows `NA` on all four rows, `data` unchanged

One thing worth a reviewer's eye: ruff caught a genuine late-binding bug in my first draft (B023 — the placeholder closure captured `level` from the enclosing per-array loop). It is now bound at definition time via a default argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
