### PR TITLE
fix(network): make interface apply succeed and blocked plans report why

### DIFF
--- a/xiNAS-MCP/src/__tests__/agent/task/net-executor.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/task/net-executor.test.ts
@@ -114,6 +114,50 @@ describe('net.iface.update executor', () => {
     expect(host.kernel().addrs.ibp9s0f0).toContain('10.10.2.1/24');
   });
 
+  it('verify POLLS until networkd settles (netplan apply returns early)', async () => {
+    // Regression: `netplan apply` returns BEFORE systemd-networkd finishes
+    // reconfiguring — measured on a live IB host, the address reappeared
+    // ~0.4 s after apply returned. A single immediate read saw the
+    // post-flush empty state, so EVERY legitimate change failed verify and
+    // rolled back. Verify must wait for the desired state to appear.
+    let reads = 0;
+    const slowHost = {
+      ...host,
+      async ipAddrShow(): Promise<string> {
+        reads += 1;
+        // first few reads: networkd has not re-added the address yet
+        if (reads <= 3) return JSON.stringify([{ ifname: 'ibp65s0', addr_info: [] }]);
+        return host.ipAddrShow();
+      },
+    };
+    const executor = makeNetIfaceUpdateExecutor({
+      host: slowHost as typeof host,
+      settleMs: 5_000,
+      pollMs: 1,
+      sleep: async () => {},
+    });
+    await runAll(executor, makeCtx(spec()));
+    expect(reads).toBeGreaterThan(3); // it retried rather than failing on read #1
+  });
+
+  it('verify gives up after the settle budget, reporting the live state', async () => {
+    const blindHost = {
+      ...host,
+      async ipAddrShow(): Promise<string> {
+        return JSON.stringify([{ ifname: 'ibp65s0', addr_info: [] }]);
+      },
+    };
+    const executor = makeNetIfaceUpdateExecutor({
+      host: blindHost as typeof host,
+      settleMs: 5,
+      pollMs: 1,
+      sleep: async () => {},
+    });
+    await expect(runAll(executor, makeCtx(spec()))).rejects.toThrow(
+      /missing 10\.10\.5\.1\/24 after apply .*waited/,
+    );
+  });
+
   it('preflight live hash gate: out-of-band netplan edit aborts before any write', async () => {
     await host.writeNetplanFile('/etc/netplan/77-rogue.yaml', 'network: {version: 2}\n');
     const opsBefore = host.ops().length;

--- a/xiNAS-MCP/src/__tests__/api/plan/network-provider.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/plan/network-provider.test.ts
@@ -197,6 +197,25 @@ describe('netIfaceUpdateProvider', () => {
     expect(planResult.blockers.map((b) => b.code)).toContain('address_conflict');
   });
 
+  it('malformed CIDR → addresses_invalid blocker, not a thrown INTERNAL', async () => {
+    // Regression: the provider rendered the netplan unconditionally, so
+    // connectedSubnet() threw on the bad CIDR and the request 500'd before
+    // the blocker the validator had already produced could be returned.
+    const { planResult } = await h.engine.plan(
+      planArgs({ id: 'ibp65s0', addresses: ['not-an-ip'] }),
+    );
+    expect(planResult.blockers.map((b) => b.code)).toContain('addresses_invalid');
+    // a blocked plan carries no render (it can never be applied)
+    expect((planResult.enriched_spec as { render?: string }).render).toBe('');
+  });
+
+  it('address missing its prefix is also addresses_invalid', async () => {
+    const { planResult } = await h.engine.plan(
+      planArgs({ id: 'ibp65s0', addresses: ['10.10.9.5'] }),
+    );
+    expect(planResult.blockers.map((b) => b.code)).toContain('addresses_invalid');
+  });
+
   it('re-parses its own enriched spec (apply re-check contract)', async () => {
     const first = await h.engine.plan(planArgs({ id: 'ibp65s0', addresses: ['10.10.5.1/24'] }));
     const persisted = h.store.get(first.task.task_id)?.spec as Record<string, unknown>;

--- a/xiNAS-MCP/src/agent/task/net-executor.ts
+++ b/xiNAS-MCP/src/agent/task/net-executor.ts
@@ -204,38 +204,87 @@ async function netRollback(
   ctx.emitOutput(`rollback (${op}): ${Object.keys(stashed).length} file(s) restored + re-applied`);
 }
 
-/** Verify a dev's desired addresses are live (ip -j) + its rule exists. */
+/** Settle budget for verify — `netplan apply` returns before networkd finishes. */
+const VERIFY_SETTLE_MS = 15_000;
+const VERIFY_POLL_MS = 250;
+
+export interface VerifySettleOptions {
+  /** Total time to wait for the kernel to reach the desired state. */
+  settleMs?: number;
+  /** Gap between re-reads while waiting. */
+  pollMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/** Live CIDRs on `dev`, from `ip -j addr show`. */
+async function liveAddresses(host: NetHost, dev: string): Promise<string[]> {
+  const parsed = JSON.parse(await host.ipAddrShow()) as Array<{
+    ifname?: string;
+    addr_info?: Array<{ local?: string; prefixlen?: number }>;
+  }>;
+  const entry = parsed.find((e) => e.ifname === dev);
+  return (entry?.addr_info ?? []).map((a) => `${a.local}/${a.prefixlen}`);
+}
+
+/**
+ * Verify a dev's desired addresses are live (ip -j) + its rule exists.
+ *
+ * POLLS until the desired state appears or the settle budget runs out.
+ * `netplan apply` returns BEFORE systemd-networkd has finished reconfiguring:
+ * measured on a live IB host, `netplan apply` returned with the address still
+ * absent and networkd re-added it ~0.4 s later. A single immediate read
+ * therefore observed the post-flush empty state and failed every legitimate
+ * change, rolling it back — the apply path could never succeed.
+ */
 async function verifyDev(
   host: NetHost,
   dev: string,
   addresses: string[],
   tableId: number,
   enabled: boolean,
+  opts: VerifySettleOptions = {},
 ): Promise<void> {
-  const parsed = JSON.parse(await host.ipAddrShow()) as Array<{
-    ifname?: string;
-    addr_info?: Array<{ local?: string; prefixlen?: number }>;
-  }>;
-  const entry = parsed.find((e) => e.ifname === dev);
-  const live = (entry?.addr_info ?? []).map((a) => `${a.local}/${a.prefixlen}`);
   if (!enabled) return; // disabled iface: flushed is the desired end state
-  for (const cidr of addresses) {
-    if (!live.includes(cidr)) {
-      throw new Error(
-        `verify: ${dev} is missing ${cidr} after apply (live: ${live.join(', ') || 'none'})`,
-      );
+  const settleMs = opts.settleMs ?? VERIFY_SETTLE_MS;
+  const pollMs = opts.pollMs ?? VERIFY_POLL_MS;
+  const sleep =
+    opts.sleep ??
+    ((ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms)));
+
+  const deadline = Date.now() + settleMs;
+  let live: string[] = [];
+  let missing: string | undefined;
+  let ruleMissing = false;
+
+  for (;;) {
+    live = await liveAddresses(host, dev);
+    missing = addresses.find((cidr) => !live.includes(cidr));
+    ruleMissing = false;
+    if (missing === undefined) {
+      if (addresses.length === 0) return;
+      const rules = await host.ipRuleShow();
+      if (rules.includes(`lookup ${tableId}`)) return;
+      ruleMissing = true;
     }
+    if (Date.now() >= deadline) break;
+    await sleep(pollMs);
   }
-  if (addresses.length > 0) {
-    const rules = await host.ipRuleShow();
-    if (!rules.includes(`lookup ${tableId}`)) {
-      throw new Error(`verify: no PBR rule for table ${tableId} after apply`);
-    }
+
+  if (missing !== undefined) {
+    throw new Error(
+      `verify: ${dev} is missing ${missing} after apply (live: ${live.join(', ') || 'none'}; waited ${settleMs}ms)`,
+    );
+  }
+  if (ruleMissing) {
+    throw new Error(`verify: no PBR rule for table ${tableId} after apply (waited ${settleMs}ms)`);
   }
 }
 
-export function makeNetIfaceUpdateExecutor(opts: { host: NetHost }): Executor {
+export function makeNetIfaceUpdateExecutor(
+  opts: { host: NetHost } & VerifySettleOptions,
+): Executor {
   const host = opts.host;
+  const settle: VerifySettleOptions = opts;
 
   const preflight: ExecutorStage = {
     name: 'preflight',
@@ -281,6 +330,7 @@ export function makeNetIfaceUpdateExecutor(opts: { host: NetHost }): Executor {
         spec.desired?.addresses ?? [],
         spec.surgical.pbr_table_id,
         spec.desired?.enabled !== false,
+        settle,
       );
       ctx.emitOutput(`verified: ${spec.surgical.dev} matches the desired state`);
     },
@@ -319,8 +369,9 @@ function narrowPoolSpec(ctx: ExecutorContext): PoolEnriched {
   return raw as unknown as PoolEnriched;
 }
 
-export function makeNetPoolApplyExecutor(opts: { host: NetHost }): Executor {
+export function makeNetPoolApplyExecutor(opts: { host: NetHost } & VerifySettleOptions): Executor {
   const host = opts.host;
+  const settle: VerifySettleOptions = opts;
 
   return {
     operation_kind: 'net.pool.apply',
@@ -364,7 +415,7 @@ export function makeNetPoolApplyExecutor(opts: { host: NetHost }): Executor {
         async run(ctx: ExecutorContext): Promise<void> {
           const spec = narrowPoolSpec(ctx);
           for (const t of spec.targets) {
-            await verifyDev(host, t.dev, t.addresses, t.pbr_table_id, true);
+            await verifyDev(host, t.dev, t.addresses, t.pbr_table_id, true, settle);
           }
           ctx.emitOutput(`verified: ${spec.targets.length} interface(s) match the pool`);
         },

--- a/xiNAS-MCP/src/api/plan/providers/network.ts
+++ b/xiNAS-MCP/src/api/plan/providers/network.ts
@@ -311,7 +311,13 @@ export const netIfaceUpdateProvider: PlanProvider = {
         .map((n): ResourceRef => ({ kind: 'NetworkInterface', id: n })),
     ];
 
-    const render = renderNetplan(rows);
+    // A blocked plan can NEVER be applied (the route re-runs preflight and
+    // refuses on any blocker), and the render requires every address to be a
+    // parsable CIDR. Rendering regardless turned an `addresses_invalid`
+    // blocker into a 500 INTERNAL — connectedSubnet() throws on the bad CIDR
+    // before this function can return the blocker the validator had already
+    // produced. Skip the render when blocked and let the plan report why.
+    const render = blockers.length > 0 ? '' : renderNetplan(rows);
     const cleanupFiles =
       spec.cleanup === true && targetDuplicates.length > 0 ? { [id]: targetDuplicates } : {};
 
@@ -427,7 +433,8 @@ export const netPoolApplyProvider: PlanProvider = {
       ...facts.managed.map((m): ResourceRef => ({ kind: 'NetworkInterface', id: m.name })),
     ];
 
-    const render = renderNetplan(rows);
+    // Same guard as the iface-update provider: never render a blocked plan.
+    const render = blockers.length > 0 ? '' : renderNetplan(rows);
     return {
       affected_resources: affected,
       blockers,


### PR DESCRIPTION
## What

Two defects found while E2E-testing the network surface against a live host.
Together they meant a **legitimate address change could never be applied**, and
a malformed one answered **500** instead of naming the problem.

## 1. `verify` raced systemd-networkd — every change rolled back

`verifyDev` read `ip -j addr show` **once**, immediately after `netplan apply`.
But `netplan apply` returns *before* networkd finishes reconfiguring. Measured
on this host:

```
netplan apply returned after 6.03s; address at that instant: <none>
address reappeared after 6.46s          # ~0.4s AFTER apply returned
```

So verify observed the post-flush empty state, threw
`missing <cidr> after apply (live: none)`, and the runner rolled back — in
**both** directions, so the interface could never be re-addressed at all.

**Fix:** verify now polls to a settle deadline (15 s, 250 ms interval) and fails
only if the desired state never appears. The budget is injectable
(`settleMs`/`pollMs`/`sleep`) following the existing `xiraid-array-executor`
convention, so tests stay fast.

## 2. A blocked plan rendered anyway, turning a blocker into a 500

`validateIfaceUpdate` **already** produces an `addresses_invalid` blocker for a
malformed CIDR — but the provider then called `renderNetplan(rows)`
unconditionally, and `connectedSubnet()` throws on an unparsable CIDR:

```
HTTP 500  {"code":"INTERNAL","message":"connectedSubnet: unparsable CIDR 'not-an-ip'"}
```

That leaks an internal symbol, uses a server-fault status for bad user input,
and hides the blocker that already said exactly what was wrong. A blocked plan
can never be applied (the route re-runs preflight and refuses on any blocker),
so the render is now skipped when blockers exist. Both providers guarded.

```
HTTP 200  blockers: [{"code":"addresses_invalid","message":"'not-an-ip' is not a valid IPv4 CIDR"}]
```

## Verified end to end on a live host

Round trip `ibp65s0` `10.10.1.1/24 → 10.10.1.5/24 → 10.10.1.1/24`, **both
applies `task success`** (before the fix: both failed verify and rolled back):

| layer | tracked the change |
|---|---|
| `/etc/netplan/99-xinas.yaml` | ✅ rewritten |
| live `ip addr` | ✅ `10.10.1.5/24` |
| PBR rule | ✅ `from 10.10.1.5 lookup 100` (table id preserved) |
| `drift.netplan` health check | skipped → **ok** once desired rows seeded |

**Management-interface safety:** `enp209s0f0` (igb, default route, SSH) was
asserted unchanged at every step and never touched. It is *structurally*
unmanageable — only mlx/RDMA interfaces enter the managed set, so a PATCH
against it is rejected pre-plan with `UNSUPPORTED`/`iface_not_managed`.

`npm run typecheck` / `lint` (exit 0) / `format:check` clean; `npm test`
**1407 passed**, including two new regression tests (verify retries until the
address appears; verify still gives up after the budget with the live state in
the message).

## Notes / follow-ups (not fixed here)

- After a successful apply, the next plan pins the **observed** netplan hash,
  which lags the live file by up to one 30 s poll — so an immediate follow-up
  apply is refused by the executor preflight with `netplan file set changed
  since plan — re-plan`. Correct fail-closed behaviour, but it makes
  back-to-back changes need a wait. Worth a usability follow-up.
- The observed row is briefly stale right after an apply (the event path
  publishes a narrower status than the snapshot); it self-heals on the next
  poll.
- The management-interface guard is driver-based (`driver.includes('mlx')`),
  not role-based — it does not consult the default route. A Mellanox NIC used
  for management would be considered managed. Not the case here, but worth an
  explicit guard someday.

`Requires-Rebuild: xinas_node_build` — control-path TS; the agent must rebuild
`dist/` and restart for the verify fix to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
