### PR TITLE
fix(raid): unify RAID minimum drive counts to the engine-enforced table

### DIFF
--- a/collection/roles/nvme_namespace/README.md
+++ b/collection/roles/nvme_namespace/README.md
@@ -19,7 +19,8 @@ This role implements the Default Storage Namespace and RAID Specification:
 
 - `nvme-cli` package must be installed
 - NVMe drives must support namespace management (most enterprise NVMe do)
-- Sufficient drives for requested RAID levels (minimum 3 for RAID 5, 4 for RAID 10)
+- Sufficient drives for the requested RAID levels — the engine-enforced minimums
+  (4 for RAID 5, 4 for RAID 10, 8 for RAID 50/60), not textbook RAID math
 
 ## Role Variables
 
@@ -33,8 +34,14 @@ This role implements the Default Storage Namespace and RAID Specification:
 | `nvme_raid_log_strip_kb` | `16` | Strip size for log array in KB |
 | `nvme_abort_if_no_system_drive` | `true` | Abort if system drive cannot be detected |
 | `nvme_skip_failed_devices` | `true` | Continue if individual device fails |
-| `nvme_min_devices_for_raid5` | `3` | Minimum devices for RAID 5 |
-| `nvme_min_devices_for_raid10` | `4` | Minimum devices for RAID 10 |
+| `nvme_raid_min_devices` | `{0: 2, 1: 2, 5: 4, 6: 4, 10: 4, 50: 8, 60: 8}` | Engine-enforced minimum member count per RAID level |
+| `nvme_raid_min_devices_default` | `2` | Minimum for a level absent from the table |
+
+> `nvme_min_devices_for_raid5` and `nvme_min_devices_for_raid10` were removed —
+> they let the installer accept a 3-drive RAID 5 that `xicli raid create`
+> rejects. Setting either now fails the play with an explicit message. The
+> replacement table is documented in
+> [docs/Installer/raid-spec.md](../../../docs/Installer/raid-spec.md) §6.1.
 
 ## Dependencies
 

--- a/collection/roles/nvme_namespace/defaults/main.yml
+++ b/collection/roles/nvme_namespace/defaults/main.yml
@@ -47,6 +47,27 @@ nvme_skip_failed_devices: true        # Continue if individual device fails
 nvme_cleanup_existing_storage: true   # Detect and remove LVM, MD RAID, ZFS on data drives
 nvme_skip_cleanup_confirmation: false  # Skip confirmation prompt (DANGEROUS - set true for automation)
 
-# Minimum device counts for RAID creation
-nvme_min_devices_for_raid5: 3         # Minimum devices for RAID 5
-nvme_min_devices_for_raid10: 4        # Minimum devices for RAID 10 (must be even)
+# Minimum member counts for RAID creation, keyed by RAID level.
+#
+# These are the counts the xiRAID *engine* enforces, not textbook RAID math —
+# `xicli raid create` rejects a 3-drive RAID 5 with "To create RAID level '5',
+# a minimum of '4' disks are required." Read off the engine's own rejection
+# messages on xiRAID Classic 4.4 (`xicli raid create --help` does not document
+# them), so re-confirm these numbers when the engine version moves.
+#
+# docs/Storage/raid-management-spec.md §4 owns the table; the TUI Create Array
+# wizard (_RAID_MIN_DRIVES in xinas_menu/screens/raid.py) and the control path
+# (LEVEL_CONSTRAINTS in xiNAS-MCP/src/lib/xiraid/schema.ts) carry the same
+# values. A level absent from this map falls back to nvme_raid_min_devices_default.
+#
+# Replaces the former nvme_min_devices_for_raid5 / nvme_min_devices_for_raid10
+# scalars, which is how RAID 5 ended up with a 3-drive floor the engine rejects.
+nvme_raid_min_devices:
+  0: 2
+  1: 2
+  5: 4
+  6: 4
+  10: 4                               # RAID 10 additionally rounds down to an even count
+  50: 8
+  60: 8
+nvme_raid_min_devices_default: 2

--- a/collection/roles/nvme_namespace/tasks/generate_raid_config.yml
+++ b/collection/roles/nvme_namespace/tasks/generate_raid_config.yml
@@ -1,30 +1,49 @@
 ---
 # Generate RAID configuration for raid_fs role
 
+# The per-level scalars were replaced by the nvme_raid_min_devices table (they
+# disagreed with the engine: RAID 5 had a 3-drive floor xiRAID rejects). Honour
+# them nowhere, but say so loudly — a silently ignored override is the same
+# class of bug as the divergence itself.
+- name: Fail on removed per-level minimum-device knobs
+  ansible.builtin.assert:
+    that:
+      - nvme_min_devices_for_raid5 is not defined
+      - nvme_min_devices_for_raid10 is not defined
+    fail_msg: >-
+      nvme_min_devices_for_raid5 / nvme_min_devices_for_raid10 have been removed.
+      Minimum member counts now come from the nvme_raid_min_devices table
+      (defaults/main.yml), which carries the counts the xiRAID engine actually
+      enforces. Drop the removed variable from your inventory or preset; override
+      nvme_raid_min_devices only if you have confirmed the numbers against your
+      xiRAID version. See docs/Installer/raid-spec.md section 6.1.
+    quiet: true
+
 # Validate minimum device counts for requested RAID levels
 - name: Calculate available device counts
   ansible.builtin.set_fact:
     nvme_small_ns_count: "{{ nvme_small_ns_devices | length }}"
     nvme_large_ns_count: "{{ nvme_large_ns_devices | length }}"
 
-# Determine if we can create the requested RAID arrays
-- name: Validate RAID 5 requirements for data array
+# One table, one lookup per array — no per-level cascade, and no ">= 2" fallback
+# for levels nobody wrote a branch for (that is how RAID 50/60 got a 2-drive
+# floor). docs/Storage/raid-management-spec.md section 4 owns the numbers.
+- name: Resolve engine-enforced minimum member counts
   ansible.builtin.set_fact:
-    nvme_can_create_data_raid: >-
-      {{ nvme_large_ns_count | int >= nvme_min_devices_for_raid5 | int }}
-  when: nvme_raid_data_level | int == 5
+    _data_min_devices: >-
+      {{ nvme_raid_min_devices[nvme_raid_data_level | int]
+         | default(nvme_raid_min_devices_default) }}
+    _log_min_devices: >-
+      {{ nvme_raid_min_devices[nvme_raid_log_level | int]
+         | default(nvme_raid_min_devices_default) }}
 
-- name: Validate RAID 6 requirements for data array
+- name: Validate member counts against the engine minimums
   ansible.builtin.set_fact:
-    nvme_can_create_data_raid: >-
-      {{ nvme_large_ns_count | int >= 4 }}
-  when: nvme_raid_data_level | int == 6
+    nvme_can_create_data_raid: "{{ nvme_large_ns_count | int >= _data_min_devices | int }}"
+    nvme_can_create_log_raid: "{{ nvme_small_ns_count | int >= _log_min_devices | int }}"
 
-- name: Validate RAID 10 requirements for log array
+- name: Calculate even log device count for RAID 10
   ansible.builtin.set_fact:
-    nvme_can_create_log_raid: >-
-      {{ nvme_small_ns_count | int >= nvme_min_devices_for_raid10 | int }}
-    _log_raid_level: "{{ nvme_raid_log_level }}"
     # For RAID 10, use N-1 devices if count is odd to ensure even number
     _log_device_count: >-
       {{ (nvme_small_ns_count | int) - (nvme_small_ns_count | int % 2) }}
@@ -33,42 +52,19 @@
 # Trim device list for RAID 10 if odd count (use first N-1 devices)
 - name: Adjust log devices for RAID 10 (odd count uses N-1)
   ansible.builtin.set_fact:
+    _log_raid_level: "{{ nvme_raid_log_level }}"
     _log_devices_adjusted: "{{ nvme_small_ns_devices[: _log_device_count | int] }}"
     _log_device_dropped: "{{ nvme_small_ns_devices[_log_device_count | int :] }}"
   when:
     - nvme_raid_log_level | int == 10
     - nvme_small_ns_count | int % 2 == 1
 
-- name: Use all log devices for RAID 10 (even count)
+- name: Use all log devices (RAID 10 with an even count, or any other level)
   ansible.builtin.set_fact:
-    _log_devices_adjusted: "{{ nvme_small_ns_devices }}"
-    _log_device_dropped: []
-  when:
-    - nvme_raid_log_level | int == 10
-    - nvme_small_ns_count | int % 2 == 0
-
-- name: Validate RAID 1 requirements for log array
-  ansible.builtin.set_fact:
-    nvme_can_create_log_raid: >-
-      {{ nvme_small_ns_count | int >= 2 }}
-    _log_raid_level: "1"
-    _log_devices_adjusted: "{{ nvme_small_ns_devices }}"
-    _log_device_dropped: []
-  when: nvme_raid_log_level | int == 1
-
-# Set defaults for other RAID levels
-- name: Default data RAID validation
-  ansible.builtin.set_fact:
-    nvme_can_create_data_raid: "{{ nvme_large_ns_count | int >= 2 }}"
-  when: nvme_can_create_data_raid is not defined
-
-- name: Default log RAID validation
-  ansible.builtin.set_fact:
-    nvme_can_create_log_raid: "{{ nvme_small_ns_count | int >= 2 }}"
     _log_raid_level: "{{ nvme_raid_log_level }}"
     _log_devices_adjusted: "{{ nvme_small_ns_devices }}"
     _log_device_dropped: []
-  when: nvme_can_create_log_raid is not defined
+  when: not (nvme_raid_log_level | int == 10 and nvme_small_ns_count | int % 2 == 1)
 
 # Report validation results
 - name: Report insufficient devices for data array
@@ -76,7 +72,7 @@
     msg: |
       WARNING: Insufficient devices for data array (RAID {{ nvme_raid_data_level }})
       Available: {{ nvme_large_ns_count }} large namespaces
-      Required: {{ nvme_min_devices_for_raid5 }} (RAID 5) or 4 (RAID 6)
+      Required: {{ _data_min_devices }}
   when: not (nvme_can_create_data_raid | bool)
 
 - name: Report insufficient devices for log array
@@ -84,7 +80,7 @@
     msg: |
       WARNING: Insufficient devices for log array (RAID {{ nvme_raid_log_level }})
       Available: {{ nvme_small_ns_count }} small namespaces
-      Required: {{ nvme_min_devices_for_raid10 }} (RAID 10) or 2 (RAID 1)
+      Required: {{ _log_min_devices }}
   when: not (nvme_can_create_log_raid | bool)
 
 # Calculate parity disks based on RAID level
@@ -138,8 +134,14 @@
   ansible.builtin.fail:
     msg: |
       Cannot create required RAID arrays due to insufficient devices.
-      Data array (RAID {{ nvme_raid_data_level }}): {{ 'OK' if nvme_can_create_data_raid | bool else 'FAILED - need more devices' }}
-      Log array (RAID {{ nvme_raid_log_level }}): {{ 'OK' if nvme_can_create_log_raid | bool else 'FAILED - need more devices' }}
+      Data array (RAID {{ nvme_raid_data_level }}): {{ 'OK' if nvme_can_create_data_raid | bool else
+        'FAILED - have ' ~ nvme_large_ns_count ~ ', need ' ~ _data_min_devices }}
+      Log array (RAID {{ nvme_raid_log_level }}): {{ 'OK' if nvme_can_create_log_raid | bool else
+        'FAILED - have ' ~ nvme_small_ns_count ~ ', need ' ~ _log_min_devices }}
+
+      These are the minimums the xiRAID engine enforces, not textbook RAID math
+      (RAID 5 needs 4 members, RAID 50/60 need 8). Attach more drives, or pick a
+      RAID level that fits the drives you have.
   when: not (nvme_can_create_data_raid | bool and nvme_can_create_log_raid | bool)
 
 # Display final configuration

--- a/docs/Installer/raid-spec.md
+++ b/docs/Installer/raid-spec.md
@@ -53,10 +53,17 @@ and zero data drives were found**:
    `nvme_detect_mode: all` …"* — the role will not silently RAID over SATA disks
    the operator didn't mean to consume.
 
-Effective minimum for the VM auto-path is **5 non-OS disks** (2 log + 3 data for
-RAID5); fewer disks fail with the clear "insufficient devices" message from §6,
-identical to how the `xinnorVM` preset fails today. The fallback changes only the
-`default`-preset path; `autoinstall.sh`, the presets, and the menus are untouched.
+Effective minimum for the VM auto-path is **6 non-OS disks** (2 log + 4 data for
+RAID5 — see §6.1); fewer disks fail with the clear "insufficient devices" message
+from §6, identical to how the `xinnorVM` preset fails today. The fallback changes
+only the `default`-preset path; `autoinstall.sh`, the presets, and the menus are
+untouched.
+
+> This minimum was **5** (2 log + 3 data) until the RAID-5 minimum was corrected
+> from the textbook `3` to the engine-enforced `4` (§6.1). A VM with exactly 5
+> non-OS disks used to pass preflight and then fail mid-install at
+> `xicli raid create` — it now fails earlier, at the `generate_raid_config.yml`
+> preflight, before any namespace or array work has run.
 
 ---
 
@@ -272,15 +279,46 @@ Source: [generate_raid_config.yml](../../collection/roles/nvme_namespace/tasks/g
 
 ### 6.1 Capacity checks
 
-| RAID level | Min members | Source variable |
-|---|---|---|
-| RAID 5 (data) | `nvme_min_devices_for_raid5` (default `3`) | `nvme_can_create_data_raid` |
-| RAID 6 (data) | hardcoded `4` | same |
-| RAID 10 (log) | `nvme_min_devices_for_raid10` (default `4`, must be even) | `nvme_can_create_log_raid` |
-| RAID 1 (log) | hardcoded `2` | same |
-| Other levels (default fallback) | `≥ 2` | same |
+Both arrays are checked against **one** table, `nvme_raid_min_devices` in
+[defaults/main.yml](../../collection/roles/nvme_namespace/defaults/main.yml),
+keyed by RAID level:
 
-If either array fails its check, the play fails with a message that names both checks and which one came up short.
+| RAID level | Min members |
+|---|---|
+| 0, 1 | 2 |
+| 5 | **4** |
+| 6 | 4 |
+| 10 | 4 (and see §6.2 — an odd count is trimmed to even) |
+| 50, 60 | **8** |
+| any level not in the table | 2 |
+
+The data array checks `nvme_large_ns_count` against
+`nvme_raid_min_devices[nvme_raid_data_level]` into `nvme_can_create_data_raid`;
+the log array checks `nvme_small_ns_count` against
+`nvme_raid_min_devices[nvme_raid_log_level]` into `nvme_can_create_log_raid`. If
+either fails, the play fails with a message that names both checks, which one
+came up short, and the count-vs-required numbers.
+
+These are the **engine-enforced** minimums, not textbook RAID math. They are
+xiRAID-version-specific and were read off xiRAID Classic 4.4's own rejection
+messages (`Error: To create RAID level '5', a minimum of '4' disks are
+required.`) rather than from `xicli raid create --help`, which does not document
+them. The table is shared verbatim with the TUI Create Array wizard and the
+control-path constraint table — see
+[Storage/raid-management-spec.md §4](../Storage/raid-management-spec.md#engine-enforced-minimum-drive-counts),
+which owns the numbers and the re-confirmation rule for a xiRAID version bump.
+
+> **This tightened the default preset.** The RAID-5 minimum was `3` (the
+> `nvme_min_devices_for_raid5` variable, now removed along with
+> `nvme_min_devices_for_raid10`; both are rejected with an explicit error if an
+> old inventory or preset still sets them). A node with exactly **three** data
+> namespaces used to pass this preflight and then fail several tasks later, at
+> `xicli raid create`, with the engine's rejection — after `nvme_namespace` had
+> already destroyed and rebuilt every namespace. It now fails **here**, at
+> preflight, with an actionable count. That is a behavior change for any
+> three-data-drive node that previously got as far as the array create; such a
+> node was never able to complete an install, so nothing that used to work stops
+> working.
 
 ### 6.2 RAID 10 odd-count correction
 

--- a/docs/Storage/raid-management-spec.md
+++ b/docs/Storage/raid-management-spec.md
@@ -291,7 +291,9 @@ A failed validation re-prompts via the `while True:` loop until the user enters 
 
 `SelectDialog` over `_RAID_LEVELS = ["0", "1", "5", "6", "10", "50", "60"]`, pre-selecting the previously-chosen level on re-entry. xiRAID Classic accepts all seven; the TUI passes the string through to the array-create spec's `level` field.
 
-**Engine-enforced minimum drive counts (finding #20).** xiRAID Classic enforces higher minimums than textbook RAID math, and `xicli raid create --help` does not document the numbers — an under-count is rejected with e.g. `Error: To create RAID level '5', a minimum of '4' disks are required.`:
+#### Engine-enforced minimum drive counts
+
+(Finding #20; unified across surfaces by finding #4.) xiRAID Classic enforces higher minimums than textbook RAID math — an under-count is rejected with e.g. `Error: To create RAID level '5', a minimum of '4' disks are required.` This table is the **single source of truth for minimum member counts across the whole repo**: the TUI Create wizard, the control-path constraint table, and the installer's auto-generated arrays all encode these numbers and must not diverge (review finding #4).
 
 | Level | Textbook min | xiRAID min |
 |---|---|---|
@@ -302,9 +304,21 @@ A failed validation re-prompts via the `while True:` loop until the user enters 
 | 50 | 6 | **8** |
 | 60 | 6–8 | **8** |
 
-(Minimums per the installer-feedback observations; the RAID-5 value is the engine's own rejection message. They could not be re-probed live here because the engine validates device existence before drive count and no free devices were available.)
+> **Provenance and version scope.** These numbers were read off the **engine's own rejection messages** on xiRAID Classic 4.4 (the version the `xiraid_classic` role installs), *not* from `xicli raid create --help` — the help text does not document them. They are therefore **xiRAID-version-specific**: a future engine release may relax or tighten a minimum, and the table would then be wrong in the safe direction (rejecting a layout the engine would accept) or the unsafe one (passing preflight and failing at `xicli raid create`). They could not be re-probed live when recorded, because the engine validates device existence before drive count and no free devices were available. **When bumping the xiRAID version, re-confirm each minimum against the new engine before trusting this table.**
 
-The Create wizard does **not** pre-validate drive count against the chosen level — an under-count is caught by the engine only *after* the confirmation step and surfaced as a failure dialog. Pre-checking count-vs-level in the drives step before dispatch (so the operator gets an immediate, actionable message) is a tracked follow-up.
+##### Where the table is encoded
+
+| Surface | Where | Enforced at |
+|---|---|---|
+| TUI Create Array wizard | `_RAID_MIN_DRIVES` in [xinas_menu/screens/raid.py](../../xinas_menu/screens/raid.py) | drives step, before the confirmation dialog (below) |
+| Control path (API + agent) | `LEVEL_CONSTRAINTS[…].minDrives` in [xiNAS-MCP/src/lib/xiraid/schema.ts](../../xiNAS-MCP/src/lib/xiraid/schema.ts) | `validateCreateSpec` → `min_drives` blocker |
+| Installer auto-path | `nvme_raid_min_devices` in [collection/roles/nvme_namespace/defaults/main.yml](../../collection/roles/nvme_namespace/defaults/main.yml) | `generate_raid_config.yml` preflight — see [Installer/raid-spec.md §6.1](../Installer/raid-spec.md#61-capacity-checks) |
+
+##### Pre-validation in the wizard
+
+**The Create wizard pre-validates drive count against the chosen level.** After the operator finishes the drives step, the wizard compares the selection against `_RAID_MIN_DRIVES[level]` and, on an under-count, shows an OK-only dialog naming the level, the minimum, and the count actually selected (`RAID 5 needs at least 4 drives; 3 selected.`) and re-prompts the drives step rather than advancing. Previously the under-count was caught by the engine only *after* the confirmation step, so the operator paid for the whole wizard before learning the layout was impossible. A level unknown to `_RAID_MIN_DRIVES` falls back to a minimum of `2` — the wizard never blocks on a level it cannot reason about, leaving the engine as the backstop.
+
+Because `level` is chosen *before* `drives`, revising the level on a Back visit can invalidate an already-collected drive selection (e.g. `5` → `50` with 4 drives picked). The check runs on every entry into the drives step, including re-entry with a prior selection pre-checked, so the stale-selection case is caught on the way forward rather than at dispatch.
 
 Changing the level on a Back visit can flip whether `group_size` applies going forward — e.g. going from `50` back to `5` — in which case the driver prunes the now-inapplicable `group_size` answer and the wizard skips straight past it on the next advance.
 

--- a/install.MD
+++ b/install.MD
@@ -295,8 +295,8 @@ The `nvme_namespace` role auto-detects system vs. data drives and builds RAID ar
 | `nvme_skip_failed_devices` | `true` | Continue if a single device fails |
 | `nvme_cleanup_existing_storage` | `true` | Remove existing LVM/MD/ZFS on data drives |
 | `nvme_skip_cleanup_confirmation` | `false` | Skip cleanup confirmation (set `true` for automation) |
-| `nvme_min_devices_for_raid5` | `3` | Minimum drives for RAID 5 |
-| `nvme_min_devices_for_raid10` | `4` | Minimum drives for RAID 10 (must be even) |
+| `nvme_raid_min_devices` | `{0: 2, 1: 2, 5: 4, 6: 4, 10: 4, 50: 8, 60: 8}` | Engine-enforced minimum member count per RAID level (RAID 10 is additionally rounded down to an even count) |
+| `nvme_raid_min_devices_default` | `2` | Minimum for a RAID level absent from the table |
 
 #### Filesystem and Array Creation
 

--- a/presets/xinnorVM/nvme_namespace.yml
+++ b/presets/xinnorVM/nvme_namespace.yml
@@ -44,6 +44,8 @@ nvme_skip_failed_devices: true        # Continue if individual device fails
 nvme_cleanup_existing_storage: true   # Detect and remove LVM, MD RAID, ZFS on data drives
 nvme_skip_cleanup_confirmation: false  # Skip confirmation prompt (DANGEROUS - set true for automation)
 
-# Minimum device counts for RAID creation
-nvme_min_devices_for_raid5: 3         # Minimum devices for RAID 5
-nvme_min_devices_for_raid10: 4        # Minimum devices for RAID 10 (must be even)
+# Minimum member counts are NOT overridden here: they come from the
+# nvme_raid_min_devices table in the role defaults, which carries the counts the
+# xiRAID engine actually enforces (RAID 5 needs 4 members, not 3). With
+# nvme_log_drive_count: 2 and a RAID 5 data array, this preset therefore needs
+# at least 6 non-OS disks — 2 log + 4 data. See docs/Installer/raid-spec.md §6.1.

--- a/tests/test_raid_min_drives.py
+++ b/tests/test_raid_min_drives.py
@@ -1,0 +1,223 @@
+"""Minimum RAID member counts must agree across every surface.
+
+xiRAID Classic enforces stricter minimums than textbook RAID math (RAID 5 needs
+4 members, RAID 50/60 need 8). Three places encode that table independently —
+the TUI Create Array wizard, the control-path constraint table, and the
+installer's auto-generated arrays — and they disagreed until review finding #4:
+the installer and the control path both allowed a 3-drive RAID 5 that the engine
+rejects at `xicli raid create`, i.e. after the namespaces had been rebuilt.
+
+`docs/Storage/raid-management-spec.md` §4 owns the numbers. These tests pin every
+surface to that table so a future edit cannot silently re-diverge.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[1]
+SCHEMA_TS = REPO / "xiNAS-MCP/src/lib/xiraid/schema.ts"
+ROLE = REPO / "collection/roles/nvme_namespace"
+DEFAULTS = ROLE / "defaults/main.yml"
+GENERATE = ROLE / "tasks/generate_raid_config.yml"
+VM_PRESET = REPO / "presets/xinnorVM/nvme_namespace.yml"
+STORAGE_SPEC = REPO / "docs/Storage/raid-management-spec.md"
+
+# The engine-enforced table, keyed by bare level number. This literal is the
+# test's own copy on purpose: if someone relaxes a minimum they must edit this
+# file too, which makes the change visible in review.
+STRICT_MINIMUMS = {"0": 2, "1": 2, "5": 4, "6": 4, "10": 4, "50": 8, "60": 8}
+
+# Levels the strict table shares with the control path's wider level list
+# (which also carries raid7/raid70/n+m, outside the TUI + installer surface).
+TS_LEVEL_NAMES = {f"raid{level}": level for level in STRICT_MINIMUMS}
+
+
+def _ts_min_drives() -> dict[str, int]:
+    """Parse `LEVEL_CONSTRAINTS` minDrives out of schema.ts."""
+    text = SCHEMA_TS.read_text()
+    table = re.search(
+        r"LEVEL_CONSTRAINTS:\s*Record<Level,\s*LevelConstraints>\s*=\s*\{(.*?)\n\};",
+        text,
+        re.DOTALL,
+    )
+    assert table, "LEVEL_CONSTRAINTS table not found in schema.ts"
+    found = dict(
+        re.findall(r"'?([\w+]+)'?:\s*\{\s*minDrives:\s*(\d+)", table.group(1)),
+    )
+    assert found, "no minDrives entries parsed from LEVEL_CONSTRAINTS"
+    return {name: int(value) for name, value in found.items()}
+
+
+def _role_defaults() -> dict:
+    return yaml.safe_load(DEFAULTS.read_text())
+
+
+def _generate_tasks() -> list:
+    return yaml.safe_load(GENERATE.read_text())
+
+
+def _iter_tasks(tasks):
+    for task in tasks or []:
+        if not isinstance(task, dict):
+            continue
+        yield task
+        if isinstance(task.get("block"), list):
+            yield from _iter_tasks(task["block"])
+
+
+# ── TUI Create Array wizard ──────────────────────────────────────────────────
+
+
+def test_tui_table_matches_the_strict_minimums():
+    from xinas_menu.screens.raid import _RAID_LEVELS, _RAID_MIN_DRIVES
+
+    assert _RAID_MIN_DRIVES == STRICT_MINIMUMS
+    # Every level the wizard offers must have an entry, or the operator gets no
+    # pre-validation at all for that level.
+    assert set(_RAID_LEVELS) <= set(_RAID_MIN_DRIVES)
+
+
+def test_tui_rejects_under_count_and_accepts_the_minimum():
+    from xinas_menu.screens.raid import _min_drives_error
+
+    for level, minimum in STRICT_MINIMUMS.items():
+        assert _min_drives_error(level, minimum) is None, level
+        assert _min_drives_error(level, minimum + 1) is None, level
+        message = _min_drives_error(level, minimum - 1)
+        assert message is not None, f"RAID {level} accepted {minimum - 1} drives"
+        # The message has to be actionable: name the level, the floor, and the
+        # count actually selected.
+        assert f"RAID {level}" in message
+        assert str(minimum) in message
+        assert str(minimum - 1) in message
+
+
+def test_tui_rejects_the_textbook_raid5_and_raid50_counts():
+    """The exact layouts that used to sail through to the engine."""
+    from xinas_menu.screens.raid import _min_drives_error
+
+    assert _min_drives_error("5", 3) is not None
+    assert _min_drives_error("50", 6) is not None
+
+
+def test_tui_never_blocks_a_level_it_cannot_reason_about():
+    from xinas_menu.screens.raid import _min_drives_error
+
+    # Unknown level → fall back to 2 and leave the engine as the backstop,
+    # rather than blocking a layout the wizard has no opinion on.
+    assert _min_drives_error("70", 2) is None
+    assert _min_drives_error("70", 1) is not None
+
+
+# ── Control path ─────────────────────────────────────────────────────────────
+
+
+def test_control_path_table_matches_the_strict_minimums():
+    ts = _ts_min_drives()
+    for ts_name, level in TS_LEVEL_NAMES.items():
+        assert ts_name in ts, f"{ts_name} missing from LEVEL_CONSTRAINTS"
+        assert ts[ts_name] == STRICT_MINIMUMS[level], (
+            f"{ts_name} minDrives={ts[ts_name]}, strict table says {STRICT_MINIMUMS[level]}"
+        )
+
+
+# ── Installer ────────────────────────────────────────────────────────────────
+
+
+def test_role_defaults_carry_the_strict_table():
+    table = _role_defaults().get("nvme_raid_min_devices")
+    assert isinstance(table, dict), "nvme_raid_min_devices must be a level→count mapping"
+    # YAML keys parse as ints; compare on a normalised form.
+    assert {str(k): int(v) for k, v in table.items()} == STRICT_MINIMUMS
+
+
+def test_removed_scalar_knobs_are_gone_from_defaults_and_presets():
+    """The per-level scalars are what let the two surfaces drift apart."""
+    defaults = _role_defaults()
+    for removed in ("nvme_min_devices_for_raid5", "nvme_min_devices_for_raid10"):
+        assert removed not in defaults, f"{removed} still defined in role defaults"
+        assert removed not in VM_PRESET.read_text(), f"{removed} still set in the xinnorVM preset"
+
+
+def test_generate_raid_config_validates_from_the_table():
+    assert "nvme_raid_min_devices" in GENERATE.read_text()
+
+    tasks = list(_iter_tasks(_generate_tasks()))
+    facts = [t for t in tasks if "ansible.builtin.set_fact" in t]
+
+    # The removed scalars may only survive inside the deprecation guard (asserted
+    # separately below) — never in a fact expression or a `when:`.
+    live = yaml.safe_dump([t for t in tasks if "ansible.builtin.assert" not in t])
+    for removed in ("nvme_min_devices_for_raid5", "nvme_min_devices_for_raid10"):
+        assert removed not in live, f"{removed} still drives logic in generate_raid_config.yml"
+
+    def _sets(var: str) -> list[dict]:
+        return [t for t in facts if var in (t["ansible.builtin.set_fact"] or {})]
+
+    for min_var, level_var in (
+        ("_data_min_devices", "nvme_raid_data_level"),
+        ("_log_min_devices", "nvme_raid_log_level"),
+    ):
+        setters = _sets(min_var)
+        assert len(setters) == 1, f"{min_var} is set by {len(setters)} tasks; expected one"
+        expr = str(setters[0]["ansible.builtin.set_fact"][min_var])
+        assert "nvme_raid_min_devices" in expr, expr
+        assert level_var in expr, expr
+        assert "nvme_raid_min_devices_default" in expr, f"{min_var} has no fallback: {expr}"
+        assert "when" not in setters[0], f"the {min_var} lookup must not be level-gated"
+
+    for var, count_var, min_var in (
+        ("nvme_can_create_data_raid", "nvme_large_ns_count", "_data_min_devices"),
+        ("nvme_can_create_log_raid", "nvme_small_ns_count", "_log_min_devices"),
+    ):
+        setters = _sets(var)
+        assert setters, f"nothing sets {var}"
+        # Exactly one unconditional comparison — the old code had a per-level
+        # cascade of `when:`-guarded branches with a >= 2 fallback for anything
+        # it did not recognise, which is how RAID 50/60 got a 2-drive floor.
+        assert len(setters) == 1, f"{var} is set by {len(setters)} tasks; expected a single check"
+        expr = str(setters[0]["ansible.builtin.set_fact"][var])
+        assert min_var in expr, expr
+        assert count_var in expr, expr
+        assert "when" not in setters[0], f"the {var} check must not be level-gated"
+
+    # The play must still hard-fail (not just warn) when a check comes up short.
+    fails = [t for t in tasks if "ansible.builtin.fail" in t]
+    assert fails, "generate_raid_config.yml no longer fails on insufficient devices"
+
+
+def test_removed_knobs_fail_loudly_if_an_old_inventory_still_sets_them():
+    """A silently ignored override is the same class of bug as the drift itself."""
+    tasks = list(_iter_tasks(_generate_tasks()))
+    asserts = [t for t in tasks if "ansible.builtin.assert" in t]
+    assert asserts, "no deprecation guard for the removed nvme_min_devices_for_* knobs"
+    joined = yaml.safe_dump(asserts)
+    assert "nvme_min_devices_for_raid5" in joined
+    assert "nvme_min_devices_for_raid10" in joined
+
+
+# ── Spec ─────────────────────────────────────────────────────────────────────
+
+
+def test_spec_table_matches_the_code():
+    """docs/Storage/raid-management-spec.md §4 owns these numbers."""
+    text = STORAGE_SPEC.read_text()
+    section = text.split("Engine-enforced minimum drive counts", 1)
+    assert len(section) == 2, "the minimum-drive-counts section is missing"
+    body = section[1]
+
+    documented: dict[str, int] = {}
+    for row in re.finditer(r"^\|\s*([\d,\s]+?)\s*\|[^|]*\|\s*\**(\d+)\**\s*\|", body, re.MULTILINE):
+        for level in row.group(1).split(","):
+            documented[level.strip()] = int(row.group(2))
+    assert documented == STRICT_MINIMUMS, documented
+
+    # The provenance note is load-bearing: these numbers came from the engine's
+    # rejection messages on a specific xiRAID version, not from its --help.
+    assert "xiRAID-version-specific" in body
+    assert "rejection messages" in body
+    assert "xicli raid create --help" in body

--- a/xiNAS-MCP/src/__tests__/lib/xiraid/validate.test.ts
+++ b/xiNAS-MCP/src/__tests__/lib/xiraid/validate.test.ts
@@ -30,6 +30,8 @@ function facts(over: Partial<CreateFacts> = {}): CreateFacts {
       disk('d4'),
       disk('d5'),
       disk('d6'),
+      disk('d7'),
+      disk('d8'),
       disk('claimed'),
     ],
     existingArrayNames: ['taken'],
@@ -67,22 +69,47 @@ describe('validateCreateSpec', () => {
 
   it('level minimums', () => {
     expect(codes(spec({ member_disk_ids: ['d1', 'd2', 'd3'] }))).toContain('min_drives');
-    expect(codes(spec({ level: 'raid5', member_disk_ids: ['d1', 'd2', 'd3'] }))).toEqual([]);
+    expect(codes(spec({ level: 'raid5', member_disk_ids: ['d1', 'd2', 'd3', 'd4'] }))).toEqual([]);
+  });
+
+  // The engine minimums are stricter than textbook RAID math: xiRAID Classic
+  // rejects RAID 5 under 4 drives and RAID 50/60 under 8. See
+  // docs/Storage/raid-management-spec.md §4 → "Engine-enforced minimum drive
+  // counts" — the numbers there are the single source of truth for the TUI,
+  // this table, and the installer alike.
+  it('enforces the engine minimums, not the textbook ones', () => {
+    // raid5 with 3 drives is textbook-legal but rejected by the engine.
+    expect(codes(spec({ level: 'raid5', member_disk_ids: ['d1', 'd2', 'd3'] }))).toContain(
+      'min_drives',
+    );
+    // raid50 with 6 drives splits evenly into 2 groups of 3, yet is under the
+    // engine's 8-drive floor — the group_size rules alone would let it pass.
+    expect(
+      codes(
+        spec({
+          level: 'raid50',
+          member_disk_ids: ['d1', 'd2', 'd3', 'd4', 'd5', 'd6'],
+          group_size: 3,
+        }),
+      ),
+    ).toContain('min_drives');
   });
 
   it('raid50/60/70 group_size rules', () => {
-    const six = ['d1', 'd2', 'd3', 'd4', 'd5', 'd6'];
-    expect(codes(spec({ level: 'raid50', member_disk_ids: six }))).toContain('group_size_required');
-    expect(codes(spec({ level: 'raid50', member_disk_ids: six, group_size: 1 }))).toContain(
+    const eight = ['d1', 'd2', 'd3', 'd4', 'd5', 'd6', 'd7', 'd8'];
+    expect(codes(spec({ level: 'raid50', member_disk_ids: eight }))).toContain(
+      'group_size_required',
+    );
+    expect(codes(spec({ level: 'raid50', member_disk_ids: eight, group_size: 1 }))).toContain(
       'group_size_range',
     );
-    expect(codes(spec({ level: 'raid50', member_disk_ids: six, group_size: 4 }))).toContain(
+    expect(codes(spec({ level: 'raid50', member_disk_ids: eight, group_size: 3 }))).toContain(
       'members_not_divisible_by_group',
     );
-    // 6 % 3 == 0 and 6/3 = 2 groups → valid
-    expect(codes(spec({ level: 'raid50', member_disk_ids: six, group_size: 3 }))).toEqual([]);
+    // 8 % 4 == 0 and 8/4 = 2 groups → valid
+    expect(codes(spec({ level: 'raid50', member_disk_ids: eight, group_size: 4 }))).toEqual([]);
     // group_size == member count → only 1 group → compound level needs >= 2
-    expect(codes(spec({ level: 'raid50', member_disk_ids: six, group_size: 6 }))).toContain(
+    expect(codes(spec({ level: 'raid50', member_disk_ids: eight, group_size: 8 }))).toContain(
       'members_not_divisible_by_group',
     );
   });

--- a/xiNAS-MCP/src/lib/xiraid/schema.ts
+++ b/xiNAS-MCP/src/lib/xiraid/schema.ts
@@ -7,7 +7,8 @@
  *
  * Constraint sources: xiraid-analysis/api_behavior_doc.md §3.4 (param
  * ranges, group_size 2-32 required for 50/60/70, synd_cnt 4-32 for n+m,
- * >= 2 groups for compound levels) + standard per-level drive minimums.
+ * >= 2 groups for compound levels) + the engine-enforced per-level drive
+ * minimums in docs/Storage/raid-management-spec.md §4.
  */
 
 export const LEVELS = [
@@ -68,14 +69,27 @@ export interface LevelConstraints {
   needsSyndCnt: boolean;
 }
 
+/**
+ * `minDrives` is what the **engine** enforces, not textbook RAID math: xiRAID
+ * Classic rejects RAID 5 under 4 drives (`Error: To create RAID level '5', a
+ * minimum of '4' disks are required.`) and RAID 50/60 under 8. The numbers were
+ * read off those rejection messages on xiRAID Classic 4.4 — `xicli raid create
+ * --help` does not document them — so they are version-specific and must be
+ * re-confirmed when the engine version moves.
+ *
+ * docs/Storage/raid-management-spec.md §4 owns the table; the TUI Create Array
+ * wizard (`_RAID_MIN_DRIVES` in xinas_menu/screens/raid.py) and the installer
+ * (`nvme_raid_min_devices` in collection/roles/nvme_namespace/defaults/main.yml)
+ * carry the same values. Changing one without the others is review finding #4.
+ */
 export const LEVEL_CONSTRAINTS: Record<Level, LevelConstraints> = {
   raid0: { minDrives: 2, needsGroupSize: false, needsSyndCnt: false },
   raid1: { minDrives: 2, needsGroupSize: false, needsSyndCnt: false },
-  raid5: { minDrives: 3, needsGroupSize: false, needsSyndCnt: false },
+  raid5: { minDrives: 4, needsGroupSize: false, needsSyndCnt: false },
   raid6: { minDrives: 4, needsGroupSize: false, needsSyndCnt: false },
   raid7: { minDrives: 4, needsGroupSize: false, needsSyndCnt: false },
   raid10: { minDrives: 4, needsGroupSize: false, needsSyndCnt: false },
-  raid50: { minDrives: 6, needsGroupSize: true, needsSyndCnt: false },
+  raid50: { minDrives: 8, needsGroupSize: true, needsSyndCnt: false },
   raid60: { minDrives: 8, needsGroupSize: true, needsSyndCnt: false },
   raid70: { minDrives: 8, needsGroupSize: true, needsSyndCnt: false },
   'n+m': { minDrives: 4, needsGroupSize: false, needsSyndCnt: true },

--- a/xinas_menu/screens/raid.py
+++ b/xinas_menu/screens/raid.py
@@ -48,6 +48,17 @@ from xinas_menu.widgets.wizard import BACK, CANCEL, WizardStep, run_wizard
 _ARRAY_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 _RAID_LEVELS = ["0", "1", "5", "6", "10", "50", "60"]
 _STRIP_SIZES = ["16", "32", "64", "128", "256"]
+# Minimum member count per RAID level, as enforced by the xiRAID engine — not
+# textbook RAID math. RAID 5 wants 4 (not 3) and RAID 50/60 want 8 (not 6);
+# an under-count is rejected by `xicli raid create` with e.g. "To create RAID
+# level '5', a minimum of '4' disks are required." Read off the engine's own
+# rejection messages on xiRAID Classic 4.4, so re-confirm on a version bump.
+# docs/Storage/raid-management-spec.md §4 owns this table; LEVEL_CONSTRAINTS in
+# xiNAS-MCP/src/lib/xiraid/schema.ts and nvme_raid_min_devices in
+# collection/roles/nvme_namespace/defaults/main.yml carry the same values.
+_RAID_MIN_DRIVES = {"0": 2, "1": 2, "5": 4, "6": 4, "10": 4, "50": 8, "60": 8}
+# A level we have no entry for is left to the engine rather than blocked here.
+_RAID_MIN_DRIVES_FALLBACK = 2
 _CPU_LIST_RE = re.compile(r"^\d+(-\d+)?(,\d+(-\d+)?)*$")
 # Live-modify surface = the ADR-0006 writability matrix: spare_disk_ids
 # (the "sparepool" entry) + tuning.* keys. resync_enabled is create-only
@@ -89,6 +100,22 @@ def _fmt_size(size_bytes: float) -> str:
             return f"{size_bytes:.1f} {unit}" if unit != "B" else f"{size_bytes} B"
         size_bytes /= 1024
     return f"{size_bytes:.1f} EB"
+
+
+def _min_drives_error(level: str, count: int) -> str | None:
+    """Return an operator-facing message when `count` is under the level's floor.
+
+    Returns ``None`` when the selection is acceptable. Catching the under-count
+    here means the operator hears about it in the drives step rather than after
+    the confirmation dialog, when the engine rejects the create.
+    """
+    minimum = _RAID_MIN_DRIVES.get(str(level), _RAID_MIN_DRIVES_FALLBACK)
+    if count >= minimum:
+        return None
+    return (
+        f"RAID {level} needs at least {minimum} drives; {count} selected.\n\n"
+        "Select more drives, or go back and pick a different RAID level."
+    )
 
 
 def _numa_node(name: str) -> int:
@@ -502,22 +529,40 @@ class RAIDScreen(XiNASAppMixin, Screen):
             return pick
 
         async def drives_step(answers, allow_back, step_no):
+            level = answers.get("level", "")
+
+            async def enough_drives(selected) -> bool:
+                """Pre-validate count vs level so the engine isn't the first to say no."""
+                message = _min_drives_error(level, len(selected))
+                if message is None:
+                    return True
+                await self.app.push_screen_wait(
+                    ConfirmDialog(message, "Not enough drives", ok_only=True)
+                )
+                return False
+
             prior = answers.get("drives")
             if prior:
                 # Re-entry: jump straight to the picker with the prior selection.
-                selected = await self.app.push_screen_wait(
-                    DrivePickerScreen(
-                        nvme,
-                        title="Create Array — Select Drives",
-                        preselected=prior,
-                        allow_back=allow_back,
+                # Looped, because a Back visit may have changed the level and
+                # left the prior selection under the new level's floor.
+                while True:
+                    selected = await self.app.push_screen_wait(
+                        DrivePickerScreen(
+                            nvme,
+                            title="Create Array — Select Drives",
+                            preselected=prior,
+                            allow_back=allow_back,
+                        )
                     )
-                )
-                if selected is None:
-                    return CANCEL
-                if selected is BACK:
-                    return BACK
-                return selected
+                    if selected is None:
+                        return CANCEL
+                    if selected is BACK:
+                        return BACK
+                    if not await enough_drives(selected):
+                        prior = selected
+                        continue
+                    return selected
             while True:
                 choices = list(groups.keys()) + ["Pick individual drives"]
                 group_choice = await self.app.push_screen_wait(
@@ -562,6 +607,8 @@ class RAIDScreen(XiNASAppMixin, Screen):
                     await self.app.push_screen_wait(
                         ConfirmDialog("No drives selected.", "Error", ok_only=True)
                     )
+                    continue
+                if not await enough_drives(selected):
                     continue
                 return selected
 


### PR DESCRIPTION
Review finding #4 (P1). xiRAID Classic requires **4** members for RAID 5 and **8** for RAID 50/60, but the three surfaces that encode those minimums each disagreed:

| Surface | RAID 5 | RAID 50/60 |
|---|---|---|
| Installer (`nvme_namespace`) | 3 | 2 (fell through the `>= 2` catch-all) |
| Control path (`schema.ts`) | 3 | 6 / 8 |
| TUI Create Array wizard | no check | no check |

So an under-count passed preflight and failed later at `xicli raid create` — in the installer's case **after** `nvme_namespace` had already destroyed and rebuilt every namespace, and in the TUI's case only after the operator had walked the whole wizard through its confirmation step.

Per the maintainer's decision, this hardwires the strict numbers from [`docs/Storage/raid-management-spec.md` §4](../blob/claude/cranky-napier-a477e3/docs/Storage/raid-management-spec.md) rather than waiting on a live probe.

## Changes

- **`schema.ts`** — `raid5` 3 → 4, `raid50` 6 → 8. `validate.ts` consumes `LEVEL_CONSTRAINTS` unchanged.
- **`xinas_menu/screens/raid.py`** — new `_RAID_MIN_DRIVES` + `_min_drives_error()`, wired into **both** entry paths of the wizard's drives step. Re-entry is included and looped, since a Back visit can change the level out from under an existing selection. An unknown level falls back to 2, leaving the engine as the backstop rather than blocking a layout the wizard has no opinion on.
- **`nvme_namespace`** — the `nvme_min_devices_for_raid5` / `_raid10` scalars are replaced by a single `nvme_raid_min_devices` level→count table, and the per-level `when:` cascade collapses to one lookup. That cascade's `>= 2` catch-all is what silently gave RAID 50/60 a 2-drive floor. The removed knobs now **fail the play explicitly** rather than being silently ignored — a dead override is the same class of bug as the divergence itself.
- **Specs** — `raid-management-spec.md` §4 becomes the named, repo-wide authoritative table and lists the three code sites that encode it; `raid-spec.md` §1.1 and §6.1 are updated.

## Behavior change to flag

**This tightens the default preset.** The VM auto-path minimum rises from **5** non-OS disks to **6** (2 log + 4 data), and a node with three data namespaces now fails at *preflight* instead of mid-install. Such a node could never complete an install, so nothing that used to work stops working — it just fails earlier, before any namespace or array work, and with an actionable count. Called out in `raid-spec.md` §1.1 and §6.1.

## Provenance of the numbers

Recorded in the spec, as requested: these are **xiRAID-version-specific** and were read off the engine's own rejection messages on xiRAID Classic 4.4 (`Error: To create RAID level '5', a minimum of '4' disks are required.`) — **not** from `xicli raid create --help`, which does not document them. The spec carries an explicit instruction to re-confirm each minimum when the engine version moves.

## Tests

TDD throughout — the tests were written red first.

- New `tests/test_raid_min_drives.py` (10 tests) pins the TUI table, the control-path table, the role defaults, the `generate_raid_config.yml` structure, the deprecation guard, **and the spec's own markdown table** to the same numbers, so a future edit cannot silently re-diverge.
- `validate.test.ts`: the case asserting `raid5` × 3 drives produced *no blockers* is flipped, plus a new case covering `raid50` × 6 (which splits evenly into 2 groups of 3 and would otherwise pass the group-size rules).

Beyond the test suites, the Jinja lookup was exercised under real Ansible across 11 cases — string vs. int levels, both regressions, and the unknown-level fallback — and the deprecation guard was confirmed to fire on `-e nvme_min_devices_for_raid5=3`.

Full sweep green: 645 pytest, 1422 vitest, 8 contract tests, ruff, pyright, ansible-lint, yamllint, markdownlint.

## Note

`docs/plans/2026-07-05-nvme-vm-fallback-{plan,design}.md` still say 5 non-OS disks. Left deliberately — `docs/plans/` is append-only per CLAUDE.md; the live spec is the source of truth.

`Requires-Rebuild: xinas_node_build` is on the commit — `xinas-api`/`xinas-agent` run compiled JS from the untracked `dist/`, so a release-tag checkout alone would never deliver the new minimums to the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
