### PR TITLE
fix(nfs): render the real client/path in Active Sessions

### DIFF
--- a/tests/test_nfs_wizard_helpers.py
+++ b/tests/test_nfs_wizard_helpers.py
@@ -2,7 +2,47 @@
 
 from __future__ import annotations
 
-from xinas_menu.screens.nfs import _host_prefill, _path_prefill, _xiraid_mount_points
+from xinas_menu.screens.nfs import (
+    _format_sessions,
+    _host_prefill,
+    _path_prefill,
+    _xiraid_mount_points,
+)
+
+
+def test_format_sessions_reads_helper_shape():
+    # nfs.list_sessions() returns this shape (spec §4.8). The row must show
+    # the real client IP and export path, not "?  ->  ?".
+    out = _format_sessions(
+        [
+            {
+                "client_ip": "10.0.0.15",
+                "nfs_version": "4.2",
+                "export_path": "/mnt/data",
+                "active_locks": 3,
+            },
+            {
+                "client_ip": "10.0.0.22",
+                "nfs_version": "4.1",
+                "export_path": "unknown",
+                "active_locks": 0,
+            },
+        ]
+    )
+    assert "10.0.0.15  ->  /mnt/data" in out
+    assert "10.0.0.22  ->  unknown" in out
+    assert "?  ->  ?" not in out
+
+
+def test_format_sessions_empty():
+    assert "(no active sessions)" in _format_sessions([])
+
+
+def test_format_sessions_legacy_client_path_fallback():
+    # An alternate source that uses client/path still renders.
+    out = _format_sessions([{"client": "192.168.1.5", "path": "/mnt/data/sub"}])
+    assert "192.168.1.5  ->  /mnt/data/sub" in out
+
 
 _HOST_CHOICES = [
     "Everyone (any host on the network)",

--- a/xinas_menu/screens/nfs.py
+++ b/xinas_menu/screens/nfs.py
@@ -1110,8 +1110,16 @@ def _format_sessions(data: Any) -> str:
         if not sessions:
             lines.append("  (no active sessions)")
         for s in sessions:
-            client = s.get("client", "?") if isinstance(s, dict) else str(s)
-            path = s.get("path", "?") if isinstance(s, dict) else ""
+            if isinstance(s, dict):
+                # nfs.list_sessions() returns {client_ip, nfs_version,
+                # export_path, active_locks} (spec §4.8). Read those keys —
+                # the old client/path keys never exist in that shape, so every
+                # row rendered as "?  ->  ?". Keep client/path as a fallback so
+                # an alternate session source still renders.
+                client = s.get("client_ip") or s.get("client") or "?"
+                path = s.get("export_path") or s.get("path") or "?"
+            else:
+                client, path = str(s), ""
             lines.append(f"  {client}  ->  {path}")
     except Exception as exc:
         lines.append(f"(parse error: {exc})")


### PR DESCRIPTION
## What

The **Active Sessions** screen (NFS management → Active Sessions) rendered
`?  ->  ?` for every connected NFS client, hiding the client IP and export
path that were sitting right there in the data.

## Why

`nfs.list_sessions()` returns `{client_ip, nfs_version, export_path,
active_locks}` dicts (documented in `docs/Storage/fs-shares-management-spec.md`
§4.8), sourced from `/proc/fs/nfsd/clients/*/info` (fallback
`/proc/net/rpc/auth.unix.ip`). But `_format_sessions` read `s["client"]` /
`s["path"]` — keys that shape never contains — so both fell through to the
`"?"` default on every row.

## Fix

Read `client_ip` / `export_path` (the shape the helper and the spec both
name), keeping the old `client` / `path` keys as a fallback so an alternate
session source still renders. The spec already documents the intended row
(`client → export_path`), so no spec change was needed — this just makes the
code match it.

```
Before:  ?  ->  ?
After:   10.0.0.15  ->  /mnt/data
```

## Tests / verification

- New unit tests for `_format_sessions`: the real helper shape, the legacy
  `client`/`path` fallback, and the empty case.
- `pytest` — all NFS tests pass (the only failures in the run were the
  installer whiptail-exit-code contract tests, which can't run headless and
  are unrelated to this change).
- `ruff check` / `ruff format --check` clean on the changed files.

## Scope

Found while testing the NFS **share path** end to end (share
create/update/delete verified across daemon `exportfs` + API + TUI; the
control-path share and filesystem mutation paths themselves were correct).
Code-only Python TUI fix — no `Requires-Rebuild` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
