### PR TITLE
fix(arrays): repair the RAID tuning modify path end to end

### DIFF
--- a/docs/control-path/adr/0006-xiraid-array.md
+++ b/docs/control-path/adr/0006-xiraid-array.md
@@ -124,7 +124,8 @@ The gRPC client dials the xiRAID daemon over **TCP with TLS** (`host:port` from 
 | `spec.block_size` | ✅ | ❌ `UNSUPPORTED` | `512` or `4096`. |
 | `spec.force_metadata` | ✅ | ❌ `UNSUPPORTED` | Create-only override; overwrites stale metadata on members. |
 | `spec.spare_disk_ids` | ✅ (since S4 — create provisions + activates the pool) | ✅ | Spare pool lifecycle below. |
-| `spec.tuning.*` | ✅ | ✅ | Priorities `[1,100]`; `memory_limit` `0` or `[1024,1048576]` MiB; merge timings in microseconds; booleans map to xiRAID `0/1`. |
+| `spec.tuning.*` (live-writable) | ✅ | ✅ | Priorities `[1,100]`; `memory_limit` `0` or `[1024,1048576]` MiB; merge timings in microseconds; booleans map to xiRAID `0/1`. |
+| `spec.tuning.{resync_enabled, discard, drive_trim}` | ✅ | ❌ `UNSUPPORTED` | Create-surface tuning only — the daemon's `RaidModify` message has **no field** for any of them (verified against the running 4.3.1 descriptor). Rejected pre-plan with `reason: create_only_tuning`; forwarding one would be silently dropped by protobuf and report a false success. |
 | `status.*` | server-managed | server-managed | Computed by the agent from `raid_show`. |
 
 Writes to a `Modify=UNSUPPORTED` (topology) field on `PATCH /arrays/{id}` fail at validation **before** any plan is produced, with the per-field shape:
@@ -137,6 +138,8 @@ Writes to a `Modify=UNSUPPORTED` (topology) field on `PATCH /arrays/{id}` fail a
   "remediation": "RAID level/members/strip cannot be changed live. Delete and recreate the array (data is destroyed)."
 }
 ```
+
+The three create-surface tuning keys reject on the same pre-plan path, with `field: "spec.tuning.<key>"` and `reason: "create_only_tuning"`. This is a daemon-capability limit, not a policy choice: `RaidModify` carries no `resync_enabled` / `discard` / `drive_trim` field, so `translate.ts` also drops them from the modify request (belt-and-suspenders — the route rejects first). *(A related latent gap: the running 4.3.1 `RaidCreate` also lacks these three, so they are not writable at create against that daemon either, even though the control-path schema and the hand-maintained `src/grpc/raid.ts` wrapper model them as create knobs. Reconciling the create surface is out of scope here and tracked separately.)*
 
 ### Spare pools
 
@@ -179,7 +182,7 @@ All `risk_level` / `rollback_model` values below use the api-v1.yaml enums (`ris
 - Executor stages: `preflight` (re-check `device_by_id` paths exist + not already members, via live `raid_show`) → `create` (`raid_create`; mark created) → `wait_online` (poll `raid_show` until `state ∈ {optimal, rebuilding}` or timeout) → `verify` (`/dev/xi_<name>` present). `rollback`: if created → `raid_destroy(name, force)`, else no-op. `snapshot_before/after` are auto-captured by the runner.
 
 **Modify** (`xiraid.array.modify`, `PATCH /arrays/{id}`).
-- Writable: `spare_disk_ids` (pool lifecycle above) + `spec.tuning.*`. Topology fields → `UNSUPPORTED` (matrix). Maps to `raid_modify` (+ pool ops). `risk_level: non_disruptive`, `rollback_model: non_disruptive` (re-apply prior values / inverse pool ops).
+- Writable: `spare_disk_ids` (pool lifecycle above) + `spec.tuning.*` **except the create-surface trio** (`resync_enabled`/`discard`/`drive_trim`, matrix). Topology fields and the create-surface tuning keys → `UNSUPPORTED` (matrix). Maps to `raid_modify` (+ pool ops). `risk_level: non_disruptive`, `rollback_model: non_disruptive` (re-apply prior values / inverse pool ops).
 
 **Import** (`xiraid.array.import`, `POST /arrays` with an import-shaped spec `{ uuid, new_name? }`).
 - *(Amended by the S4 spec, 2026-06-10.)* Plan-mode validates what the api can know from KV alone: spec shape, target-name validity + availability. The candidate UUID is validated **at executor preflight** via a live `raid_import_show()` — the privilege split makes a plan-time daemon call impossible (only the agent reaches xiRAID; `PlanContext` is KV-only). A plan-time discovery surface (an observed import-candidates annex or an on-demand agent RPC) is follow-on work; until then clients learn candidate UUIDs from xiRAID tooling. **Adopt:** `mode=apply` → the executor runs `raid_import_apply(uuid, new_name?)`. The apply task terminates `success`; the adopted array surfaces through the normal observe path. `risk_level: non_disruptive`; `rollback_model: non_disruptive` (un-adopt = config-only removal, `raid_destroy { config_only: true }` — data untouched). See `docs/control-path/s4-xiraid-array-mutations-spec.md` §6.

--- a/docs/control-path/s4-xiraid-array-mutations-spec.md
+++ b/docs/control-path/s4-xiraid-array-mutations-spec.md
@@ -17,7 +17,7 @@
 
 ### In scope (S4)
 - **Engine dangerous gate (§3):** `TaskEngine.apply` enforces `risk_level == 'destructive' && dangerous !== true` → `PRECONDITION_FAILED { reason: 'dangerous_flag_required' }` — one gate for every client (REST/CLI/TUI/MCP), per reqs §14.
-- **Modify** (`xiraid.array.modify`, `PATCH /arrays/{id}`): `spec.tuning.*` + `spec.spare_disk_ids` writable; topology fields → per-field `UNSUPPORTED` before any plan. Spare changes drive the executor-owned pool lifecycle.
+- **Modify** (`xiraid.array.modify`, `PATCH /arrays/{id}`): `spec.tuning.*` (except the create-surface trio `resync_enabled`/`discard`/`drive_trim`) + `spec.spare_disk_ids` writable; topology fields and create-surface tuning keys → per-field `UNSUPPORTED` before any plan. Spare changes drive the executor-owned pool lifecycle.
 - **Create-with-spares un-deferral:** the S3 `spare_pool_deferred` blocker is removed; create validates/leases/resolves spare disks and the create executor provisions the pool before `raid_create`.
 - **Import** (`xiraid.array.import`, `POST /arrays` import-shaped spec `{ uuid, new_name? }`): adopt a foreign array; executor-side validation via `raid_import_show` (§7).
 - **Delete** (`xiraid.array.delete`, `DELETE /arrays/{id}`): dependency guard + blast radius + the dangerous gate; `raid_destroy`; failed destroy → `requires_manual_recovery`.
@@ -81,7 +81,7 @@ A future migration may persist the observed pin and let the engine's `plan_stale
 
 **Request shape.** `{ mode, spec: { spare_disk_ids?, tuning? } }` (+ `plan_id`/`expected_revision`/`idempotency_key` on apply). The array id comes from the path; `spec.name` is not accepted.
 
-**Writability enforcement (pre-plan).** Any topology field present in the PATCH spec (`name`, `level`, `member_disk_ids`, `group_size`, `synd_cnt`, `strip_size_kib`, `block_size`, `force_metadata`) → `UNSUPPORTED` (422) with the ADR-0006 per-field shape (`reason: 'topology_immutable'`) **before** any plan row is written.
+**Writability enforcement (pre-plan).** Any topology field present in the PATCH spec (`name`, `level`, `member_disk_ids`, `group_size`, `synd_cnt`, `strip_size_kib`, `block_size`, `force_metadata`) → `UNSUPPORTED` (422) with the ADR-0006 per-field shape (`reason: 'topology_immutable'`) **before** any plan row is written. The three **create-surface tuning keys** — `spec.tuning.resync_enabled`, `spec.tuning.discard`, `spec.tuning.drive_trim` — reject on the same pre-plan path with `reason: 'create_only_tuning'`: the daemon's `RaidModify` message has no field for any of them (verified against the running 4.3.1 descriptor), so forwarding one would be silently dropped by protobuf and report a false `success`. `translate.ts` also omits them from the `raid_modify` request as a second line of defence.
 
 **Provider preflight.**
 1. The array must exist in observed state (else `NOT_FOUND`); read its observed `spec` as the *before*.
@@ -165,7 +165,7 @@ The S3 route re-runs the create provider's preflight at apply. S4 generalizes: e
 
 ## 10. Error model — reuse existing codes (no additions)
 
-New **blocker codes** (plan `blockers[]`, not `ErrorCode`s): `dangerous_flag_required`, `dependent_filesystem_mounted`, `dependent_share_active`, `uuid_invalid`, `foreign sparepool` surfaces as an executor failure (not a plan blocker — the api cannot see pool ownership). New `details.reason` discriminators on `PRECONDITION_FAILED`: `dangerous_flag_required` (engine), `observed_revision_stale` (route). Topology writes on PATCH → `UNSUPPORTED` (422). Everything else unchanged from S3/S2.
+New **blocker codes** (plan `blockers[]`, not `ErrorCode`s): `dangerous_flag_required`, `dependent_filesystem_mounted`, `dependent_share_active`, `uuid_invalid`, `foreign sparepool` surfaces as an executor failure (not a plan blocker — the api cannot see pool ownership). New `details.reason` discriminators on `PRECONDITION_FAILED`: `dangerous_flag_required` (engine), `observed_revision_stale` (route). Topology writes on PATCH → `UNSUPPORTED` (422, `reason: 'topology_immutable'`); create-surface tuning keys (`resync_enabled`/`discard`/`drive_trim`) on PATCH → `UNSUPPORTED` (422, `reason: 'create_only_tuning'`). Everything else unchanged from S3/S2.
 
 ## 11. Contract revisions (T0)
 

--- a/docs/control-path/s8-clients-spec.md
+++ b/docs/control-path/s8-clients-spec.md
@@ -225,6 +225,18 @@ Generation invariant: the MCP tools/list, the call dispatcher, AND the
 xinasctl command tree derive from this one table — a new route reaches
 all three clients by adding one entry.
 
+For a `plan_apply` entry, `input_schema` MUST expose the **full apply
+envelope** the OpenAPI `ApplyRequest` requires — `mode`, `plan_id`,
+`expected_revision` (integer), `idempotency_key`, and `dangerous` — so a
+schema-driven client (an MCP tool call, the generated `xinasctl`) can
+construct a valid `mode: 'apply'` body from the schema alone. Omitting
+`expected_revision`, which every apply route validates with
+`requireInteger`, made apply unreachable for such clients (they never sent
+the field and the route answered `INVALID_ARGUMENT`); the catalog test pins
+its presence. `xinasctl` additionally coerces each string argv value to the
+scalar type the schema declares, because argv is all strings while the API
+body is typed JSON.
+
 ## 4. The gate (T4)
 
 In the MCP dispatch layer (REST untouched):

--- a/xiNAS-MCP/proto/xraid/gRPC/protobuf/message_raid.proto
+++ b/xiNAS-MCP/proto/xraid/gRPC/protobuf/message_raid.proto
@@ -195,7 +195,12 @@ message RaidInitStop{
     * Modify the parameters of the created RAID.
 */
 message RaidModify{
-    reserved 10, 11, 17 to 19, 27;
+    // 19 (max_sectors_kb), 27 (adaptive_merge_path) and 29 (sdc_prio) were
+    // added by the daemon after this file was vendored. Field numbers below
+    // are taken from the RUNNING daemon's own descriptor (xiRAID 4.3.1,
+    // xraid.gRPC.protobuf.message_raid_pb2.RaidModify) — NOT guessed. A wrong
+    // number here would write a different knob than the caller asked for.
+    reserved 10, 11, 17, 18;
     reserved "merge_wait", "merge_max";
     /**
         * The name of the RAID.
@@ -284,9 +289,21 @@ message RaidModify{
     */
     optional bool single_run = 26;
     /**
+        * Path used by the adaptive merge tuner.
+    */
+    optional string adaptive_merge_path = 27;
+    /**
         * Reserved memory pool in MiB
     */
     optional uint32 memory_prealloc = 28;
+    /**
+        * Maximum size of an I/O request in KB.
+    */
+    optional uint32 max_sectors_kb = 19;
+    /**
+        * Silent data corruption detection priority in percent.
+    */
+    optional uint32 sdc_prio = 29;
 }
 
 /**

--- a/xiNAS-MCP/src/__tests__/api/mcp-catalog.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/mcp-catalog.test.ts
@@ -20,6 +20,22 @@ describe('client catalog (S8 T2)', () => {
     }
   });
 
+  it('plan/apply entries expose the whole apply envelope in their schema', () => {
+    // A schema-driven client (MCP tool, generated CLI) builds its apply call
+    // FROM these properties. expected_revision is validated by requireInteger
+    // on every apply route, so if the schema omits it the client can never
+    // reach a successful apply. plan_id marks the plan/apply-shaped entries.
+    const props = (e: (typeof CATALOG)[number]) =>
+      (e.input_schema as { properties?: Record<string, { type?: string }> }).properties ?? {};
+    const planApply = CATALOG.filter((e) => 'plan_id' in props(e));
+    expect(planApply.length).toBeGreaterThan(0);
+    for (const e of planApply) {
+      const p = props(e);
+      expect(p.expected_revision?.type, `${e.name} missing expected_revision`).toBe('integer');
+      expect(p.idempotency_key?.type, `${e.name} missing idempotency_key`).toBe('string');
+    }
+  });
+
   it('min_role spot pins (ported legacy matrix)', () => {
     const byName = new Map(CATALOG.map((e) => [e.name, e]));
     expect(byName.get('arrays.create')?.min_role).toBe('admin');

--- a/xiNAS-MCP/src/__tests__/api/routes-arrays.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/routes-arrays.test.ts
@@ -316,6 +316,20 @@ describe('POST /api/v1/arrays', () => {
       expect(count('SELECT COUNT(*) AS n FROM tasks')).toBe(0);
     });
 
+    it.each(['resync_enabled', 'discard', 'drive_trim'])(
+      'create-only tuning key %s in the body → 422 UNSUPPORTED, no plan row',
+      async (field) => {
+        // The daemon's RaidModify has no field for these; protobuf would drop
+        // them silently and report a false success, so the route rejects them.
+        seedObservedArray();
+        const res = await patchPlan({ tuning: { [field]: true } });
+        expect(res.status).toBe(422);
+        expect(res.body.errors[0].details?.field).toBe(`spec.tuning.${field}`);
+        expect(res.body.errors[0].details?.reason).toBe('create_only_tuning');
+        expect(count('SELECT COUNT(*) AS n FROM tasks')).toBe(0);
+      },
+    );
+
     it('plan + apply happy path: 202 running, array + spare leased', async () => {
       seedObservedArray();
       setup.state.kv.put('/xinas/v1/observed/Disk/nvme5n1', {

--- a/xiNAS-MCP/src/__tests__/cli/xinasctl.test.ts
+++ b/xiNAS-MCP/src/__tests__/cli/xinasctl.test.ts
@@ -61,6 +61,46 @@ describe('parseArgs', () => {
     ]);
     expect(args).toMatchObject({ mode: 'apply', plan_id: 'p-9', dangerous: true });
   });
+
+  it('coerces string argv to the catalog-declared scalar type', () => {
+    // --expected-revision is integer in the schema; argv delivers it as a
+    // string, and the apply route validates with requireInteger. Without the
+    // coercion this reached the route as "102" and apply failed INVALID_ARGUMENT.
+    const { args } = parseArgs(entry('arrays.modify'), [
+      'data',
+      '--apply',
+      '--plan-id',
+      'p-1',
+      '--expected-revision',
+      '102',
+      '--idempotency-key',
+      'k-1',
+    ]);
+    expect(args.expected_revision).toBe(102);
+    expect(typeof args.expected_revision).toBe('number');
+    expect(args.plan_id).toBe('p-1'); // string param stays a string
+    expect(args.idempotency_key).toBe('k-1');
+  });
+
+  it('leaves an unparseable numeric arg as a string for the route to reject', () => {
+    const { args } = parseArgs(entry('arrays.modify'), [
+      'data',
+      '--apply',
+      '--expected-revision',
+      'not-a-number',
+    ]);
+    expect(args.expected_revision).toBe('not-a-number');
+  });
+
+  it('does not touch already-parsed --spec JSON during coercion', () => {
+    const { args } = parseArgs(entry('arrays.modify'), [
+      'data',
+      '--plan',
+      '--spec',
+      '{"tuning":{"init_prio":20}}',
+    ]);
+    expect(args.spec).toEqual({ tuning: { init_prio: 20 } });
+  });
 });
 
 describe('runCli', () => {

--- a/xiNAS-MCP/src/__tests__/lib/xiraid/translate.test.ts
+++ b/xiNAS-MCP/src/__tests__/lib/xiraid/translate.test.ts
@@ -129,11 +129,15 @@ describe('toRaidCreateRequest', () => {
 });
 
 describe('toRaidModifyRequest', () => {
-  it('tuning golden: boolean→0/1, null dropped, never force; resync_enabled is create-only (dropped)', () => {
+  it('tuning golden: boolean→0/1, null dropped, never force; create-only knobs dropped', () => {
     const req = toRaidModifyRequest('data', {
       tuning: {
         init_prio: 50,
-        resync_enabled: true, // create-time knob — RaidModify has no field for it
+        // create-time knobs — RaidModify has no field for any of them, so the
+        // translator drops them (they are also rejected up front by the route).
+        resync_enabled: true,
+        discard: true,
+        drive_trim: false,
         merge_read_enabled: false,
         cpu_allowed: '0-3',
         memory_limit: null,
@@ -147,6 +151,9 @@ describe('toRaidModifyRequest', () => {
       cpu_allowed: '0-3',
       single_run: true,
     });
+    expect('discard' in req).toBe(false);
+    expect('drive_trim' in req).toBe(false);
+    expect('resync_enabled' in req).toBe(false);
     expect('force' in req).toBe(false);
   });
 

--- a/xiNAS-MCP/src/api/mcp/catalog.ts
+++ b/xiNAS-MCP/src/api/mcp/catalog.ts
@@ -60,7 +60,17 @@ const MUTATE_PROPS: Record<string, unknown> = {
     description: 'operation spec (see api-v1.yaml for the per-resource schema)',
   },
   plan_id: { type: 'string', description: 'required for mode=apply' },
-  idempotency_key: { type: 'string' },
+  idempotency_key: { type: 'string', description: 'required for mode=apply' },
+  // Every apply route validates this with requireInteger (api-v1 ApplyRequest,
+  // see routes/apply-helpers.ts). Leaving it out of the schema made apply
+  // unreachable for any client that builds its call FROM the schema: the
+  // request omits the field and the route answers INVALID_ARGUMENT.
+  expected_revision: {
+    type: 'integer',
+    description:
+      'required for mode=apply — the state_revision the plan was computed against ' +
+      '(state_revision_expected in the plan response); the apply fails if it moved',
+  },
   dangerous: { type: 'boolean', description: 'required true for destructive operations' },
 };
 

--- a/xiNAS-MCP/src/api/routes/arrays.ts
+++ b/xiNAS-MCP/src/api/routes/arrays.ts
@@ -51,6 +51,18 @@ const TOPOLOGY_FIELDS = [
   'force_metadata',
 ] as const;
 
+/**
+ * Tuning keys the daemon's RaidModify message has no field for (verified
+ * against the running 4.3.1 descriptor): `resync_enabled`, `discard`,
+ * `drive_trim`. The control-path schema (ADR-0006) models them as
+ * create-surface tuning, but they cannot be changed on a live array.
+ *
+ * These MUST be rejected rather than forwarded: protobuf drops an unknown
+ * field silently, so a modify carrying one used to come back `success` with
+ * the stage reporting `tuning applied: <key>` while the daemon never saw it.
+ */
+const CREATE_ONLY_TUNING = ['resync_enabled', 'discard', 'drive_trim'] as const;
+
 /** Per-field UNSUPPORTED (422) for topology keys in a raw PATCH body. */
 function rejectTopologyKeys(spec: unknown): void {
   if (typeof spec !== 'object' || spec === null) return;
@@ -61,6 +73,18 @@ function rejectTopologyKeys(spec: unknown): void {
         `spec.${field} cannot be changed live`,
         { field: `spec.${field}`, reason: 'topology_immutable' },
         'RAID topology is immutable (ADR-0006). Delete and recreate the array (data is destroyed).',
+      );
+    }
+  }
+  const tuning = (spec as { tuning?: unknown }).tuning;
+  if (typeof tuning !== 'object' || tuning === null) return;
+  for (const field of CREATE_ONLY_TUNING) {
+    if (field in (tuning as Record<string, unknown>)) {
+      throw new ApiException(
+        'UNSUPPORTED',
+        `spec.tuning.${field} cannot be changed live`,
+        { field: `spec.tuning.${field}`, reason: 'create_only_tuning' },
+        `The daemon's RaidModify has no ${field} field; this tuning knob cannot be changed on an existing array.`,
       );
     }
   }

--- a/xiNAS-MCP/src/cli/xinasctl.ts
+++ b/xiNAS-MCP/src/cli/xinasctl.ts
@@ -124,7 +124,44 @@ export function parseArgs(entry: CatalogEntry, rest: string[]): ParsedArgs {
   for (const [idx, param] of pathParams.entries()) {
     if (positionals[idx] !== undefined) args[param] = positionals[idx];
   }
-  return { args, conn, json, wait };
+  return { args: coerceToSchema(entry, args), conn, json, wait };
+}
+
+/**
+ * argv is all strings; the API body is typed JSON. Coerce each arg to the
+ * type the catalog declares for it.
+ *
+ * Without this every `--flag value` reaches the route as a string, and a
+ * route that validates with requireInteger rejects it. `--expected-revision
+ * 102` arrived as `"102"`, so `--apply` answered INVALID_ARGUMENT on every
+ * plan/apply command — the whole mutating surface of the CLI.
+ *
+ * Only STRING values are converted, and only when the schema names a scalar
+ * type: `--spec` is already parsed JSON and must pass through untouched. A
+ * value that does not parse as its declared type is left alone so the route
+ * reports it, rather than the CLI silently turning `--expected-revision abc`
+ * into NaN.
+ */
+function coerceToSchema(
+  entry: CatalogEntry,
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  const schema = entry.input_schema as { properties?: Record<string, { type?: string }> };
+  const props = schema?.properties;
+  if (props === undefined) return args;
+  const out: Record<string, unknown> = { ...args };
+  for (const [key, value] of Object.entries(out)) {
+    if (typeof value !== 'string') continue;
+    const type = props[key]?.type;
+    if (type === 'integer' || type === 'number') {
+      const n = Number(value);
+      if (Number.isFinite(n) && (type === 'number' || Number.isInteger(n))) out[key] = n;
+    } else if (type === 'boolean') {
+      if (value === 'true') out[key] = true;
+      else if (value === 'false') out[key] = false;
+    }
+  }
+  return out;
 }
 
 export const httpRequester: Requester = (conn, req) =>

--- a/xiNAS-MCP/src/lib/xiraid/translate.ts
+++ b/xiNAS-MCP/src/lib/xiraid/translate.ts
@@ -102,11 +102,12 @@ export function toRaidModifyRequest(
     ...num('max_sectors_kb', t.max_sectors_kb),
     ...num('sdc_prio', t.sdc_prio),
     ...(t.single_run !== undefined && t.single_run !== null ? { single_run: t.single_run } : {}),
-    ...bool01('discard', t.discard),
-    ...bool01('drive_trim', t.drive_trim),
-    // resync_enabled is a CREATE-time knob (proto RaidCreate field 12);
-    // RaidModify has no such field (force_resync is a different semantic),
-    // so a modify-time resync_enabled is silently dropped here.
+    // resync_enabled, discard and drive_trim are CREATE-time knobs: the
+    // daemon's RaidModify has no field for any of them (checked against the
+    // running 4.3.1 descriptor). They are NOT emitted here — protobuf drops
+    // an unknown field without complaint, so emitting one produced a modify
+    // that reported success while changing nothing. They are rejected up
+    // front instead, in CREATE_ONLY_TUNING (routes/arrays.ts).
   };
 }
 


### PR DESCRIPTION
## What

Exercising **every** modifiable xiRAID tuning knob through `xinasctl`/the
API (a full sweep on a live RAID 5 `data` + RAID 10 `log` pair) surfaced
three defects that made the array **modify** path either unreachable or
silently lossy. All three are fixed here, with tests, and re-verified by a
second sweep + a full restore to baseline.

## The three bugs

1. **`expected_revision` unreachable for schema-driven clients.** Every
   apply route validates `expected_revision` with `requireInteger`, but it
   was absent from the MCP catalog's mutate schema, and `xinasctl` forwarded
   it as the raw string argv (`"102"`). So `--apply` answered
   `INVALID_ARGUMENT` across the whole mutating CLI/MCP surface.
   → added `expected_revision` to `MUTATE_PROPS`; added `coerceToSchema()`
   converting each string arg to the catalog-declared scalar type (parsed
   `--spec` JSON and unparseable values are left for the route to report).

2. **Stale vendored `RaidModify` proto.** `sdc_prio`, `max_sectors_kb` and
   `adaptive_merge_path` were added to the daemon after the file was
   vendored. A `sdc_prio` modify therefore reached the daemon with only
   `name` set (protobuf drops unknown fields silently) → "required arguments
   are missing". Field numbers are taken from the **running 4.3.1
   descriptor**, not guessed.

3. **`translate.ts` emitted non-existent modify fields.** `discard` /
   `drive_trim` have no `RaidModify` field, so a modify carrying one returned
   `success` with `tuning applied: <key>` while the daemon changed nothing.
   These (and `resync_enabled`) are now dropped from the request **and**
   rejected pre-plan with `reason: create_only_tuning` (422) — a bad request
   fails loudly instead of lying.

## Verification

- Full knob sweep on live `data` (RAID 5) + `log` (RAID 10): every
  live-writable knob applies and reads back at daemon + API + TUI; remaining
  non-applies are **honest daemon rejections** (parity-only knobs on a
  mirror, `memory_prealloc` above available RAM, etc.).
- Arrays restored to their pre-sweep baseline through the fixed path (both
  now byte-for-byte at baseline).
- `npm run typecheck` / `lint` (exit 0) / `format:check` clean;
  `npm test` **1407 passed**; `npm run test:contracts` **8 passed**;
  markdownlint clean on the changed docs.

## Specs

Updated in the same change: ADR-0006 writability matrix (create-surface
tuning carve-out), S4 modify contract, S8 catalog apply-envelope rule.

## Scope notes / dependencies

- **cpu_allowed** writes correctly through this path; its **display** still
  reads `unknown` until the observe-side array-shape fix
  (`fix/cpu-allowed-array-shape`) lands. That is a separate **read**-path
  change — not this write-path PR.
- **Latent, out of scope:** the running 4.3.1 `RaidCreate` also lacks
  `resync_enabled`/`discard`/`drive_trim`, so the **create** surface needs
  its own reconciliation (noted in ADR-0006).

`Requires-Rebuild: xinas_node_build` — TS control-path change; `dist/` is
rebuilt and the api/agent services restarted by that role on update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
