### PR TITLE
fix(nfs): observe exports from the real helper wire shape

### DIFF
--- a/xiNAS-MCP/src/__tests__/agent/probe/nfs.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/probe/nfs.test.ts
@@ -35,26 +35,29 @@ describe('NfsProbe', () => {
   const socketPath = join(tmpdir(), `xinas-test-helper-${process.pid}.sock`);
   let server: ReturnType<typeof createNetServer>;
 
-  // Use the nested clients format that parseListExports expects
+  // The real nfs-helper wire shape: { ok, result:[{path, clients:[{host, options}]}] }.
   const exportsFixture = {
-    exports: [
+    ok: true,
+    result: [
       {
         path: '/srv/share01',
-        clients: [{ host_pattern: '10.0.0.0/24', options: ['rw', 'no_root_squash'] }],
+        clients: [{ host: '10.0.0.0/24', options: ['rw', 'no_root_squash'] }],
       },
     ],
+    request_id: 'test',
   };
-  // parseListSessions expects flat sessions array with these fields
+  // list_sessions wire shape: { ok, result:[{client_ip, nfs_version, export_path, active_locks}] }.
   const sessionsFixture = {
-    sessions: [
+    ok: true,
+    result: [
       {
-        client_addr: '10.0.0.5',
-        client_hostname: 'client-01',
+        client_ip: '10.0.0.5',
+        nfs_version: 'v4.1',
         export_path: '/srv/share01',
-        proto_version: 'v4.1',
-        locked_files: 0,
+        active_locks: 0,
       },
     ],
+    request_id: 'test',
   };
 
   afterAll(async () => {

--- a/xiNAS-MCP/src/__tests__/lib/health/drift.test.ts
+++ b/xiNAS-MCP/src/__tests__/lib/health/drift.test.ts
@@ -32,6 +32,21 @@ describe('compareExports (semantic)', () => {
     expect(drift).toEqual({ missing: [], extra: [], changed: [] });
   });
 
+  it('fsid=N on the observed side is not drift (desired models it via spec.fsid)', () => {
+    // Regression: the NFSv4 root export carries fsid=0 in /etc/exports, but
+    // the desired compile does not render fsid (§4). This must NOT read as a
+    // permanent "changed" drift.
+    const drift = compareExports(DESIRED, [
+      {
+        export_path: '/mnt/a',
+        rules: [
+          { host_pattern: '*', options: ['rw', 'no_root_squash', 'no_subtree_check', 'fsid=0'] },
+        ],
+      },
+    ]);
+    expect(drift).toEqual({ missing: [], extra: [], changed: [] });
+  });
+
   it('detects missing, extra, and changed (options + hosts)', () => {
     const drift = compareExports(
       [...DESIRED, { path: '/mnt/b', clients: [{ host: '10.0.0.0/24', options: ['ro'] }] }],

--- a/xiNAS-MCP/src/__tests__/lib/parse/__fixtures__/nfs-helper-list-exports.json
+++ b/xiNAS-MCP/src/__tests__/lib/parse/__fixtures__/nfs-helper-list-exports.json
@@ -1,16 +1,15 @@
 {
-  "op": "list_exports",
-  "status": "ok",
-  "exports": [
+  "ok": true,
+  "result": [
     {
       "path": "/srv/share01",
       "clients": [
         {
-          "host_pattern": "10.0.0.0/24",
+          "host": "10.0.0.0/24",
           "options": ["rw", "sync", "root_squash", "no_subtree_check", "anon_uid=65534", "anon_gid=65534"]
         },
         {
-          "host_pattern": "10.0.1.5",
+          "host": "10.0.1.5",
           "options": ["ro", "no_root_squash", "no_subtree_check"]
         }
       ]
@@ -19,10 +18,11 @@
       "path": "/srv/share02",
       "clients": [
         {
-          "host_pattern": "*",
+          "host": "*",
           "options": ["rw", "sync", "all_squash", "anon_uid=1000", "anon_gid=1000"]
         }
       ]
     }
-  ]
+  ],
+  "request_id": "test"
 }

--- a/xiNAS-MCP/src/__tests__/lib/parse/__fixtures__/nfs-helper-list-sessions.json
+++ b/xiNAS-MCP/src/__tests__/lib/parse/__fixtures__/nfs-helper-list-sessions.json
@@ -1,25 +1,24 @@
 {
-  "op": "list_sessions",
-  "status": "ok",
-  "sessions": [
+  "ok": true,
+  "result": [
     {
-      "client_addr": "10.0.0.10",
-      "client_hostname": "compute-01.local",
+      "client_ip": "10.0.0.10",
+      "nfs_version": "v4.1",
       "export_path": "/srv/share01",
-      "proto_version": "v4.1",
-      "locked_files": 3
+      "active_locks": 3
     },
     {
-      "client_addr": "10.0.0.11",
+      "client_ip": "10.0.0.11",
+      "nfs_version": "v3",
       "export_path": "/srv/share01",
-      "proto_version": "v3",
-      "locked_files": 0
+      "active_locks": 0
     },
     {
-      "client_addr": "10.0.0.12",
+      "client_ip": "10.0.0.12",
+      "nfs_version": "v4.2",
       "export_path": "/srv/share02",
-      "proto_version": "v4.2",
-      "locked_files": 12
+      "active_locks": 12
     }
-  ]
+  ],
+  "request_id": "test"
 }

--- a/xiNAS-MCP/src/__tests__/lib/parse/nfs.test.ts
+++ b/xiNAS-MCP/src/__tests__/lib/parse/nfs.test.ts
@@ -38,9 +38,16 @@ describe('parseListExports', () => {
     expect(() => parseListExports('not json')).toThrow(/JSON/);
   });
 
-  it('returns empty array when exports field is absent or empty', () => {
-    const raw = JSON.stringify({ op: 'list_exports', status: 'ok', exports: [] });
-    expect(parseListExports(raw)).toEqual([]);
+  it('returns empty array when the helper result is absent or empty', () => {
+    expect(parseListExports(JSON.stringify({ ok: true, result: [], request_id: 'x' }))).toEqual([]);
+    expect(parseListExports(JSON.stringify({ ok: true, request_id: 'x' }))).toEqual([]);
+  });
+
+  it('throws on an ok:false helper error instead of returning empty', () => {
+    // Returning [] here would let the collector reconcile-DELETE every observed
+    // export on a transient helper failure — the error must propagate.
+    const raw = JSON.stringify({ ok: false, error: 'boom', code: 'INTERNAL', request_id: 'x' });
+    expect(() => parseListExports(raw)).toThrow(/boom/);
   });
 });
 
@@ -50,24 +57,33 @@ describe('parseListSessions', () => {
     const sessions = parseListSessions(raw);
     expect(sessions).toHaveLength(3);
 
+    // The helper maps client_ip → client_addr, nfs_version → proto_version,
+    // active_locks → locked_files, and does not resolve a hostname.
     const s1 = sessions.find((s) => s.spec.client_addr === '10.0.0.10');
     expect(s1).toBeDefined();
-    expect(s1?.spec.client_hostname).toBe('compute-01.local');
+    expect(s1?.spec.client_hostname).toBeUndefined();
     expect(s1?.spec.export_path).toBe('/srv/share01');
     expect(s1?.status.proto_version).toBe('v4.1');
     expect(s1?.status.locked_files).toBe(3);
     expect(s1?.id).toBe('10.0.0.10:/srv/share01');
 
-    const s2 = sessions.find((s) => s.spec.client_addr === '10.0.0.11');
-    expect(s2?.spec.client_hostname).toBeUndefined();
+    const s3 = sessions.find((s) => s.spec.client_addr === '10.0.0.12');
+    expect(s3?.status.locked_files).toBe(12);
   });
 
   it('throws on malformed JSON', () => {
     expect(() => parseListSessions('not json')).toThrow(/JSON/);
   });
 
-  it('returns empty array when sessions field is absent or empty', () => {
-    const raw = JSON.stringify({ op: 'list_sessions', status: 'ok', sessions: [] });
-    expect(parseListSessions(raw)).toEqual([]);
+  it('returns empty array when the helper result is absent or empty', () => {
+    expect(parseListSessions(JSON.stringify({ ok: true, result: [], request_id: 'x' }))).toEqual(
+      [],
+    );
+    expect(parseListSessions(JSON.stringify({ ok: true, request_id: 'x' }))).toEqual([]);
+  });
+
+  it('throws on an ok:false helper error instead of returning empty', () => {
+    const raw = JSON.stringify({ ok: false, error: 'boom', request_id: 'x' });
+    expect(() => parseListSessions(raw)).toThrow(/boom/);
   });
 });

--- a/xiNAS-MCP/src/lib/health/drift.ts
+++ b/xiNAS-MCP/src/lib/health/drift.ts
@@ -31,8 +31,22 @@ export interface ObservedExportRuleRow {
  */
 const KERNEL_NOISE_OPTIONS = new Set(['wdelay', 'no_wdelay', 'hide', 'nohide', 'pnfs', 'no_pnfs']);
 
+/**
+ * `fsid=N` is not a client option in the desired model — it is a first-class
+ * `Share.spec.fsid` field, and the compile deliberately does NOT render it
+ * into the export entry (s3-nfs-executor-spec §4 deferral). The live
+ * /etc/exports, however, DOES carry `fsid=N` (the installer writes `fsid=0`
+ * for the NFSv4 root). Comparing raw options would therefore flag a
+ * PERMANENT false "changed" drift on every fsid-bearing export. Normalize it
+ * out of both sides. (fsid drift itself is invisible to this compare until
+ * §4 renders fsid; tracked separately.)
+ */
+function isComparedOption(o: string): boolean {
+  return !KERNEL_NOISE_OPTIONS.has(o) && !o.startsWith('fsid=');
+}
+
 function canonicalOptions(options: string[]): string {
-  return [...new Set(options.filter((o) => !KERNEL_NOISE_OPTIONS.has(o)))].sort().join(',');
+  return [...new Set(options.filter(isComparedOption))].sort().join(',');
 }
 
 export interface ExportsDrift {

--- a/xiNAS-MCP/src/lib/parse/nfs.ts
+++ b/xiNAS-MCP/src/lib/parse/nfs.ts
@@ -53,8 +53,21 @@ function parseJson(raw: string, caller: string): unknown {
   }
 }
 
+/**
+ * The nfs-helper wraps every response as `{ ok, result, request_id }`
+ * (success) or `{ ok: false, error, code, request_id }` (failure) —
+ * nfs_helper.py `handle_request`. The parsers below take the RAW response
+ * JSON, so they unwrap that envelope themselves.
+ */
+interface HelperEnvelope {
+  ok?: boolean;
+  result?: unknown;
+  error?: string;
+}
+
+/** One list_exports entry in the helper's wire shape: `{ path, clients:[{host, options}] }`. */
 interface RawClient {
-  host_pattern: string;
+  host: string;
   options?: string[];
 }
 
@@ -63,13 +76,23 @@ interface RawExport {
   clients?: RawClient[];
 }
 
-interface RawListExports {
-  exports?: RawExport[];
+/**
+ * Unwrap the helper envelope. An `ok:false` response MUST throw, not return
+ * empty: the NFS collector treats a successful-but-empty sweep as "no
+ * entities" and reconcile-DELETEs the observed rows for the kind, so
+ * swallowing a helper error would wipe good observed state on a transient
+ * failure. A throw makes the sweep fail, which skips reconcile (boot.ts).
+ */
+function helperResult(data: HelperEnvelope, caller: string): unknown {
+  if (data.ok === false) {
+    throw new Error(`${caller}: nfs-helper returned an error: ${data.error ?? 'unknown'}`);
+  }
+  return data.result;
 }
 
 export function parseListExports(raw: string): ObservedExportRule[] {
-  const data = parseJson(raw, 'parseListExports') as RawListExports;
-  const exports_ = data.exports ?? [];
+  const data = parseJson(raw, 'parseListExports') as HelperEnvelope;
+  const exports_ = (helperResult(data, 'parseListExports') as RawExport[] | undefined) ?? [];
   const rules: ObservedExportRule[] = [];
 
   for (const exp of exports_) {
@@ -81,7 +104,7 @@ export function parseListExports(raw: string): ObservedExportRule[] {
       const anon_gid = extractAnonId(opts, 'anon_gid');
       rules.push({
         export_path: exp.path,
-        host_pattern: client.host_pattern,
+        host_pattern: client.host,
         options: opts,
         ...(squash_mode !== undefined ? { squash_mode } : {}),
         ...(anon_uid !== undefined ? { anon_uid } : {}),
@@ -93,33 +116,32 @@ export function parseListExports(raw: string): ObservedExportRule[] {
   return rules;
 }
 
+/**
+ * One list_sessions entry in the helper's wire shape (nfs_sessions.py):
+ * `{ client_ip, nfs_version, export_path, active_locks }`. The helper does
+ * not resolve a hostname or per-session lock count beyond active_locks.
+ */
 interface RawSession {
-  client_addr: string;
+  client_ip: string;
   export_path: string;
-  proto_version: string;
-  locked_files: number;
-  client_hostname?: string;
-}
-
-interface RawListSessions {
-  sessions?: RawSession[];
+  nfs_version: string;
+  active_locks: number;
 }
 
 export function parseListSessions(raw: string): ObservedNfsSession[] {
-  const data = parseJson(raw, 'parseListSessions') as RawListSessions;
-  const sessions = data.sessions ?? [];
+  const data = parseJson(raw, 'parseListSessions') as HelperEnvelope;
+  const sessions = (helperResult(data, 'parseListSessions') as RawSession[] | undefined) ?? [];
 
   return sessions.map<ObservedNfsSession>((s) => ({
     kind: 'NfsSession',
-    id: `${s.client_addr}:${s.export_path}`,
+    id: `${s.client_ip}:${s.export_path}`,
     spec: {
-      client_addr: s.client_addr,
+      client_addr: s.client_ip,
       export_path: s.export_path,
-      ...(s.client_hostname !== undefined ? { client_hostname: s.client_hostname } : {}),
     },
     status: {
-      proto_version: s.proto_version,
-      locked_files: s.locked_files,
+      proto_version: s.nfs_version,
+      locked_files: s.active_locks,
     },
   }));
 }


### PR DESCRIPTION
## What

The health check flagged shares that **are** exported as `nfs.exports:
<share> not exported` and `drift.nfs-exports: N missing`, and
`Share.status.exports` was always empty. Root cause: the observe-side NFS
parsers read a wire shape the `nfs-helper` never emits, so **no ExportRule
or NfsSession was ever observed**.

## Root cause

`parseListExports` / `parseListSessions` (`src/lib/parse/nfs.ts`) read:
- `data.exports[].clients[].host_pattern`
- `data.sessions[].{client_addr, proto_version, locked_files}`

But the helper returns (nfs_helper.py; wire contract in
`docs/MCP/spec-nfs-helper.md`):
- envelope `{ ok, result, request_id }`
- exports `{ path, clients:[{ host, options }] }`
- sessions `{ client_ip, nfs_version, export_path, active_locks }`

So both parsers always returned `[]`. The **executor's** helper client
parsed correctly (writes worked), and the fixtures/tests encoded the
fabricated shape — so this passed CI while production observation was
silently dead.

## Fixes

1. **Parsers read the real `{ok, result}` envelope + field names.** An
   `ok:false` response now **throws** instead of returning `[]` — returning
   empty would let the collector reconcile-DELETE good observed rows on a
   transient helper error.
2. **Rewrote the two parse fixtures + tests** to the real helper output,
   and fixed the probe test's mock helper shape. Added regression tests for
   the envelope, the empty case, and the `ok:false` throw.
3. **`drift.nfs-exports`: normalize `fsid=N` out of the options compare.**
   The desired model carries fsid as `Share.spec.fsid` and the compile does
   not render it (`s3-nfs-executor-spec` §4), while `/etc/exports` carries
   `fsid=0` for the NFSv4 root — so once exports became observable, the
   compare flagged a **permanent false "changed" drift** on the root export.

## Verified on a live host

| check | before | after |
|---|---|---|
| `Share.status.exports` | `[]` | populated (host, options, squash_mode) |
| `nfs.exports` | degraded — "not exported" | **ok** — "1 share(s) exported" |
| `drift.nfs-exports` | degraded — "1 missing" → "1 changed" | **ok** — "exports match" |

`ExportRule/mnt/data` now appears in observed state after a poll sweep.
(Remaining `overall: degraded` is honest: RDMA interfaces down + sysctl
drift on this host — not NFS.)

`npm run typecheck` / `lint` (exit 0) / `format:check` clean; `npm test`
**1403 passed**.

## Related / scope

- No spec change: `docs/MCP/spec-nfs-helper.md` already documents the correct
  `{ok, result, host}` contract — the code had drifted from it.
- Sibling PR #273 fixes the **TUI** session renderer (`_format_sessions`),
  the same helper-contract drift one layer up. Independent; both stand alone.
- Follow-up noted in code: fsid *drift* itself is invisible to the compare
  until §4 renders fsid into the desired export.

`Requires-Rebuild: xinas_node_build` — control-path TS change; the agent
must rebuild `dist/` and restart to observe exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
