### PR TITLE
fix(storage): fail-closed state detection, and discard on new arrays

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,10 +149,41 @@ end state.**
 4. `docs/plans/` is for execution plans (sequenced work, milestones,
    rollout), not for the durable behavior contract. Plans reference the
    spec; the spec is what survives.
+5. **Validate every claim about third-party behavior against that
+   vendor's own documentation before the spec lands.** This covers
+   xiRAID (`xicli` flags, defaults, limits, constraints), DOCA-OFED,
+   netplan, NVMe / `nvme-cli`, XFS, and nfsd. Cite the doc URL and the
+   product version inline in the spec, so the next reader can re-check
+   it. When published docs cannot settle a question, write down how the
+   answer was actually obtained (observed on a node, inferred from an
+   error message) instead of stating it as fact. Where a vendor page
+   contradicts an internal reverse-engineering doc such as
+   `xiNAS-MCP/xiraid-analysis/api_behavior_doc.md`, the vendor page
+   wins and the internal doc gets a correction note.
+
+   A plausible reading of a flag name is not a source. xiRAID's
+   `--drive_trim` reads like "the array sends TRIM to its drives"; it
+   actually TRIMs every disk *before* the array is created, and xiRAID
+   enables it on its own only when no disk carries metadata — a
+   safety check that keeps a TRIM from destroying recoverable data.
+   A spec written from the name alone told the installer to override
+   exactly that check.
 
 The only exemptions are trivial code-only fixes that don't change
 externally observable behavior (typos, refactors, log-message tweaks,
 test-only changes). When in doubt, write the spec.
+
+#### Deferred work → [docs/TODO.md](docs/TODO.md)
+
+When a change deliberately leaves something out, record it in
+[docs/TODO.md](docs/TODO.md) as part of that same change — what is
+missing, what the code does instead, why it was cut, and what "done"
+looks like. That file is the one place deferred work accumulates, so a
+scoping decision survives the conversation that produced it.
+
+It is not a bug tracker: anything that makes shipped behavior wrong gets
+fixed, not deferred. Delete an entry when it lands — the spec it changed
+is the durable record.
 
 ### Configuration History (`xinas_history/`)
 

--- a/collection/roles/nvme_namespace/tasks/detect_storage_state.yml
+++ b/collection/roles/nvme_namespace/tasks/detect_storage_state.yml
@@ -1,8 +1,19 @@
 ---
 # Read-only storage-identity detection. Sets xinas_storage_state to one of:
 #   MATCH   - xiRAID data+log arrays online AND /dev/xi_data is XFS with the wanted label
-#   EMPTY   - no xiRAID arrays and no XFS/foreign signature on /dev/xi_data
+#   EMPTY   - both probes ANSWERED, and what they answered was "nothing here"
 #   FOREIGN - some xiRAID/fs signature exists but does not match the expected layout
+#   UNKNOWN - a probe could not answer; the box is not provably empty
+#
+# EMPTY is what authorizes namespace deletion and mkfs (raid-spec §11), so it is
+# only ever reached from SUCCESSFUL negative probes. This matters because a
+# failed probe looks exactly like a factory-fresh node: with xiRAID down (daemon
+# stopped, kernel module not loaded, xicli absent) `xicli raid show` exits
+# non-zero AND /dev/xi_data does not exist, so an unguarded classifier reads a
+# live, data-bearing array as EMPTY and wipes it on a routine re-run. Both probes
+# therefore record whether they answered at all, and UNKNOWN outranks every other
+# state — including FOREIGN, which would claim knowledge of an array list we do
+# not have.
 #
 # "Online" is read out of the daemon's own per-array `state` words — it is not
 # inferred from the array merely existing. A degraded, offline, initializing or
@@ -28,6 +39,12 @@
   register: _ssd_raid_show
   changed_when: false
   failed_when: false
+
+- name: Record whether the xiRAID probe answered
+  ansible.builtin.set_fact:
+    # rc 0 means the daemon replied, so an empty reply genuinely means "no
+    # arrays". Any other rc means the array list could not be read at all.
+    _ssd_raid_probe_ok: "{{ (_ssd_raid_show.rc | default(1)) == 0 }}"
 
 - name: Parse xiRAID array output (native dict/list, empty dict on failure)
   ansible.builtin.set_fact:
@@ -86,6 +103,11 @@
          and (not (_ssd_arrays_online | bool)) }}
     xinas_storage_array_states: "{{ _ssd_array_states }}"
 
+- name: Check whether the xiRAID data volume exists
+  ansible.builtin.stat:
+    path: /dev/xi_data
+  register: _ssd_volume
+
 - name: Probe filesystem type on /dev/xi_data (read-only)
   ansible.builtin.command: blkid -s TYPE -o value /dev/xi_data
   register: _ssd_fstype
@@ -98,19 +120,31 @@
   changed_when: false
   failed_when: false
 
+- name: Record whether the filesystem probe answered
+  ansible.builtin.set_fact:
+    # No volume ⇒ conclusively no filesystem, whatever blkid made of the missing
+    # path. Otherwise only blkid's "found" (0) and "nothing found" (2) are
+    # answers; any other rc (usage error, I/O error, blkid missing) leaves the
+    # volume's content unknown.
+    _ssd_fs_probe_ok: >-
+      {{ (not (_ssd_volume.stat.exists | default(false)))
+         or ((_ssd_fstype.rc | default(1)) in [0, 2]) }}
+
 - name: Classify storage state
   ansible.builtin.set_fact:
     xinas_storage_state: >-
       {{
-        'MATCH'
-        if (('data' in _ssd_array_names) and ('log' in _ssd_array_names)
-            and (_ssd_arrays_online | bool)
-            and ((_ssd_fstype.stdout | default('') | trim) == 'xfs')
-            and ((_ssd_fslabel.stdout | default('') | trim) == xfs_label_wanted))
-        else ('EMPTY'
-              if ((_ssd_array_names | length) == 0
-                  and ((_ssd_fstype.stdout | default('') | trim) | length) == 0)
-              else 'FOREIGN')
+        'UNKNOWN'
+        if (not (_ssd_raid_probe_ok | bool) or not (_ssd_fs_probe_ok | bool))
+        else ('MATCH'
+              if (('data' in _ssd_array_names) and ('log' in _ssd_array_names)
+                  and (_ssd_arrays_online | bool)
+                  and ((_ssd_fstype.stdout | default('') | trim) == 'xfs')
+                  and ((_ssd_fslabel.stdout | default('') | trim) == xfs_label_wanted))
+              else ('EMPTY'
+                    if ((_ssd_array_names | length) == 0
+                        and ((_ssd_fstype.stdout | default('') | trim) | length) == 0)
+                    else 'FOREIGN'))
       }}
 
 - name: Report storage state
@@ -118,5 +152,19 @@
     msg: >-
       Storage state = {{ xinas_storage_state }}
       (arrays={{ _ssd_array_states }}, online={{ _ssd_arrays_online }},
+      raid_probe_ok={{ _ssd_raid_probe_ok }}, fs_probe_ok={{ _ssd_fs_probe_ok }},
       fstype='{{ _ssd_fstype.stdout | default('') | trim }}',
       label='{{ _ssd_fslabel.stdout | default('') | trim }}', wanted='{{ xfs_label_wanted }}')
+
+- name: Explain an undeterminable storage state
+  ansible.builtin.debug:
+    msg: >-
+      Storage state could not be determined:
+      {{ "'xicli raid show' failed (rc="
+         + (_ssd_raid_show.rc | default('?') | string) + ") — is xiraid-core running?"
+         if not (_ssd_raid_probe_ok | bool) else "" }}
+      {{ "blkid could not read /dev/xi_data (rc="
+         + (_ssd_fstype.rc | default('?') | string) + ")."
+         if not (_ssd_fs_probe_ok | bool) else "" }}
+      Refusing to treat this as a fresh box. Nothing has been modified.
+  when: xinas_storage_state == 'UNKNOWN'

--- a/collection/roles/nvme_namespace/tasks/main.yml
+++ b/collection/roles/nvme_namespace/tasks/main.yml
@@ -22,6 +22,17 @@
     - name: Detect current storage state
       ansible.builtin.include_tasks: detect_storage_state.yml
 
+    - name: Fail fast when the storage state could not be determined (UNKNOWN)
+      ansible.builtin.fail:
+        msg: >-
+          Could not determine what is on this node (state=UNKNOWN): a read-only probe
+          failed, so an existing array is indistinguishable from a fresh box. Refusing
+          to provision. Bring xiRAID up (systemctl status xiraid.target, modprobe xiraid)
+          and re-run, or set xinas_storage_reset=true to wipe and rebuild regardless.
+      when:
+        - (xinas_storage_state | default('UNKNOWN')) == 'UNKNOWN'
+        - not (xinas_storage_reset | default(false) | bool)
+
     - name: Fail fast on an existing xiNAS layout whose arrays are not online
       ansible.builtin.fail:
         msg: >-
@@ -31,7 +42,7 @@
           re-run; a healthy array converges. Do NOT set xinas_storage_reset to
           get past this: it would destroy the data on a recoverable array.
       when:
-        - (xinas_storage_state | default('EMPTY')) == 'FOREIGN'
+        - (xinas_storage_state | default('UNKNOWN')) == 'FOREIGN'
         - xinas_storage_arrays_unhealthy | default(false) | bool
         - not (xinas_storage_reset | default(false) | bool)
 
@@ -42,7 +53,7 @@
           Refusing to touch it. Set xinas_storage_reset=true to wipe and rebuild, or
           clean the drives manually.
       when:
-        - (xinas_storage_state | default('EMPTY')) == 'FOREIGN'
+        - (xinas_storage_state | default('UNKNOWN')) == 'FOREIGN'
         - not (xinas_storage_reset | default(false) | bool)
 
     - name: Confirm reset before any destructive operation
@@ -87,7 +98,7 @@
         - nvme_data_drives | length > 0
         - nvme_cleanup_existing_storage | default(true) | bool
         - (xinas_storage_reset | default(false) | bool)
-          or (xinas_storage_state | default('EMPTY')) == 'EMPTY'
+          or (xinas_storage_state | default('UNKNOWN')) == 'EMPTY'
 
     - name: Generate RAID configuration
       ansible.builtin.include_tasks: generate_raid_config.yml
@@ -150,7 +161,7 @@
         - nvme_data_drives | length > 0
         - nvme_cleanup_existing_storage | default(true) | bool
         - (xinas_storage_reset | default(false) | bool)
-          or (xinas_storage_state | default('EMPTY')) == 'EMPTY'
+          or (xinas_storage_state | default('UNKNOWN')) == 'EMPTY'
 
     # Phase 4: Check if there are any data drives to process
     - name: Check for available data drives
@@ -165,7 +176,7 @@
       ansible.builtin.include_tasks: detect_existing_namespaces.yml
       when:
         - nvme_data_drives | length > 0
-        - (xinas_storage_state | default('EMPTY')) == 'MATCH'
+        - (xinas_storage_state | default('UNKNOWN')) == 'MATCH'
         - not (xinas_storage_reset | default(false) | bool)
 
     - name: Collect NVMe topology for namespace rebuild
@@ -173,7 +184,7 @@
       when:
         - nvme_data_drives | length > 0
         - (xinas_storage_reset | default(false) | bool)
-          or (xinas_storage_state | default('EMPTY')) == 'EMPTY'
+          or (xinas_storage_state | default('UNKNOWN')) == 'EMPTY'
 
     # Phase 6: Rebuild namespaces (fresh install or explicit reset)
     - name: Rebuild namespaces on data drives
@@ -181,7 +192,7 @@
       when:
         - nvme_data_drives | length > 0
         - (xinas_storage_reset | default(false) | bool)
-          or (xinas_storage_state | default('EMPTY')) == 'EMPTY'
+          or (xinas_storage_state | default('UNKNOWN')) == 'EMPTY'
 
     # Phase 7: Generate RAID configuration (only if namespaces were created)
     - name: Generate RAID configuration
@@ -292,7 +303,7 @@
             - nvme_data_drives | length > 0
             - nvme_cleanup_existing_storage | default(true) | bool
             - (xinas_storage_reset | default(false) | bool)
-              or (xinas_storage_state | default('EMPTY')) == 'EMPTY'
+              or (xinas_storage_state | default('UNKNOWN')) == 'EMPTY'
 
         - name: Generate RAID configuration (fallback)
           ansible.builtin.include_tasks: generate_raid_config.yml

--- a/collection/roles/raid_fs/defaults/main.yml
+++ b/collection/roles/raid_fs/defaults/main.yml
@@ -12,6 +12,26 @@ xiraid_license_path: "/tmp/license"
 # Set to `false` if metadata should not be overwritten
 xiraid_force_metadata: true
 
+# TRIM/discard for NEW arrays (raid-spec §7.5). xiRAID's `--discard` defaults to
+# 0, and enabling it requires EVERY member to support Deterministic Read Zero
+# after TRIM (RZAT) — see the xiRAID Classic 4.4 command reference.
+#   auto - enable iff every member of that array reports discard support AND RZAT
+#          (decided per array)
+#   on   - pass the flags regardless of what the members report
+#   off  - never pass them
+xiraid_trim_mode: auto
+
+# The literal flags appended to `xicli raid create` when TRIM is enabled. Kept as
+# a variable so a future xiRAID spelling is a one-line override; the role probes
+# `xicli raid create --help` and drops them all when the installed CLI does not
+# advertise every flag named here, since an unknown argument fails the create.
+#
+# `--drive_trim` is deliberately absent. It TRIMs the disks before creation, and
+# xiRAID already enables it by default when RZAT holds AND no disk carries
+# metadata — that second condition is what stops a TRIM from destroying data that
+# is still recoverable. Forcing `--drive_trim 1` here would override it.
+xiraid_trim_create_args: "--discard 1"
+
 # DEPRECATED / internal — do NOT use to reformat. The supported control is
 # `xinas_storage_reset`. Kept only so older inventories don't error; pinned to the
 # safe side. `xfs_force_mkfs: true` set alone no longer reformats a healthy array.

--- a/collection/roles/raid_fs/tasks/create_array.yml
+++ b/collection/roles/raid_fs/tasks/create_array.yml
@@ -39,12 +39,61 @@
   when: (_mem_avail_kb.stdout | int // 1024) < (raid_create_min_free_mb | default(2560) | int)
   tags: [raid_fs, raid]
 
+# TRIM/discard is decided per array, not per node: a log array on TRIM-capable
+# namespaces still gets TRIM when a data-array member does not support it. A
+# member reporting 0 (or missing the attribute) cannot discard. Both xiRAID knobs
+# are create-only, so this is the only chance to set them — see raid-spec §7.5.
+- name: Probe member discard support for {{ item.name }}
+  ansible.builtin.shell: |
+    set -u
+    for dev in {{ _devlist }}; do
+      max=$(cat "/sys/block/$(basename "$dev")/queue/discard_max_bytes" 2>/dev/null || echo 0)
+      # RZAT: deallocated blocks must read back as zeroes. On NVMe that is the
+      # namespace's DLFEAT field, low 3 bits == 1. The kernel's old
+      # discard_zeroes_data attribute was removed in 4.12, so sysfs cannot
+      # answer this on the supported Ubuntu kernels.
+      dlfeat=$(nvme id-ns "$dev" 2>/dev/null \
+               | awk -F: '/dlfeat/ {gsub(/[^0-9]/, "", $2); print $2; exit}')
+      if [ "${max:-0}" -eq 0 ] 2>/dev/null; then
+        echo "$dev (no discard support)"
+      elif [ -z "${dlfeat:-}" ] || [ $((dlfeat & 7)) -ne 1 ]; then
+        echo "$dev (no RZAT)"
+      fi
+    done
+  register: _trim_probe
+  changed_when: false
+  when: (xiraid_trim_mode | default('auto')) != 'off'
+  tags: [raid_fs, raid]
+
+- name: Decide TRIM for {{ item.name }}
+  ansible.builtin.set_fact:
+    _array_trim: >-
+      {{ (xiraid_trim_mode | default('auto')) != 'off'
+         and (_xicli_trim_supported | default(false) | bool)
+         and ((xiraid_trim_mode | default('auto')) == 'on'
+              or ((_trim_probe.stdout_lines | default([])) | length) == 0) }}
+  tags: [raid_fs, raid]
+
+- name: Report the TRIM decision for {{ item.name }}
+  ansible.builtin.debug:
+    msg: >-
+      Array '{{ item.name }}': TRIM {{ 'ENABLED' if (_array_trim | bool) else 'disabled' }}
+      {{ '(' + xiraid_trim_create_args + ')' if (_array_trim | bool) else '' }}
+      {{ '- members not eligible: '
+         + (_trim_probe.stdout_lines | default([]) | join('; '))
+         if ((_trim_probe.stdout_lines | default([])) | length) > 0 else '' }}
+      {{ '- xicli does not advertise the TRIM flags'
+         if not (_xicli_trim_supported | default(false) | bool)
+            and (xiraid_trim_mode | default('auto')) != 'off' else '' }}
+  tags: [raid_fs, raid]
+
 - name: Create array {{ item.name }}
   ansible.builtin.command: >-
     xicli raid create -n {{ item.name }} -l {{ item.level }}
     -d {{ _devlist }} -ss {{ item.strip_size_kb }}
     {% if item.spare_pool is defined %}-sp {{ item.spare_pool }}{% endif %}
     {% if xiraid_force_metadata | bool %}--force_metadata{% endif %}
+    {% if _array_trim | bool %}{{ xiraid_trim_create_args }}{% endif %}
   register: raid_create
   changed_when: raid_create.rc == 0
   failed_when:

--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -244,6 +244,55 @@
       {%- endif -%}
   tags: [raid_fs, raid]
 
+# TRIM is a create-time knob, so the CLI's support for it is established once,
+# before the per-array loop. Passing a flag an older xicli does not know fails
+# EVERY array creation on "unrecognized arguments", so the flags are only ever
+# used when this probe finds both of them. See raid-spec §7.5.
+- name: Probe xicli for TRIM support
+  ansible.builtin.command: xicli raid create --help
+  register: _xicli_create_help
+  changed_when: false
+  failed_when: false
+  when: (xiraid_trim_mode | default('auto')) != 'off'
+  tags: [raid_fs, raid]
+
+# Every `--flag` named in xiraid_trim_create_args must appear in the help text —
+# an override that adds a flag this build lacks then disables TRIM instead of
+# failing every create.
+- name: Set fact – TRIM flags the installed xicli does not advertise
+  ansible.builtin.set_fact:
+    _xicli_trim_missing: >-
+      {%- set missing = [] -%}
+      {%- for tok in (xiraid_trim_create_args | default('')).split() -%}
+        {%- if tok[:2] == '--' and tok not in (_xicli_create_help.stdout | default('')) -%}
+          {%- set _ = missing.append(tok) -%}
+        {%- endif -%}
+      {%- endfor -%}
+      {{ missing }}
+  tags: [raid_fs, raid]
+
+- name: Set fact – whether xicli accepts the TRIM flags
+  ansible.builtin.set_fact:
+    _xicli_trim_supported: >-
+      {{ (xiraid_trim_mode | default('auto')) != 'off'
+         and ((_xicli_create_help.rc | default(1)) == 0)
+         and ((_xicli_trim_missing | default([])) | length) == 0 }}
+  tags: [raid_fs, raid]
+
+- name: Report that xicli does not advertise the TRIM flags
+  ansible.builtin.debug:
+    msg: >-
+      Installed xicli does not accept {{ (_xicli_trim_missing | default([])) | join(', ')
+      if ((_xicli_trim_missing | default([])) | length) > 0
+      else 'the TRIM flags (xicli raid create --help failed, rc='
+           + (_xicli_create_help.rc | default('?') | string) + ')' }};
+      arrays will be created without TRIM. Override xiraid_trim_create_args if this
+      build spells them differently.
+  when:
+    - (xiraid_trim_mode | default('auto')) != 'off'
+    - not (_xicli_trim_supported | bool)
+  tags: [raid_fs, raid]
+
 - name: Create xiRAID arrays that are missing
   ansible.builtin.include_tasks: create_array.yml
   loop: "{{ xiraid_arrays }}"

--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -56,6 +56,18 @@
     - not (xinas_storage_reset_confirmed | default(false) | bool)
   tags: [raid_fs, raid, fs]
 
+- name: Fail fast when the storage state could not be determined (UNKNOWN, raid_fs layer)
+  ansible.builtin.fail:
+    msg: >-
+      Could not determine what is on this node (state=UNKNOWN): a read-only probe failed,
+      so an existing array is indistinguishable from a fresh box. Refusing to run
+      drive-clean / mkfs. Bring xiRAID up (systemctl status xiraid.target, modprobe xiraid)
+      and re-run, or set xinas_storage_reset=true to wipe and rebuild regardless.
+  when:
+    - (xinas_storage_state | default('UNKNOWN')) == 'UNKNOWN'
+    - not (xinas_storage_reset | default(false) | bool)
+  tags: [raid_fs, raid, fs]
+
 - name: Fail fast on an existing xiNAS layout whose arrays are not online (raid_fs layer)
   ansible.builtin.fail:
     msg: >-
@@ -65,7 +77,7 @@
       re-run; a healthy array converges. Do NOT set xinas_storage_reset to get
       past this: it would destroy the data on a recoverable array.
   when:
-    - (xinas_storage_state | default('EMPTY')) == 'FOREIGN'
+    - (xinas_storage_state | default('UNKNOWN')) == 'FOREIGN'
     - xinas_storage_arrays_unhealthy | default(false) | bool
     - not (xinas_storage_reset | default(false) | bool)
   tags: [raid_fs, raid, fs]
@@ -77,7 +89,7 @@
       Refusing to run drive-clean / mkfs. Set xinas_storage_reset=true to wipe and
       rebuild, or clean the drives manually.
   when:
-    - (xinas_storage_state | default('EMPTY')) == 'FOREIGN'
+    - (xinas_storage_state | default('UNKNOWN')) == 'FOREIGN'
     - not (xinas_storage_reset | default(false) | bool)
   tags: [raid_fs, raid, fs]
 
@@ -109,7 +121,7 @@
   failed_when: false
   when: >-
     (xinas_storage_reset | default(false) | bool)
-    or (xinas_storage_state | default('EMPTY')) == 'EMPTY'
+    or (xinas_storage_state | default('UNKNOWN')) == 'EMPTY'
   tags: [raid_fs, raid, cleanup]
 
 - name: Warn about drives that could not be cleaned
@@ -202,7 +214,7 @@
   changed_when: false
   when: >-
     (xinas_storage_reset | default(false) | bool)
-    or (xinas_storage_state | default('EMPTY')) == 'EMPTY'
+    or (xinas_storage_state | default('UNKNOWN')) == 'EMPTY'
   tags: [raid_fs, raid]
 
 - name: Gather existing xiRAID arrays (json)

--- a/docs/Installer/raid-spec.md
+++ b/docs/Installer/raid-spec.md
@@ -388,9 +388,68 @@ xicli raid create -n <name> -l <level> \
                   -ss <strip_size_kb> \
                   [-sp <spare_pool>] \
                   [--force_metadata]   # when xiraid_force_metadata=true
+                  [--discard 1]        # when TRIM is enabled for this array
 ```
 
 `xiraid_force_metadata` defaults to `true` in both presets. After creation, the role `wait_for`-s the resulting block device at `/dev/xi_<name>` with a 120 s timeout. If the array already existed and the preset declares a `spare_pool`, the role runs `xicli raid modify --name <name> -sp <pool>` separately so adding a pool to a live array is idempotent too.
+
+#### TRIM / discard
+
+New arrays are created with discard enabled when the hardware supports it, so discards
+issued by XFS reach the NVMe media instead of being dropped at the RAID layer. The
+xiRAID Classic 4.4 command reference defines two related knobs, and the installer sets
+exactly one of them:
+
+| Knob | What xiRAID does with it | Installer |
+|---|---|---|
+| `--discard 0\|1` | enables discarding of unused blocks in the RAID. Defaults to `0`; requires **every** member to support Deterministic Read Zero after TRIM (RZAT) | **set to `1`** when the probe passes |
+| `--drive_trim 0\|1` | TRIMs the disks *before* the RAID is created. xiRAID enables it **by default** when all disks support RZAT **and none carries metadata** | **never passed** |
+
+**`--drive_trim` is deliberately left alone.** Its default already does the right thing,
+and its second condition — no metadata on any disk — is a data-safety check: TRIMming a
+disk that still carries metadata makes the data on it unrecoverable. Forcing
+`--drive_trim 1` would override exactly that check, so the installer does not name the
+flag at all and lets xiRAID decide.
+
+**Detection is per array, not per node.** For every member device the role checks two
+things:
+
+1. **Discard support** — `/sys/block/<dev>/queue/discard_max_bytes` is non-zero.
+2. **RZAT** — the NVMe namespace's `DLFEAT` field (from `nvme id-ns`) has its low three
+   bits equal to `1`, meaning deallocated blocks read back as zeroes. Plain discard
+   support does not imply this, and the kernel attribute that used to answer it
+   (`discard_zeroes_data`) was removed in 4.12, so it does not exist on the supported
+   Ubuntu kernels. A non-NVMe member (the VM whole-disk path) answers neither and is
+   treated as ineligible; so is any member on a host without `nvme-cli`, which a normal
+   `site.yml` run cannot hit (`nvme_namespace` hard-requires it and runs first) but a
+   bare `--tags raid_fs` run can. Both degrade to "create without discard", never to a
+   failed create.
+
+`--discard 1` is passed only when **every** member of *that* array passes both — so a log
+array on eligible namespaces still gets discard when a data-array member does not.
+
+**Discard cannot be added by a later install run.** A converging re-run of `site.yml`
+never recreates a healthy array (§11), so an array created without `--discard` keeps that
+setting until it is destroyed and rebuilt under an explicit, confirmed
+`xinas_storage_reset`. (The 4.4 CLI does document `discard` as modifiable via
+`xicli raid modify`, but the control path currently rejects it as create-only — that was
+verified against the 4.3.1 gRPC descriptor and has not been re-checked on 4.4.)
+
+Two role variables control it, both mirrored in the shipping presets (a preset replaces
+the role's `defaults/main.yml` wholesale, so an unmirrored default is lost at preset-apply):
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `xiraid_trim_mode` | `auto` | `auto` = enable iff every member passes both probes; `on` = force the flags on regardless of the probe; `off` = never pass them |
+| `xiraid_trim_create_args` | `--discard 1` | the literal flags appended to `xicli raid create`; one-line override if a future xiRAID spells them differently |
+
+**The CLI is probed before the flags are used.** The role runs `xicli raid create --help`
+once, outside the per-array loop, and appends the flags only when every `--flag` named in
+`xiraid_trim_create_args` appears in that help text. Without the guard an older xiRAID
+would fail *every* array creation on an unrecognised argument; with it, an unsupporting
+build — or an override naming a flag this build lacks — simply creates arrays without
+discard. The decision and its reason (which member failed which probe, or which flag the
+CLI does not accept) are printed per array before creation.
 
 ### 7.6 Filesystem creation
 

--- a/docs/Installer/raid-spec.md
+++ b/docs/Installer/raid-spec.md
@@ -163,7 +163,7 @@ The list of dicts is stored as `nvme_topology`.
 Source: [detect_existing_namespaces.yml](../../collection/roles/nvme_namespace/tasks/detect_existing_namespaces.yml).
 
 A read-only preflight (`detect_storage_state.yml`) classifies the box as
-`xinas_storage_state` ∈ {MATCH, EMPTY, FOREIGN} before any namespace decision (see §11).
+`xinas_storage_state` ∈ {MATCH, EMPTY, FOREIGN, UNKNOWN} before any namespace decision (see §11).
 When the box is **MATCH** (the expected xiRAID `data`+`log` arrays are online and
 `/dev/xi_data` is XFS with the configured label) and `xinas_storage_reset` is not set,
 the role reuses the namespaces already on the drives — no rebuild, no data loss:
@@ -175,7 +175,7 @@ the role reuses the namespaces already on the drives — no rebuild, no data los
 
 **EMPTY** (a fresh box, including a factory single-`n1` drive) or an explicit
 `xinas_storage_reset: true` falls through to the delete+recreate path in §4.3. **FOREIGN**
-without reset fails fast before touching anything. The deprecated
+and **UNKNOWN** without reset fail fast before touching anything. The deprecated
 `nvme_use_existing_namespaces` knob no longer drives this choice.
 
 ### 4.3 Delete + recreate
@@ -512,6 +512,7 @@ For one-shot validation, the Textual TUI's Health tab (`xinas-menu`) and the MCP
 | Odd number of log namespaces and `raid_log_level=10` | xiRAID rejects the unbalanced array | `generate_raid_config.yml` drops one device and reports it in the summary |
 | Routine `site.yml` re-run reformats the live array (finding C1) | any `site.yml` re-run (incl. the TUI update flow's `Requires-Rebuild: all`) stopped NFS, ran `mkfs -f` over the live array, and finished green | Read-only `detect_storage_state` → MATCH **converges**: mkfs, namespace rebuild, `drive clean`, the MD sweep, and all three `cleanup_storage` wipes are skipped. Destruction requires an explicit `xinas_storage_reset` behind a `YES` gate enforced in **both** roles (§11) |
 | Existing storage doesn't match the expected layout | a stray/foreign array or wrong-label XFS would have been silently reformatted | **FOREIGN fail-fast** at both the namespace and filesystem layers, before any wipe; requires `xinas_storage_reset` to proceed |
+| Storage probes can't answer (xiRAID daemon down, module not loaded, `xicli`/`blkid` unusable) | a live array looks exactly like a fresh box — `xicli raid show` fails and `/dev/xi_data` is absent — so detection classified it `EMPTY` and a routine re-run wiped it | Probe success is tracked; a non-answer yields **UNKNOWN**, which outranks every other state and fails fast in both roles. Undefined state defaults to `UNKNOWN`, never `EMPTY` (§11) |
 | Log RAID array smaller than the requested `log_size=1G` | `mkfs.xfs` exits with E2BIG | `_effective_log_size` clamps the size to `blockdev --getsize64` of the log device |
 | Boot-time race between xiRAID and fstab | `/mnt/data` would fail to mount on cold boot | Mount unit `Requires=` + `After=` the kernel `.device` units for `xi_data` and `xi_log` |
 | Stale xiRAID metadata from a prior install | `xicli raid create` refuses | `xicli drive clean` runs per member; `--force_metadata` is set when `xiraid_force_metadata=true` |
@@ -542,8 +543,32 @@ Formatting happens only on a genuinely fresh box, or under an explicit, confirme
 | State | Meaning | Effect (no reset) |
 |---|---|---|
 | **MATCH** | xiRAID `data`+`log` online **and** `/dev/xi_data` is XFS with the configured label | **converge** — every destructive op is skipped |
-| **EMPTY** | no xiRAID arrays and no fs signature on `/dev/xi_data` (incl. a factory single-`n1` drive) | provision as a first install |
+| **EMPTY** | both probes **answered**, and no xiRAID arrays and no fs signature exist (incl. a factory single-`n1` drive) | provision as a first install |
 | **FOREIGN** | some array/fs signature exists but doesn't match the expected layout | **fail fast** before any wipe |
+| **UNKNOWN** | a probe could not answer, so the layout is undetermined | **fail fast** before any wipe |
+
+**Probes must answer for EMPTY to be reachable.** `EMPTY` is the state that authorizes
+destruction, so it is only ever derived from *successful* negative probes — never from a
+probe that failed. This is not theoretical: with xiRAID down (daemon stopped, kernel module
+not loaded, `xicli` absent) `xicli raid show` exits non-zero **and** `/dev/xi_data` does not
+exist, which is byte-for-byte how a factory-fresh node looks. Treating that as `EMPTY` would
+erase a live, data-bearing array on a routine re-run. Detection therefore records whether
+each probe answered at all:
+
+- **Array probe** — `xicli raid show -f json` answered iff `rc == 0`. An empty reply from a
+  running daemon is a real "no arrays"; any other rc means the array list is unreadable.
+- **Filesystem probe** — conclusive iff `/dev/xi_data` is absent (then there is provably no
+  filesystem), or `blkid` returned `0` ("found") or `2` ("nothing found"). Any other rc
+  (usage error, I/O error, `blkid` missing) leaves the volume's content unknown.
+
+`UNKNOWN` **outranks every other state**, including `FOREIGN` — `FOREIGN` would assert
+knowledge about an array list that could not be read. Both roles fail fast on it with the
+remedy named (bring xiRAID up and re-run, or set `xinas_storage_reset=true` to wipe and
+rebuild regardless), and nothing is modified before that point. An explicit, confirmed reset
+still wins, exactly as it does over `FOREIGN`.
+
+The gates read `xinas_storage_state | default('UNKNOWN')`: an undefined fact is a
+non-answer, and a non-answer never authorizes destruction.
 
 **"Online" is read from the daemon, not inferred from the array existing.**
 `xicli raid show -f json` reports per-array `state` words; an array counts as

--- a/docs/Storage/raid-management-spec.md
+++ b/docs/Storage/raid-management-spec.md
@@ -193,11 +193,32 @@ those state lists empty, and the breakdown falls back to a bare total.
 
 Quick Overview shows: level, capacity, state list, device counts (online / degraded / offline derived from the per-member `status.member_states`), strip size, spare pool, and an initialisation progress bar when any state is `initing`.
 
-Extended adds three blocks, all sourced from observed `spec.tuning`:
+Extended adds four blocks, all sourced from observed `spec.tuning`:
 
 - **Priorities** — `init_prio`, `recon_prio`, `restripe_prio`, `sdc_prio`
 - **Performance** — `memory_limit`, `memory_prealloc`, `request_limit`, `cpu_allowed`, plus `block_size` (`spec`) and `memory_usage_mb` (`status`)
 - **I/O Scheduler & Merge** — `sched_enabled`, `merge_read_enabled`, `merge_write_enabled`, `adaptive_merge`, plus the four merge timing knobs `merge_read_max`, `merge_read_wait`, `merge_write_max`, `merge_write_wait`
+- **TRIM / Discard** — `discard` (the array accepts discards from the filesystem) and `drive_trim` (the array issues TRIM to its members)
+
+Neither knob is editable from this screen: the control path classifies both as
+create-only (`CREATE_ONLY_TUNING` in `routes/arrays.ts`, verified against the 4.3.1 gRPC
+descriptor, whose `RaidModify` carries no field for either), so Edit Array rejects them
+and they carry no edit affordance. The xiRAID Classic 4.4 CLI reference does list
+`discard` as modifiable via `xicli raid modify`, so that classification is worth
+re-checking against a 4.4 descriptor; until it is, the block is display-only.
+
+The installer decides them per array from the members' discard support **and RZAT**, and
+never forces `drive_trim` (see [raid-spec §7.5](../Installer/raid-spec.md#75-array-creation)).
+The block states what the array *is*, so an operator diagnosing discard behaviour does not
+have to infer it from the install log.
+
+**Day-2 creation does not match the installer yet.** The Create Array wizard (§4) sends no
+`tuning`, so an array created from the TUI gets xiRAID's default `discard = 0` while an
+installer-created array on the same hardware gets `discard = 1`. The wizard has nothing to
+decide from — the control-path `Disk` object carries neither discard nor RZAT — so closing
+the gap means extending the agent's disk probe first. Tracked in
+[docs/TODO.md](../TODO.md); until it lands, this block is where the difference becomes
+visible.
 
 Those are the **control-path** names (ADR-0006 `spec.tuning`), not the daemon's. The daemon→control-path rename happens once, in the agent parser [lib/parse/raid.ts](../../xiNAS-MCP/src/lib/parse/raid.ts):
 
@@ -248,7 +269,7 @@ rendered as a placeholder:
 | `memory_prealloc` | `unknown` | `disabled` when `0`, else `<n> MB` |
 | `cpu_allowed` | `unknown` | `all` when empty, else the CPU list (`5-7`, `0,2,4-6`) |
 | `block_size` (`spec`) | `unknown` | `<n> bytes` |
-| Booleans (`sched_enabled`, `merge_*_enabled`, `adaptive_merge`) | `unknown` | `Enabled` / `Disabled` |
+| Booleans (`sched_enabled`, `merge_*_enabled`, `adaptive_merge`, `discard`, `drive_trim`) | `unknown` | `Enabled` / `Disabled` |
 | Merge timings | row omitted when all four are unobserved | `<n> us` |
 | `memory_usage_mb` (`status`) | `unknown` | `<n> MB` |
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,62 @@
+# xiNAS — Deferred Work
+
+Work that was consciously scoped out of a change, not work that was
+forgotten. Every entry names what is missing, what the current behavior is
+instead, and what "done" looks like — enough for someone else to pick it up
+without the conversation it came from.
+
+**This is not a bug tracker and not a wishlist.** An entry belongs here when
+all three hold:
+
+- it was cut from a specific change, and the change shipped without it;
+- leaving it out is defensible on its own (it is not a half-finished feature);
+- shipping it later is a real piece of work, not a follow-up commit.
+
+Anything that makes the shipped behavior wrong is a bug — fix it or file it,
+don't defer it here. When an entry is done, delete it; the spec it changed is
+the record, not this file.
+
+Format: `## <area> — <what is missing>`, newest first, with the date it was
+deferred and the change that deferred it.
+
+---
+
+## Storage — day-2 array creation does not enable discard
+
+*Deferred 2026-08-14, from the TRIM-support change.*
+
+**What is missing.** The Create Array wizard in the TUI sends no `tuning` at
+all ([raid.py](../xinas_menu/screens/raid.py) — the wizard assembles
+`name` / `level` / `member_disk_ids` / `strip_size_kib` and, conditionally,
+`group_size` and `spare_disk_ids`). `discard` is therefore omitted and xiRAID
+applies its own default of `0`.
+
+**Current behavior.** The installer now enables `--discard 1` per array when
+every member supports discard and RZAT
+([raid-spec §7.5](Installer/raid-spec.md#75-array-creation)). An array created
+from the TUI on the same hardware does not get it, so two arrays on one node
+can differ in discard behavior depending on which surface created them.
+
+**Why it was cut.** The installer decides from a host-side probe the control
+path cannot currently reproduce: `ObservedDisk.status`
+([disk.ts](../xiNAS-MCP/src/lib/parse/disk.ts)) carries no discard and no RZAT
+field, so the wizard has nothing to decide from. Closing the gap properly is a
+four-layer change, not a wizard tweak.
+
+**What done looks like.**
+
+1. The agent's disk probe reads `/sys/block/<dev>/queue/discard_max_bytes` and
+   the NVMe namespace `DLFEAT` (low three bits == 1 means deallocated blocks
+   read back as zeroes), and surfaces both on `Disk`.
+2. `docs/control-path/api-v1.yaml` gains the fields (additive, so oasdiff
+   stays green) and `docs/control-path/` records them.
+3. The Create Array wizard enables `discard` when every selected member
+   qualifies, and says so on the confirmation step — matching the installer's
+   rule rather than asking the operator to know it.
+4. `docs/Storage/raid-management-spec.md` §4 documents the behavior, and the
+   asymmetry note added to §3 is removed.
+
+TypeScript under `xiNAS-MCP/src/` needs a `Requires-Rebuild: xinas_node_build`
+trailer. `drive_trim` stays untouched here for the same reason as in the
+installer: xiRAID enables it itself only when no disk carries metadata, and
+forcing it overrides that safety check.

--- a/presets/default/raid_fs.yml
+++ b/presets/default/raid_fs.yml
@@ -12,6 +12,14 @@ xiraid_license_path: "/tmp/license"
 # Whether to pass `--force_metadata` when creating arrays
 xiraid_force_metadata: true
 
+# TRIM/discard for new arrays: enable per array when every member reports both
+# discard support and RZAT (raid-spec §7.5). `--drive_trim` is intentionally not
+# forced — xiRAID enables it itself only when no disk carries metadata. Mirrored
+# from the role defaults because this preset REPLACES defaults/main.yml — see the
+# note on raid_create_min_free_mb.
+xiraid_trim_mode: auto
+xiraid_trim_create_args: "--discard 1"
+
 # Enable automatic NVMe namespace management
 # This will auto-detect drives and generate RAID configuration
 nvme_auto_namespace: true

--- a/presets/xinnorVM/raid_fs.yml
+++ b/presets/xinnorVM/raid_fs.yml
@@ -7,6 +7,14 @@ xiraid_license_path: "/tmp/license"
 # Whether to pass `--force_metadata` when creating arrays
 xiraid_force_metadata: true
 
+# TRIM/discard for new arrays: enable per array when every member reports both
+# discard support and RZAT (raid-spec §7.5). Virtio/SCSI backing devices report
+# neither, so `auto` quietly creates without discard here — same knob, hardware
+# decides. Mirrored from the role defaults for the same reason as
+# raid_create_min_free_mb below.
+xiraid_trim_mode: auto
+xiraid_trim_create_args: "--discard 1"
+
 # Minimum free memory (MiB) required before creating each array. xiRAID
 # preallocates a per-array kernel mempool (~memory_prealloc, ~2 GB) via
 # __get_free_pages(); creation fails cryptically below this floor. Defined here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,10 @@ dev = [
   "rich",            # imported directly (rich.text, rich.markup); textual dep
   "grpcio>=1.60.0",
   "pyyaml>=6.0",
+  # Ansible's templating engine, used by tests that render a role's real Jinja
+  # expressions instead of pattern-matching the task text (see
+  # tests/test_storage_state_fail_closed.py). Not a xiNAS runtime dependency.
+  "jinja2>=3.1",
 ]
 
 [tool.ruff]

--- a/tests/test_raid_fs_safe_defaults.py
+++ b/tests/test_raid_fs_safe_defaults.py
@@ -59,11 +59,14 @@ DETECT = REPO / "collection/roles/nvme_namespace/tasks/detect_storage_state.yml"
 def test_detection_sets_state_fact():
     text = DETECT.read_text()
     assert "xinas_storage_state" in text
-    for state in ("MATCH", "EMPTY", "FOREIGN"):
+    for state in ("MATCH", "EMPTY", "FOREIGN", "UNKNOWN"):
         assert state in text, f"detection never yields {state}"
-    # Detection must be read-only: no destructive verbs.
+    # Detection must be read-only: no destructive verbs. Scanned over the tasks
+    # only — the file's header comment names the destructive steps that EMPTY
+    # authorizes, and prose about a verb is not a use of it.
+    tasks_only = "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
     for verb in ("delete-ns", "mkfs", "drive clean", "wipefs", "zero-superblock"):
-        assert verb not in text, f"detection must not run {verb!r}"
+        assert verb not in tasks_only, f"detection must not run {verb!r}"
     # It must parse into a native list, not a stringified one.
     tasks = yaml.safe_load(text)
     assert isinstance(tasks, list) and tasks, "detection file must be a task list"

--- a/tests/test_raid_fs_trim.py
+++ b/tests/test_raid_fs_trim.py
@@ -1,0 +1,225 @@
+"""TRIM/discard is decided per array, from probes, and never breaks an old xicli.
+
+`--discard 1` is what the installer sets (raid-spec §7.5). Per the xiRAID Classic
+4.4 command reference it defaults to `0`, and enabling it requires every member to
+support Deterministic Read Zero after TRIM (RZAT) — a stronger property than plain
+discard support, so both are probed.
+
+`--drive_trim` is deliberately NOT forced: it TRIMs the disks before creation and
+xiRAID already enables it by default when RZAT holds *and no disk carries metadata*.
+Forcing `1` overrides that second condition, which is the check that keeps a TRIM
+from destroying recoverable data on a disk that still has metadata on it.
+
+The decision expression is rendered from the role's real Jinja, the same way
+tests/test_storage_state_fail_closed.py replays a set_fact chain.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+import jinja2
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[1]
+ROLE_DEFAULTS = REPO / "collection/roles/raid_fs/defaults/main.yml"
+CREATE_ARRAY = REPO / "collection/roles/raid_fs/tasks/create_array.yml"
+RAID_FS_MAIN = REPO / "collection/roles/raid_fs/tasks/main.yml"
+PRESETS = [
+    REPO / "presets/default/raid_fs.yml",
+    REPO / "presets/xinnorVM/raid_fs.yml",
+]
+
+SET_FACT_KEYS = ("set_fact", "ansible.builtin.set_fact")
+ITEM = {
+    "name": "data",
+    "level": 5,
+    "strip_size_kb": 128,
+    "parity_disks": 1,
+    "devices": ["/dev/nvme1n2", "/dev/nvme2n2", "/dev/nvme3n2"],
+}
+
+
+def _load(path: Path) -> Any:
+    return yaml.safe_load(path.read_text())
+
+
+def _ansible_bool(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in ("yes", "on", "true", "1")
+    return bool(value)
+
+
+def _render(expr: Any, variables: dict) -> Any:
+    if not isinstance(expr, str):
+        return expr
+    env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+    env.filters["bool"] = _ansible_bool
+    rendered = env.from_string(expr).render(**variables).strip()
+    try:
+        return ast.literal_eval(rendered)
+    except (ValueError, SyntaxError):
+        return rendered
+
+
+def _decide_trim(*, mode: str = "auto", unsupported: list[str] | None = None, cli: bool = True):
+    """Replay create_array.yml's set_fact chain and return the TRIM decision."""
+    variables: dict[str, Any] = {
+        "item": ITEM,
+        "xiraid_trim_mode": mode,
+        "xiraid_trim_create_args": "--discard 1",
+        "xiraid_force_metadata": True,
+        "_xicli_trim_supported": cli,
+        "_trim_probe": {"stdout_lines": unsupported or []},
+    }
+    decided: Any = None
+    for task in _load(CREATE_ARRAY) or []:
+        if not isinstance(task, dict):
+            continue
+        for key in SET_FACT_KEYS:
+            facts = task.get(key)
+            if isinstance(facts, dict):
+                for name, expr in facts.items():
+                    variables[name] = _render(expr, variables)
+                    if name.endswith("_trim"):
+                        decided = variables[name]
+    assert decided is not None, "create_array.yml computes no TRIM decision fact"
+    return decided
+
+
+# ── The decision ──────────────────────────────────────────────────────────────
+
+
+def test_auto_enables_trim_when_every_member_supports_discard():
+    assert _decide_trim(mode="auto", unsupported=[]) is True
+
+
+def test_auto_disables_trim_when_any_member_lacks_discard():
+    assert _decide_trim(mode="auto", unsupported=["/dev/nvme2n2"]) is False
+
+
+def test_off_never_enables_trim():
+    assert _decide_trim(mode="off", unsupported=[]) is False
+
+
+def test_on_forces_trim_past_the_probe():
+    assert _decide_trim(mode="on", unsupported=["/dev/nvme2n2"]) is True
+
+
+@pytest.mark.parametrize("mode", ["auto", "on"])
+def test_unsupported_xicli_never_gets_the_flags(mode):
+    """An older xicli rejects unknown arguments — that would fail every create."""
+    assert _decide_trim(mode=mode, unsupported=[], cli=False) is False
+
+
+# ── Wiring ────────────────────────────────────────────────────────────────────
+
+
+def test_probe_reads_discard_max_bytes_per_member():
+    text = CREATE_ARRAY.read_text()
+    assert "discard_max_bytes" in text, "no per-member discard probe"
+    assert "/sys/block/" in text
+
+
+def test_probe_also_checks_rzat():
+    """`--discard 1` needs Deterministic Read Zero after TRIM on every member.
+
+    Plain discard support does not imply RZAT. On NVMe it is the DLFEAT field of
+    the namespace (low 3 bits == 1 means deallocated blocks read back as zeroes);
+    the kernel's old `discard_zeroes_data` sysfs attribute was removed in 4.12 and
+    does not exist on the supported Ubuntu kernels.
+    """
+    text = CREATE_ARRAY.read_text()
+    assert "dlfeat" in text.lower(), "no RZAT probe — --discard 1 may be rejected or unsafe"
+
+
+def test_create_command_appends_the_trim_args_conditionally():
+    tasks = _load(CREATE_ARRAY)
+    create = next(
+        (
+            t
+            for t in tasks
+            if isinstance(t, dict) and str(t.get("name", "")).startswith("Create array")
+        ),
+        None,
+    )
+    assert create is not None, "no 'Create array' task"
+    cmd = str(create.get("ansible.builtin.command") or create.get("command"))
+    assert "xiraid_trim_create_args" in cmd, "create command never appends the TRIM flags"
+    # The flags must sit behind the decision, not be pasted in unconditionally.
+    decision_refs = [seg for seg in cmd.split("{%") if "xiraid_trim_create_args" in seg]
+    assert decision_refs, "TRIM args are not inside a Jinja conditional"
+    assert any("_trim" in seg for seg in decision_refs), (
+        "TRIM args are not guarded by the per-array decision"
+    )
+
+
+def test_cli_support_is_probed_once_outside_the_per_array_loop():
+    """`xicli raid create --help` is a node-level fact, not a per-array one."""
+    text = RAID_FS_MAIN.read_text()
+    assert "_xicli_trim_supported" in text, "CLI support is not established in main.yml"
+    assert "--help" in text
+
+
+def _cli_supported(*, args: str, help_stdout: str, rc: int = 0, mode: str = "auto"):
+    """Replay main.yml's help-probe facts."""
+    variables: dict[str, Any] = {
+        "xiraid_trim_mode": mode,
+        "xiraid_trim_create_args": args,
+        "_xicli_create_help": {"rc": rc, "stdout": help_stdout},
+    }
+    for task in _load(RAID_FS_MAIN) or []:
+        if not isinstance(task, dict):
+            continue
+        for key in SET_FACT_KEYS:
+            facts = task.get(key)
+            if isinstance(facts, dict) and any("trim" in name for name in facts):
+                for name, expr in facts.items():
+                    variables[name] = _render(expr, variables)
+    return variables["_xicli_trim_supported"]
+
+
+HELP_44 = "  --discard {0,1}   Enable discarding of unused blocks\n  --drive_trim {0,1}\n"
+
+
+def test_help_probe_accepts_a_cli_that_advertises_the_flag():
+    assert _cli_supported(args="--discard 1", help_stdout=HELP_44) is True
+
+
+def test_help_probe_rejects_a_cli_missing_any_flag_in_the_args():
+    """An override naming a flag this xicli lacks must disable TRIM, not fail the create."""
+    assert _cli_supported(args="--discard 1 --nonesuch 1", help_stdout=HELP_44) is False
+
+
+def test_help_probe_rejects_a_failed_help_call():
+    assert _cli_supported(args="--discard 1", help_stdout="", rc=2) is False
+
+
+# ── Defaults must survive preset-apply ────────────────────────────────────────
+
+
+def _assert_trim_args(args: str, where: str) -> None:
+    assert "--discard" in args, f"{where} does not enable discard: {args!r}"
+    # xiRAID enables drive_trim itself only when RZAT holds AND no disk carries
+    # metadata. Forcing it past that second condition TRIMs a disk whose data is
+    # still recoverable (xiRAID Classic 4.4 command reference, --drive_trim).
+    assert "--drive_trim" not in args, (
+        f"{where} forces --drive_trim, overriding xiRAID's own metadata safety check: {args!r}"
+    )
+
+
+def test_role_defaults_declare_trim_knobs():
+    data = _load(ROLE_DEFAULTS)
+    assert data.get("xiraid_trim_mode") == "auto"
+    _assert_trim_args(str(data.get("xiraid_trim_create_args", "")), "role default")
+
+
+@pytest.mark.parametrize("preset", PRESETS, ids=lambda p: p.parent.name)
+def test_presets_mirror_the_trim_knobs(preset):
+    """A preset replaces the role's defaults wholesale — an unmirrored default is lost."""
+    data = _load(preset)
+    assert data.get("xiraid_trim_mode") == "auto", f"{preset} does not set xiraid_trim_mode"
+    _assert_trim_args(str(data.get("xiraid_trim_create_args", "")), str(preset))

--- a/tests/test_raid_overview.py
+++ b/tests/test_raid_overview.py
@@ -209,3 +209,51 @@ def test_merge_max_edit_params_are_labelled_microseconds_not_kb():
     assert "(us)" in labels["merge_write_max"]
     assert "KB" not in labels["merge_read_max"]
     assert "KB" not in labels["merge_write_max"]
+
+
+# ---- TRIM / discard (raid-management-spec §3, Installer raid-spec §7.5) ----
+#
+# `discard` and `drive_trim` are create-only knobs the installer decides from
+# the members' discard support. The Extended view is where an operator finds
+# out what the array actually got, so both must render — and, like every other
+# tuning value, an unobserved one must not render as a plausible default.
+
+
+def test_trim_block_renders_observed_values():
+    rows = _api_row(spec_extra={"tuning": {"discard": True, "drive_trim": True}})
+    out = _format_raid_overview(_arrays_from_api(rows), extended=True)
+
+    assert "Enabled" in _row(out, "Discard (TRIM)")
+    assert "Enabled" in _row(out, "Drive TRIM")
+
+
+def test_trim_block_renders_disabled_when_observed_off():
+    rows = _api_row(spec_extra={"tuning": {"discard": False, "drive_trim": False}})
+    out = _format_raid_overview(_arrays_from_api(rows), extended=True)
+
+    assert "Disabled" in _row(out, "Discard (TRIM)")
+    assert "Disabled" in _row(out, "Drive TRIM")
+
+
+def test_unobserved_trim_renders_unknown_not_disabled():
+    out = _format_raid_overview(_arrays_from_api(_api_row()), extended=True)
+
+    assert "unknown" in _row(out, "Discard (TRIM)")
+    assert "Disabled" not in _row(out, "Discard (TRIM)")
+    assert "unknown" in _row(out, "Drive TRIM")
+    assert "Disabled" not in _row(out, "Drive TRIM")
+
+
+def test_trim_rows_are_absent_from_the_quick_overview():
+    rows = _api_row(spec_extra={"tuning": {"discard": True, "drive_trim": True}})
+    out = _format_raid_overview(_arrays_from_api(rows), extended=False)
+    assert "Discard (TRIM)" not in _plain(out)
+
+
+def test_trim_knobs_are_not_offered_as_edits():
+    """Create-only: RaidModify has no field for either (translate.ts)."""
+    from xinas_menu.screens.raid import _MODIFY_PARAMS
+
+    keys = {key for key, *_ in _MODIFY_PARAMS}
+    assert "discard" not in keys
+    assert "drive_trim" not in keys

--- a/tests/test_storage_state_fail_closed.py
+++ b/tests/test_storage_state_fail_closed.py
@@ -106,18 +106,23 @@ def replay(
     fslabel: str = "nfsdata",
     raid_rc: int = 0,
     wanted_label: str = "nfsdata",
+    volume_exists: bool = True,
+    fstype_rc: int = 0,
 ) -> dict:
     """Replay the classifier against synthetic probe output, returning its facts.
 
     `raid_show` is the parsed payload `xicli raid show -f json` would print
     (serialized back to JSON for the replay), or a raw string for malformed
-    output.
+    output. `volume_exists` / `fstype_rc` model the filesystem probe: whether
+    /dev/xi_data is there at all, and what blkid made of it (0 = found,
+    2 = nothing found, anything else = could not answer).
     """
     stdout = raid_show if isinstance(raid_show, str) else json.dumps(raid_show)
     context: dict[str, Any] = {
         "xfs_filesystems": [{"label": wanted_label}],
         "_ssd_raid_show": {"rc": raid_rc, "stdout": stdout},
-        "_ssd_fstype": {"rc": 0, "stdout": fstype},
+        "_ssd_volume": {"stat": {"exists": volume_exists}},
+        "_ssd_fstype": {"rc": fstype_rc, "stdout": fstype},
         "_ssd_fslabel": {"rc": 0, "stdout": fslabel},
     }
     for task in _set_fact_tasks():
@@ -263,6 +268,45 @@ def test_failed_raid_probe_never_matches():
     assert classify("", raid_rc=1) != "MATCH"
 
 
+@pytest.mark.parametrize(
+    ("raid_rc", "why"),
+    [(1, "daemon down / module not loaded"), (127, "xicli not on PATH")],
+)
+def test_failed_raid_probe_is_unknown_not_empty(raid_rc, why):
+    """The P0: with xiRAID down a live array looks exactly like a fresh box.
+
+    `xicli raid show` fails AND /dev/xi_data is absent — byte-for-byte how a
+    factory node reads. EMPTY authorizes the namespace rebuild, so a probe that
+    never answered must not produce it.
+    """
+    state = classify("", raid_rc=raid_rc, volume_exists=False, fstype="", fstype_rc=2)
+    assert state != "EMPTY", f"{why}: a failed xicli probe authorized a wipe"
+    assert state == "UNKNOWN", state
+
+
+def test_inconclusive_filesystem_probe_is_unknown_not_empty():
+    """Volume present but blkid errored: its content is not known to be absent."""
+    state = classify({}, volume_exists=True, fstype="", fstype_rc=8)
+    assert state != "EMPTY"
+    assert state == "UNKNOWN", state
+
+
+def test_unknown_outranks_foreign():
+    """FOREIGN would assert knowledge of an array list that could not be read."""
+    state = classify("", raid_rc=1, volume_exists=True, fstype="ext4", fstype_rc=0)
+    assert state == "UNKNOWN", state
+
+
+def test_a_genuinely_fresh_box_is_still_empty():
+    """The daemon answered "no arrays" and the volume is provably absent."""
+    assert classify({}, volume_exists=False, fstype="", fstype_rc=2) == "EMPTY"
+
+
+def test_present_but_unsigned_volume_is_still_empty():
+    """blkid rc 2 is a conclusive negative, not a failure."""
+    assert classify({}, volume_exists=True, fstype="", fstype_rc=2) == "EMPTY"
+
+
 def test_unparsable_raid_output_never_matches():
     """Malformed JSON with rc=0 must not converge — erroring out is fine too.
 
@@ -355,3 +399,42 @@ def test_unhealthy_array_failure_does_not_advise_a_reset(role_task_file):
     guards = " ".join(str(w) for w in task["when"])
     assert "xinas_storage_arrays_unhealthy" in guards, guards
     assert "xinas_storage_reset" in guards, "an explicit reset must still be able to proceed"
+
+
+# --- the gates must not fall back to the destructive state -----------------
+
+UNKNOWN_FAIL = "Fail fast when the storage state could not be determined"
+GATED_ROLE_FILES = [
+    "collection/roles/nvme_namespace/tasks/main.yml",
+    "collection/roles/raid_fs/tasks/main.yml",
+]
+
+
+@pytest.mark.parametrize("role_task_file", GATED_ROLE_FILES)
+def test_gates_never_default_to_empty(role_task_file):
+    """An undefined state fact is a non-answer, and must not authorize a wipe."""
+    text = (REPO / role_task_file).read_text()
+    assert "default('EMPTY')" not in text, (
+        f"{role_task_file} still treats an undefined storage state as EMPTY"
+    )
+
+
+@pytest.mark.parametrize("role_task_file", GATED_ROLE_FILES)
+def test_unknown_failure_exists_and_outranks_every_other_failure(role_task_file):
+    names = [str(t.get("name", "")) for t in _tasks_of(role_task_file)]
+    unknown = [i for i, n in enumerate(names) if n.startswith(UNKNOWN_FAIL)]
+    others = [
+        i for i, n in enumerate(names) if n.startswith(UNHEALTHY_FAIL) or n.startswith(FOREIGN_FAIL)
+    ]
+    assert unknown, f"{role_task_file} has no fail-fast guard on state=UNKNOWN"
+    assert others, f"{role_task_file} lost its FOREIGN failures"
+    assert unknown[0] < min(others), "UNKNOWN must be decided before the layout failures"
+
+
+@pytest.mark.parametrize("role_task_file", GATED_ROLE_FILES)
+def test_unknown_failure_stays_overridable_by_an_explicit_reset(role_task_file):
+    task = next(
+        t for t in _tasks_of(role_task_file) if str(t.get("name", "")).startswith(UNKNOWN_FAIL)
+    )
+    guards = " ".join(str(w) for w in task["when"])
+    assert "xinas_storage_reset" in guards, guards

--- a/xinas_menu/screens/raid.py
+++ b/xinas_menu/screens/raid.py
@@ -1526,6 +1526,22 @@ def _format_raid_overview(arrays: dict, extended: bool = False, banner: str | No
                 lines.append(_box_line(f"  {_DIM}Merge Write Max{_NC}     |  {_usecs(mw_max)}"))
                 lines.append(_box_line(f"  {_DIM}Merge Write Wait{_NC}    |  {_usecs(mw_wait)}"))
 
+            # ── TRIM / Discard ──
+            # Create-only knobs (the daemon's RaidModify has no field for
+            # either), decided by the installer from the members' discard
+            # support — see Installer/raid-spec §7.5. Shown here because this
+            # is the only place an operator can find out what the array got.
+            lines.append(_box_line())
+            lines.append(_box_sep())
+            lines.append(_box_line(f" {_BLD}{_CYN}TRIM / DISCARD{_NC}"))
+            lines.append(_box_sep())
+            lines.append(
+                _box_line(f"  {_DIM}Discard (TRIM){_NC}      |  {_on_off(arr.get('discard'))}")
+            )
+            lines.append(
+                _box_line(f"  {_DIM}Drive TRIM{_NC}          |  {_on_off(arr.get('drive_trim'))}")
+            )
+
             # ── Device Health & Wear ──
             health = arr.get("devices_health") or []
             wear = arr.get("devices_wear") or []


### PR DESCRIPTION
Three commits, split so the P0 can be cherry-picked onto `main` on its own.

## `ccd8152` — fail closed when the storage state cannot be determined (P0)

`EMPTY` is the state that authorizes namespace deletion and `mkfs`, and it was reachable from probes that never answered. With xiRAID down — daemon stopped, kernel module not loaded, `xicli` absent — `xicli raid show` exits non-zero **and** `/dev/xi_data` does not exist, which is byte-for-byte how a factory-fresh node looks. A routine re-run therefore classified a live, data-bearing array as `EMPTY` and rebuilt the namespaces over it, contradicting the absolute guarantee in raid-spec §11.

Detection now records whether each probe answered (array probe iff `rc == 0`; filesystem probe iff the volume is absent or `blkid` returned 0/2). A non-answer yields the new **UNKNOWN** state, which outranks every other state — including `FOREIGN`, which would assert knowledge of an array list that could not be read. Both roles fail fast on it, naming the remedy; an explicit confirmed reset still wins. The gates now default to `UNKNOWN` rather than `EMPTY`, so an undefined fact is a non-answer instead of an authorization.

## `4fd2e1e` — enable discard on new arrays when the hardware allows it

xiRAID's `--discard` defaults to `0` and the installer never set it, so discards issued by XFS were dropped at the RAID layer. New arrays now get it when every member qualifies, decided **per array** — a log array on eligible namespaces still gets discard when a data-array member does not.

Two probes per member: discard support (`/sys/block/<dev>/queue/discard_max_bytes`) and RZAT (the NVMe namespace `DLFEAT` field). xiRAID requires RZAT for `--discard`, and it is not implied by discard support — the kernel attribute that used to answer it (`discard_zeroes_data`) was removed in 4.12. A non-NVMe member, or a host without `nvme-cli`, is simply ineligible: that degrades to "create without discard", never to a failed create.

`--drive_trim` is deliberately **not** passed. Per the [xiRAID Classic 4.4 command reference](https://xinnor.io/docs/xiRAID-4.4.0/E/en/CR/raid.html) it TRIMs the disks *before* creation, and xiRAID enables it by default only when all disks support RZAT **and none carries metadata** — the condition that keeps a TRIM from destroying data that is still recoverable. Forcing it would override exactly that check.

`xicli raid create --help` is probed once, outside the per-array loop: every flag named in `xiraid_trim_create_args` must appear there, since an unrecognised argument fails *every* array creation. An override naming a flag this build lacks disables discard instead of breaking the install.

Extended Details in the TUI gains a TRIM / Discard block. The values already reached the TUI through `spec.tuning`; an unobserved knob renders as `unknown`, not as a plausible `Disabled`.

## `28fc675` — CLAUDE.md rules

Spec-first now requires validating third-party behavior against the vendor's own documentation, with URL and product version cited inline. The `--drive_trim` misreading above is the worked example: a spec written from the flag name alone had the installer overriding a data-safety check. Deferred work gets a home in `docs/TODO.md`, written in the change that defers it.

## Rebuild

`Requires-Rebuild: nvme_namespace, raid_fs` (union of the two role commits). Both roles must re-run on update; nothing here touches network, systemd unit definitions, or the storage layout of an existing array.

## Verification

`pytest` 669 passed · `ruff check` / `format --check` · `pyright` 0 errors · `yamllint` · `ansible-lint` 0 failures · `markdownlint` 0 issues over 142 files.

The two overlapping files were split by hand, so `ccd8152` was checked out into a throwaway worktree and tested on its own: 634 passed, 0 failures, no TRIM code present.

## Not included

- Day-2 array creation from the TUI still omits discard — the control-path `Disk` object carries neither probe result, so the wizard has nothing to decide from. Recorded in `docs/TODO.md` with the four-layer path to closing it.
- `MATCH` still does not verify that the arrays are online, though raid-spec claims it does. Tracked separately; left untouched here to keep the P0 cherry-pickable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)