### PR TITLE
fix(nvme_namespace): MATCH requires the arrays to be online

### DIFF
--- a/collection/roles/nvme_namespace/README.md
+++ b/collection/roles/nvme_namespace/README.md
@@ -102,7 +102,9 @@ array) a re-run **converges** — namespaces are reused, nothing is destroyed. N
 deleted and recreated only on a fresh box (**EMPTY**) or when the operator sets
 `xinas_storage_reset: true` (guarded by an interactive `YES`, bypassable for automation
 with `nvme_skip_cleanup_confirmation: true`). A **FOREIGN** layout fails fast rather than
-being wiped. The legacy `nvme_use_existing_namespaces` knob is deprecated. See
+being wiped. MATCH requires the arrays to report themselves **online** (`xicli raid show`
+state words) — a degraded or rebuilding array is not a MATCH, and fails with a repair-first
+message rather than the generic "wipe and rebuild" remedy. The legacy `nvme_use_existing_namespaces` knob is deprecated. See
 [docs/Installer/raid-spec.md](../../../docs/Installer/raid-spec.md) §11.
 
 ## Warning

--- a/collection/roles/nvme_namespace/tasks/detect_storage_state.yml
+++ b/collection/roles/nvme_namespace/tasks/detect_storage_state.yml
@@ -4,12 +4,24 @@
 #   EMPTY   - no xiRAID arrays and no XFS/foreign signature on /dev/xi_data
 #   FOREIGN - some xiRAID/fs signature exists but does not match the expected layout
 #
+# "Online" is read out of the daemon's own per-array `state` words — it is not
+# inferred from the array merely existing. A degraded, offline, initializing or
+# state-less `data`/`log` array is therefore NOT a MATCH; with arrays present it
+# lands in FOREIGN, which fails fast without touching anything. §4.2 of
+# docs/Installer/raid-spec.md leans on that: a genuine MATCH implies a healthy
+# `data` array, and that array is built from the n2 namespaces.
+#
 # Idempotent and side-effect-free: safe to run before any decision, at either role.
 # raid_fs reuses this via include_role (guarded on xinas_storage_state undefined).
 
 - name: Determine the wanted XFS label
   ansible.builtin.set_fact:
     xfs_label_wanted: "{{ (xfs_filesystems | default([{}]) | first).label | default('nfsdata') }}"
+    # Per-array state words that count as "online". Same allowlist the TUI
+    # health engine's raid_status check applies (xinas_menu/health/engine.py).
+    _ssd_online_states:
+      - online
+      - initialized
 
 - name: Probe existing xiRAID arrays (read-only)
   ansible.builtin.command: xicli raid show -f json
@@ -30,6 +42,49 @@
       {{ (_ssd_parsed.keys() | list) if (_ssd_parsed is mapping)
          else ((_ssd_parsed | map(attribute='name') | list)
                if (_ssd_parsed is iterable and _ssd_parsed is not string) else []) }}
+    # Per-array records, positionally aligned with _ssd_array_names. Both
+    # shapes carry the state words at the record's top level: the mapping shape
+    # (name -> record) is what xicli emits, the list-of-records shape is what
+    # some releases / the fake transport emit.
+    _ssd_array_records: >-
+      {{ (_ssd_parsed.values() | list) if (_ssd_parsed is mapping)
+         else ((_ssd_parsed | list)
+               if (_ssd_parsed is iterable and _ssd_parsed is not string) else []) }}
+
+- name: Map each array name to the state words xiRAID reported for it
+  ansible.builtin.set_fact:
+    _ssd_array_states: >-
+      {{ dict(_ssd_array_names
+              | zip(_ssd_array_records | map(attribute='state', default=[]) | list)) }}
+
+- name: Reduce the expected arrays' state words to a comparable form
+  ansible.builtin.set_fact:
+    # flatten tolerates the bare-string spelling ("online") next to the list
+    # spelling (["online", "initialized"]); a missing state yields [].
+    _ssd_data_states: >-
+      {{ [_ssd_array_states.get('data', [])] | flatten | map('string') | map('lower') | list }}
+    _ssd_log_states: >-
+      {{ [_ssd_array_states.get('log', [])] | flatten | map('string') | map('lower') | list }}
+
+- name: Decide whether the expected arrays are online
+  ansible.builtin.set_fact:
+    # Fail closed: an array that reported no state at all is not online.
+    _ssd_arrays_online: >-
+      {{ (_ssd_data_states | length) > 0
+         and (_ssd_log_states | length) > 0
+         and (((_ssd_data_states + _ssd_log_states)
+               | reject('in', _ssd_online_states) | list | length) == 0) }}
+
+- name: Export why an existing layout may not be a MATCH
+  ansible.builtin.set_fact:
+    # Both expected arrays are there, but at least one is not online: a
+    # repairable condition, NOT a foreign layout to wipe. The FOREIGN failure
+    # in nvme_namespace/raid_fs keys off this to give the right remedy —
+    # "repair / let the rebuild finish", not "set xinas_storage_reset".
+    xinas_storage_arrays_unhealthy: >-
+      {{ ('data' in _ssd_array_names) and ('log' in _ssd_array_names)
+         and (not (_ssd_arrays_online | bool)) }}
+    xinas_storage_array_states: "{{ _ssd_array_states }}"
 
 - name: Probe filesystem type on /dev/xi_data (read-only)
   ansible.builtin.command: blkid -s TYPE -o value /dev/xi_data
@@ -49,6 +104,7 @@
       {{
         'MATCH'
         if (('data' in _ssd_array_names) and ('log' in _ssd_array_names)
+            and (_ssd_arrays_online | bool)
             and ((_ssd_fstype.stdout | default('') | trim) == 'xfs')
             and ((_ssd_fslabel.stdout | default('') | trim) == xfs_label_wanted))
         else ('EMPTY'
@@ -61,5 +117,6 @@
   ansible.builtin.debug:
     msg: >-
       Storage state = {{ xinas_storage_state }}
-      (arrays={{ _ssd_array_names }}, fstype='{{ _ssd_fstype.stdout | default('') | trim }}',
+      (arrays={{ _ssd_array_states }}, online={{ _ssd_arrays_online }},
+      fstype='{{ _ssd_fstype.stdout | default('') | trim }}',
       label='{{ _ssd_fslabel.stdout | default('') | trim }}', wanted='{{ xfs_label_wanted }}')

--- a/collection/roles/nvme_namespace/tasks/main.yml
+++ b/collection/roles/nvme_namespace/tasks/main.yml
@@ -22,6 +22,19 @@
     - name: Detect current storage state
       ansible.builtin.include_tasks: detect_storage_state.yml
 
+    - name: Fail fast on an existing xiNAS layout whose arrays are not online
+      ansible.builtin.fail:
+        msg: >-
+          The expected xiNAS arrays exist but are not online
+          (states={{ xinas_storage_array_states | default({}) }}). Refusing to
+          touch the storage. Repair the array — or let a rebuild finish — and
+          re-run; a healthy array converges. Do NOT set xinas_storage_reset to
+          get past this: it would destroy the data on a recoverable array.
+      when:
+        - (xinas_storage_state | default('EMPTY')) == 'FOREIGN'
+        - xinas_storage_arrays_unhealthy | default(false) | bool
+        - not (xinas_storage_reset | default(false) | bool)
+
     - name: Fail fast on unexpected existing storage (FOREIGN)
       ansible.builtin.fail:
         msg: >-

--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -56,6 +56,20 @@
     - not (xinas_storage_reset_confirmed | default(false) | bool)
   tags: [raid_fs, raid, fs]
 
+- name: Fail fast on an existing xiNAS layout whose arrays are not online (raid_fs layer)
+  ansible.builtin.fail:
+    msg: >-
+      The expected xiNAS arrays exist but are not online
+      (states={{ xinas_storage_array_states | default({}) }}). Refusing to run
+      drive-clean / mkfs. Repair the array — or let a rebuild finish — and
+      re-run; a healthy array converges. Do NOT set xinas_storage_reset to get
+      past this: it would destroy the data on a recoverable array.
+  when:
+    - (xinas_storage_state | default('EMPTY')) == 'FOREIGN'
+    - xinas_storage_arrays_unhealthy | default(false) | bool
+    - not (xinas_storage_reset | default(false) | bool)
+  tags: [raid_fs, raid, fs]
+
 - name: Fail fast on unexpected existing storage (FOREIGN, raid_fs layer)
   ansible.builtin.fail:
     msg: >-

--- a/docs/Installer/raid-spec.md
+++ b/docs/Installer/raid-spec.md
@@ -171,7 +171,7 @@ the role reuses the namespaces already on the drives — no rebuild, no data los
 - `ls /dev/<ctrl>n*` per data drive.
 - `n1` → log devices (`nvme_small_ns_devices`).
 - `n2`–`n9` (and `n10+`) → data devices (`nvme_large_ns_devices`).
-- Requirement: existing-namespace reuse needs the n1 (log) + n2 (data) two-namespace layout on every data drive. If **no** `n2+` were found anywhere, the task fails explicitly ("Fail on single-namespace layout") naming the remedy — re-run with `xinas_storage_reset: true` to wipe and rebuild the two-namespace layout, or provision it manually. The per-tier detection banner is printed before this check, so the failure path shows which devices were classified n1. A single-namespace layout can never legitimately reach this task on a healthy converge: `MATCH` requires the `data` xiRAID array online **and** `/dev/xi_data` probing as XFS with the configured label (§11), and that array is built from `n2` devices (§6.4) — so a genuine MATCH implies `n2+` namespaces exist, and the only way to trip this fail is a layout tampered with outside the role.
+- Requirement: existing-namespace reuse needs the n1 (log) + n2 (data) two-namespace layout on every data drive. If **no** `n2+` were found anywhere, the task fails explicitly ("Fail on single-namespace layout") naming the remedy — re-run with `xinas_storage_reset: true` to wipe and rebuild the two-namespace layout, or provision it manually. The per-tier detection banner is printed before this check, so the failure path shows which devices were classified n1. A single-namespace layout can never legitimately reach this task on a healthy converge: `MATCH` requires the `data` xiRAID array to report itself online — read out of the daemon's own per-array `state` words, not inferred from the array existing (§11) — **and** `/dev/xi_data` probing as XFS with the configured label, and that array is built from `n2` devices (§6.4) — so a genuine MATCH implies `n2+` namespaces exist, and the only way to trip this fail is a layout tampered with outside the role.
 
 **EMPTY** (a fresh box, including a factory single-`n1` drive) or an explicit
 `xinas_storage_reset: true` falls through to the delete+recreate path in §4.3. **FOREIGN**
@@ -544,6 +544,30 @@ Formatting happens only on a genuinely fresh box, or under an explicit, confirme
 | **MATCH** | xiRAID `data`+`log` online **and** `/dev/xi_data` is XFS with the configured label | **converge** — every destructive op is skipped |
 | **EMPTY** | no xiRAID arrays and no fs signature on `/dev/xi_data` (incl. a factory single-`n1` drive) | provision as a first install |
 | **FOREIGN** | some array/fs signature exists but doesn't match the expected layout | **fail fast** before any wipe |
+
+**"Online" is read from the daemon, not inferred from the array existing.**
+`xicli raid show -f json` reports per-array `state` words; an array counts as
+online only when it reported at least one word and **every** word is `online` or
+`initialized` — the same allowlist the TUI health engine's `raid_status` check
+applies. So a `degraded`, `offline`, `initializing` or reconstructing array — or
+one whose record carries no `state` at all — is **not** a MATCH: with arrays
+present it classifies FOREIGN, and the run fails fast without touching anything.
+Both payload shapes are read (the `name → record` mapping xicli emits, and the
+list-of-records shape), and both the list (`["online", "initialized"]`) and bare
+string (`"online"`) spellings of `state` are accepted, case-insensitively.
+Pinned by [tests/test_storage_state_fail_closed.py](../../tests/test_storage_state_fail_closed.py),
+which replays the classifier's `set_fact` chain against synthetic probe output.
+
+**An unhealthy array is not a foreign layout.** FOREIGN's generic remedy is
+"set `xinas_storage_reset=true` to wipe and rebuild" — the wrong advice for a
+degraded or rebuilding array, which is recoverable. When both expected arrays
+are present but at least one is not online, the classifier sets
+`xinas_storage_arrays_unhealthy` (with `xinas_storage_array_states` for the
+detail), and **both** `nvme_namespace` and `raid_fs` fail *before* the generic
+FOREIGN failure with the right remedy: repair the array or let the rebuild
+finish, then re-run — a healthy array converges. An operator who really does
+want to wipe a degraded array can still do so with an explicit
+`xinas_storage_reset` (which keeps its `YES` gate).
 
 **Single control.** `xinas_storage_reset` (default `false`) is the only operator switch
 for destruction. The legacy `xfs_force_mkfs` and `nvme_use_existing_namespaces` knobs are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dev = [
   "ruff>=0.6.0",
   "pytest>=8.0",
   "pytest-cov>=5.0",
+  # tests/test_storage_state_fail_closed.py replays an Ansible set_fact chain
+  # through Jinja; ansible ships it on the host, CI needs it explicitly.
+  "jinja2>=3.0",
   # TUI runtime deps, mirrored from collection/roles/xinas_menu/tasks/main.yml
   # (the deployment venv) and install.sh so pyright/tests resolve the same
   # versions CI ships. Keep the pins in sync across all three. textual is

--- a/tests/test_storage_state_fail_closed.py
+++ b/tests/test_storage_state_fail_closed.py
@@ -1,0 +1,357 @@
+"""Behavioral guard for the storage-state classifier (raid-spec.md §11).
+
+`nvme_namespace/tasks/detect_storage_state.yml` is the read-only preflight that
+decides whether a `site.yml` re-run converges (MATCH) or refuses to touch the
+box (FOREIGN). Structural assertions over the task YAML cannot catch a wrong
+*classification*, so this module replays the file's `set_fact` chain through
+Jinja against synthetic probe output and asserts on the resulting
+`xinas_storage_state`.
+
+The bug this pins: MATCH used to mean nothing more than "the names 'data' and
+'log' appear in `xicli raid show -f json`", so a degraded or offline array
+classified as MATCH even though §11 and §4.2 both promise MATCH implies
+*online*. §4.2 leans on that promise when it argues a single-namespace layout
+can never legitimately reach the reuse path.
+
+The replay mirrors Ansible's semantics closely enough for this file:
+
+* every `ansible.builtin.set_fact` in the file is rendered in order;
+* keys of one `set_fact` task are rendered against a snapshot taken *before*
+  the task, because Ansible does not expose sibling keys to each other;
+* templates are rendered with a native environment, so `{{ [...] }}` yields a
+  real list, not its `str()`.
+
+The handful of Ansible-only filters the file uses are re-implemented here.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+jinja2 = pytest.importorskip("jinja2")
+from jinja2 import ChainableUndefined  # noqa: E402
+from jinja2.nativetypes import NativeEnvironment  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[1]
+TASK_FILE = REPO / "collection/roles/nvme_namespace/tasks/detect_storage_state.yml"
+
+SET_FACT = "ansible.builtin.set_fact"
+
+
+# --- the Ansible filters the task file leans on ----------------------------
+
+
+def _flatten(value: Any) -> list:
+    out: list = []
+    for item in value if isinstance(value, list) else [value]:
+        if isinstance(item, list):
+            out.extend(_flatten(item))
+        else:
+            out.append(item)
+    return out
+
+
+def _bool(value: Any) -> bool:
+    """`ansible.builtin.bool`: tolerant of the string spellings Ansible stores."""
+    if isinstance(value, str):
+        return value.strip().lower() in ("true", "yes", "on", "1")
+    return bool(value)
+
+
+def _env() -> Any:
+    env = NativeEnvironment(undefined=ChainableUndefined)
+    env.filters["from_json"] = json.loads
+    env.filters["flatten"] = _flatten
+    env.filters["zip"] = lambda a, *rest: list(zip(a, *rest, strict=False))
+    env.filters["bool"] = _bool
+    return env
+
+
+ENV = _env()
+
+
+# --- the replay ------------------------------------------------------------
+
+
+def _render(expr: Any, context: dict) -> Any:
+    if not isinstance(expr, str):
+        return expr
+    return ENV.from_string(expr).render(**context)
+
+
+def _set_fact_tasks() -> list[dict]:
+    tasks = yaml.safe_load(TASK_FILE.read_text())
+    out = []
+    for task in tasks:
+        if SET_FACT not in task:
+            continue
+        # The replay has no notion of conditionals or loops. If the file grows
+        # one, fail loudly here rather than silently diverging from Ansible.
+        unsupported = {k for k in ("when", "loop", "with_items") if k in task}
+        assert not unsupported, f"replay cannot model {unsupported} on {task.get('name')!r}"
+        out.append(task)
+    assert out, "no set_fact tasks found — did the file move?"
+    return out
+
+
+def replay(
+    raid_show: Any,
+    *,
+    fstype: str = "xfs",
+    fslabel: str = "nfsdata",
+    raid_rc: int = 0,
+    wanted_label: str = "nfsdata",
+) -> dict:
+    """Replay the classifier against synthetic probe output, returning its facts.
+
+    `raid_show` is the parsed payload `xicli raid show -f json` would print
+    (serialized back to JSON for the replay), or a raw string for malformed
+    output.
+    """
+    stdout = raid_show if isinstance(raid_show, str) else json.dumps(raid_show)
+    context: dict[str, Any] = {
+        "xfs_filesystems": [{"label": wanted_label}],
+        "_ssd_raid_show": {"rc": raid_rc, "stdout": stdout},
+        "_ssd_fstype": {"rc": 0, "stdout": fstype},
+        "_ssd_fslabel": {"rc": 0, "stdout": fslabel},
+    }
+    for task in _set_fact_tasks():
+        snapshot = dict(context)
+        for key, expr in task[SET_FACT].items():
+            context[key] = _render(expr, snapshot)
+    return context
+
+
+def classify(raid_show: Any, **kwargs: Any) -> str:
+    state = replay(raid_show, **kwargs).get("xinas_storage_state")
+    assert isinstance(state, str), f"classifier produced {state!r}"
+    return state
+
+
+# --- payload builders ------------------------------------------------------
+
+ONLINE = ["online", "initialized"]
+
+
+def mapping_payload(data_state: Any = ONLINE, log_state: Any = ONLINE, **extra: Any) -> dict:
+    """The shape xicli emits on a real node: name -> record."""
+    payload: dict[str, Any] = {
+        "data": {"level": "5", "devices": [], "state": data_state},
+        "log": {"level": "10", "devices": [], "state": log_state},
+    }
+    for name, state in extra.items():
+        payload[name] = {"level": "0", "devices": [], "state": state}
+    for record in payload.values():
+        if record["state"] is None:
+            del record["state"]
+    return payload
+
+
+def list_payload(data_state: Any = ONLINE, log_state: Any = ONLINE) -> list:
+    """The list-of-records shape other releases / the fake transport emit."""
+    return [
+        {"name": "data", "level": "5", "devices": [], "state": data_state},
+        {"name": "log", "level": "10", "devices": [], "state": log_state},
+    ]
+
+
+# --- MATCH requires online (the finding) -----------------------------------
+
+
+def test_healthy_arrays_match():
+    assert classify(mapping_payload()) == "MATCH"
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        ["degraded"],
+        ["offline"],
+        ["degraded", "reconstructing"],
+        ["online", "initializing"],
+        ["need_recon"],
+        ["broken"],
+    ],
+    ids=["degraded", "offline", "reconstructing", "initializing", "need_recon", "broken"],
+)
+def test_unhealthy_data_array_is_not_match(state):
+    """An array that is not online must never reach the converge path."""
+    assert classify(mapping_payload(data_state=state)) == "FOREIGN"
+
+
+@pytest.mark.parametrize("state", [["degraded"], ["offline"]], ids=["degraded", "offline"])
+def test_unhealthy_log_array_is_not_match(state):
+    assert classify(mapping_payload(log_state=state)) == "FOREIGN"
+
+
+def test_missing_state_field_is_not_match():
+    """Fail closed: a record with no `state` at all is not evidence of health."""
+    assert classify(mapping_payload(data_state=None)) == "FOREIGN"
+    assert classify(mapping_payload(log_state=None)) == "FOREIGN"
+
+
+def test_empty_state_list_is_not_match():
+    assert classify(mapping_payload(data_state=[])) == "FOREIGN"
+
+
+def test_unhealthy_array_survives_a_matching_filesystem():
+    """The XFS signature on /dev/xi_data must not vouch for the array."""
+    assert classify(mapping_payload(data_state=["degraded"]), fstype="xfs", fslabel="nfsdata") == (
+        "FOREIGN"
+    )
+
+
+# --- tolerated spellings ---------------------------------------------------
+
+
+def test_bare_string_state_is_tolerated():
+    """Some releases emit `"state": "online"` rather than a list."""
+    assert classify(mapping_payload(data_state="online", log_state="online")) == "MATCH"
+    assert classify(mapping_payload(data_state="degraded")) == "FOREIGN"
+
+
+def test_state_words_are_case_insensitive():
+    assert classify(mapping_payload(data_state=["ONLINE"], log_state=["Online"])) == "MATCH"
+
+
+def test_list_shape_payload_is_classified_the_same():
+    assert classify(list_payload()) == "MATCH"
+    assert classify(list_payload(data_state=["degraded"])) == "FOREIGN"
+    assert classify(list_payload(log_state=["offline"])) == "FOREIGN"
+
+
+def test_extra_healthy_array_does_not_block_match():
+    assert classify(mapping_payload(scratch=ONLINE)) == "MATCH"
+
+
+# --- the other states must not regress -------------------------------------
+
+
+def test_fresh_box_is_empty():
+    assert classify({}, fstype="", fslabel="") == "EMPTY"
+
+
+def test_missing_expected_array_is_foreign():
+    assert classify({"data": {"state": ONLINE}}) == "FOREIGN"
+    assert classify({"tank": {"state": ONLINE}}) == "FOREIGN"
+
+
+def test_wrong_filesystem_or_label_is_foreign():
+    assert classify(mapping_payload(), fstype="ext4") == "FOREIGN"
+    assert classify(mapping_payload(), fslabel="someone-elses") == "FOREIGN"
+
+
+def test_label_comes_from_the_configured_filesystem():
+    assert classify(mapping_payload(), fslabel="tank", wanted_label="tank") == "MATCH"
+    assert classify(mapping_payload(), fslabel="nfsdata", wanted_label="tank") == "FOREIGN"
+
+
+# --- probes that cannot answer never win MATCH -----------------------------
+#
+# The classifier may resolve an unanswerable probe to UNKNOWN, which outranks
+# every other state. These assertions hold either way: what must never happen
+# is a probe failure resolving to MATCH.
+
+
+def test_failed_raid_probe_never_matches():
+    assert classify({}, raid_rc=1) != "MATCH"
+    assert classify("", raid_rc=1) != "MATCH"
+
+
+def test_unparsable_raid_output_never_matches():
+    """Malformed JSON with rc=0 must not converge — erroring out is fine too.
+
+    Today the `from_json` in the parse step raises, which fails the task and
+    stops the play before anything destructive runs. That is a valid outcome;
+    resolving to MATCH is not.
+    """
+    try:
+        state = classify("not json at all", raid_rc=0)
+    except Exception:  # noqa: BLE001 - the play failing is an accepted outcome
+        return
+    assert state != "MATCH"
+
+
+def test_junk_array_record_never_matches():
+    assert classify({"data": "junk", "log": "junk"}) != "MATCH"
+    assert classify(["junk", "junk"]) != "MATCH"
+
+
+# --- an unhealthy array must not be reported as a foreign layout -----------
+#
+# A degraded array lands in FOREIGN, whose generic remedy is "set
+# xinas_storage_reset=true to wipe and rebuild" — advice that would destroy a
+# recoverable array. The classifier flags the case so both roles can fail with
+# the right remedy instead.
+
+
+def test_unhealthy_arrays_are_flagged_for_the_failure_message():
+    facts = replay(mapping_payload(data_state=["degraded"]))
+    assert facts["xinas_storage_state"] == "FOREIGN"
+    assert facts["xinas_storage_arrays_unhealthy"] is True
+    assert facts["xinas_storage_array_states"]["data"] == ["degraded"]
+
+
+def test_a_genuinely_foreign_layout_is_not_flagged_as_unhealthy():
+    assert replay({"tank": {"state": ONLINE}})["xinas_storage_arrays_unhealthy"] is False
+    assert replay(mapping_payload(), fstype="ext4")["xinas_storage_arrays_unhealthy"] is False
+    assert replay({}, fstype="", fslabel="")["xinas_storage_arrays_unhealthy"] is False
+
+
+UNHEALTHY_FAIL = "Fail fast on an existing xiNAS layout whose arrays are not online"
+FOREIGN_FAIL = "Fail fast on unexpected existing storage (FOREIGN"
+
+
+def _tasks_of(role_task_file: str) -> list[dict]:
+    """Every task in a role file, recursing into `block:` bodies."""
+    out: list[dict] = []
+
+    def walk(tasks):
+        for task in tasks or []:
+            if not isinstance(task, dict):
+                continue
+            out.append(task)
+            if isinstance(task.get("block"), list):
+                walk(task["block"])
+
+    walk(yaml.safe_load((REPO / role_task_file).read_text()))
+    return out
+
+
+@pytest.mark.parametrize(
+    "role_task_file",
+    [
+        "collection/roles/nvme_namespace/tasks/main.yml",
+        "collection/roles/raid_fs/tasks/main.yml",
+    ],
+)
+def test_unhealthy_array_failure_precedes_and_outranks_the_foreign_failure(role_task_file):
+    names = [str(t.get("name", "")) for t in _tasks_of(role_task_file)]
+    unhealthy = [i for i, n in enumerate(names) if n.startswith(UNHEALTHY_FAIL)]
+    foreign = [i for i, n in enumerate(names) if n.startswith(FOREIGN_FAIL)]
+    assert unhealthy, f"{role_task_file} has no unhealthy-array failure"
+    assert foreign, f"{role_task_file} has no FOREIGN failure"
+    assert unhealthy[0] < foreign[0], "the specific message must win over the generic one"
+
+
+@pytest.mark.parametrize(
+    "role_task_file",
+    [
+        "collection/roles/nvme_namespace/tasks/main.yml",
+        "collection/roles/raid_fs/tasks/main.yml",
+    ],
+)
+def test_unhealthy_array_failure_does_not_advise_a_reset(role_task_file):
+    task = next(
+        t for t in _tasks_of(role_task_file) if str(t.get("name", "")).startswith(UNHEALTHY_FAIL)
+    )
+    msg = task["ansible.builtin.fail"]["msg"]
+    assert "Do NOT set xinas_storage_reset" in msg, msg
+    guards = " ".join(str(w) for w in task["when"])
+    assert "xinas_storage_arrays_unhealthy" in guards, guards
+    assert "xinas_storage_reset" in guards, "an explicit reset must still be able to proceed"


### PR DESCRIPTION
Resolves review finding #5 (P2) — the MATCH-state contract mismatch.

## The problem

[docs/Installer/raid-spec.md](docs/Installer/raid-spec.md) §11 and §4.2 both promise MATCH means the xiRAID `data` and `log` arrays are **online** and `/dev/xi_data` is XFS with the configured label. The classifier in `detect_storage_state.yml` only checked that the names `data` and `log` appeared in the parsed `xicli raid show -f json` output, plus the fs type and label — so a degraded or offline array classified as MATCH and a `site.yml` re-run converged over it.

§4.2 leans on that promise directly when it argues a single-namespace layout can never legitimately reach the reuse path.

## The fix

Parse the per-array `state` words out of the xicli JSON. Each expected array must report at least one word, and every word must be `online` or `initialized` — the same allowlist the TUI health engine's `raid_status` check already applies (`xinas_menu/health/engine.py`).

- **Fails closed** on a record with no `state`, an empty state list, or a junk record.
- Reads **both payload shapes** — the `name → record` mapping xicli emits on a real node, and the list-of-records shape other releases / the fake transport emit.
- Accepts both the list (`["online", "initialized"]`) and bare-string (`"online"`) spellings, case-insensitively.
- Degraded / offline / rebuilding → FOREIGN → fail fast without touching anything.

## Also: don't point "wipe and rebuild" at a recoverable array

FOREIGN's generic failure message tells the operator to *"set `xinas_storage_reset=true` to wipe and rebuild"*. Routing degraded arrays into FOREIGN would aim that advice at a **recoverable** array — worse than the bug being fixed.

So the classifier also exports `xinas_storage_arrays_unhealthy` (with `xinas_storage_array_states` for the detail), and **both** `nvme_namespace` and `raid_fs` fail *before* the generic FOREIGN failure with the right remedy: repair the array or let the rebuild finish, then re-run — a healthy array converges. An operator who really does want to wipe a degraded array can still set an explicit `xinas_storage_reset`, which keeps its `YES` gate.

## Tests

`tests/test_storage_state_fail_closed.py` replays the file's `set_fact` chain through Jinja against synthetic probe output and asserts on the resulting `xinas_storage_state` — behavioral, not structural text assertions. Keys of one `set_fact` task render against a snapshot taken *before* the task, because Ansible does not expose sibling keys to each other; the Ansible-only filters (`from_json`, `flatten`, `zip`, `bool`) are re-implemented.

**14 of its 29 cases fail without the one-line `and (_ssd_arrays_online | bool)` conjunct** (verified by reverting it).

The probe-can't-answer cases assert `!= "MATCH"` rather than a specific state, so they hold whether or not the classifier grows an UNKNOWN state — UNKNOWN's precedence over every other state is preserved by construction, since the online check is only an extra conjunct inside the MATCH branch.

`jinja2>=3.0` joins the dev extras: ansible ships it on the host, but CI's `python-tests` job installs only `.[dev]`.

## Verification

`pytest` (650 passed, 14 skipped), `ruff check` / `ruff format --check`, `pyright`, `ansible-lint collection/roles/`, `yamllint`, `markdownlint-cli2 'docs/**/*.md'` — all clean.

## No `Requires-Rebuild:` trailer

This is install-time detection logic. It changes what a `site.yml` run does when it runs, not something that needs a role re-run to reach the host — and tagging it would force a full storage-role run on every update, which is exactly what you don't want pointed at a live array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
