### PR TITLE
fix(raid): enforce the xiRAID 4.4 array name rule in TUI, API and contract

### DIFF
--- a/docs/Storage/raid-management-spec.md
+++ b/docs/Storage/raid-management-spec.md
@@ -280,12 +280,45 @@ only visible symptom.
 
 ### Step — name
 
-`InputDialog` with validation:
+`InputDialog` with validation. **The rule below is the xiRAID Classic 4.4 engine rule, not a xiNAS convention** — it is transcribed from the [xiRAID 4.4 command reference](https://xinnor.io/docs/xiRAID-4.4.0/E/en/CR/raid.html) for `xicli raid create -n/--name`, and it is the canonical statement of array naming for the whole product (TUI, control-path plan validator, API contract):
 
-- 1 ≤ length ≤ 64.
-- Matches `_ARRAY_NAME_RE = ^[a-zA-Z0-9_-]+$`.
+| Rule | Value | Enforcement |
+|---|---|---|
+| Length | 1–28 characters | hard reject |
+| Character set | Latin letters, digits, underscore — `^[A-Za-z0-9_]{1,28}$`. **Hyphens are NOT allowed.** | hard reject |
+| Reserved names | `power`, `uevent` (they collide with the sysfs attributes under `/sys/block/xi_<name>/`) | hard reject |
+| Partition-identifier collisions | A name that is an existing array's name plus trailing digits, or vice versa — `test1` next to an existing `test`, because partitions of `/dev/xi_test` surface as `/dev/xi_test1` | **warn + allow override** |
 
-A failed validation re-prompts via the `while True:` loop until the user enters a valid name or cancels. This is the wizard's first step, so its dialog never renders a Back button.
+The first three are engine rejections: a name that violates them fails inside `xicli`, so accepting it anywhere upstream only defers the failure past the operator's confirmation. The fourth is worded in the reference as something to *avoid*, not something the engine refuses, so it is a warning the operator can accept, never a block.
+
+The rule is implemented once, in [xinas_menu/utils/xiraid_names.py](../../xinas_menu/utils/xiraid_names.py) (`ARRAY_NAME_RE`, `RESERVED_ARRAY_NAMES`, `validate_array_name()`, `partition_collision()`). The screens hold **no name pattern of their own** — the per-screen `_ARRAY_NAME_RE` / `_POOL_NAME_RE` constants are gone, and `tests/test_xiraid_name_rules.py` fails if a hyphenated character class reappears in either screen, which is how the three rules drifted apart in the first place. A failed validation re-prompts via the `while True:` loop until the user enters a valid name or cancels; a collision warning renders a `ConfirmDialog` whose "No" answer re-prompts and whose "Yes" answer proceeds. This is the wizard's first step, so its dialog never renders a Back button.
+
+To evaluate collisions the wizard fetches `GET /api/v1/arrays` alongside the pool list, up front. That call is swallowed on failure (`existing = []`) exactly like the pool fetch — a control-path hiccup degrades the warning, it does not block array creation.
+
+#### Why the rule lives in three places, and why the published pattern moved
+
+Before this change all three enforcement points disagreed: the TUI allowed hyphens and 64 characters, `docs/control-path/api-v1.yaml` published `^[A-Za-z0-9_-]{1,63}$`, and the engine accepted neither. A name could pass the TUI and be rejected by the API, or pass both and be rejected by `xicli` *after* the operator confirmed the create. Every layer now enforces the same rule:
+
+1. **TUI** — rejects at the name step, before any drive selection work is spent.
+2. **Control-path plan validator** — `NAME_RE` in [xiNAS-MCP/src/lib/xiraid/schema.ts](../../xiNAS-MCP/src/lib/xiraid/schema.ts), surfaced as the `name_invalid` blocker from `validateCreateSpec()`. This is the authoritative gate for non-TUI clients (REST, MCP, `xinasctl`).
+3. **`api-v1.yaml`** — the published `XiraidArray.spec.name` pattern was **tightened** to `^[A-Za-z0-9_]{1,28}$`.
+
+Tightening a published pattern is normally the breaking direction, so the choice was made deliberately rather than by default:
+
+- **The old pattern advertised values the system can never accept.** `my-array` was schema-valid and unconditionally failed at apply. A contract that documents impossible values is not "permissive", it is wrong.
+- **No conforming instance is lost.** Every array that can exist on a node already matches the tighter pattern, because xiRAID itself refuses to create anything else. The change invalidates no stored state and no request that ever succeeded.
+- **Leaving it loose would keep the contract knowingly false**, which is the exact drift this change exists to remove — clients generated from the schema would keep offering hyphens.
+
+**The `oasdiff` gate does not fail on it**, and that was checked rather than assumed. `XiraidArray` is referenced only from *responses* (`GET /arrays`, `GET /arrays/{id}`); the create/modify request body is the generic `requestBodies/Mutating`, whose `spec` is untyped. So `oasdiff` reports the change as two `response-property-pattern-changed` entries at **INFO** severity, and the workflow's `fail-on: ERR` leaves the job green:
+
+```text
+2 changes: 0 error, 0 warning, 2 info
+info  [response-property-pattern-changed] in API GET /arrays
+      the `.../spec/name` response's property pattern was changed
+      from `^[A-Za-z0-9_-]{1,63}$` to `^[A-Za-z0-9_]{1,28}$` for the status `200`
+```
+
+No exclusion was added to [.github/workflows/ci.yml](../../.github/workflows/ci.yml) and no `oasdiff` rule was suppressed. Note the corollary: because the request side is untyped, the schema pattern is documentation, not request validation — the enforcing gate for API clients is `validateCreateSpec()`, which is why the rule has to be right in **both** places.
 
 ### Step — RAID level
 
@@ -463,7 +496,15 @@ The result is fed into `DrivePickerScreen` so the operator can apply the same NU
 
 Same flow as RAID Create up to the drive picker, then:
 
-1. Pool name validated against `_POOL_NAME_RE = ^[a-zA-Z0-9_-]+$`.
+1. Pool name validated against `POOL_NAME_RE = ^[A-Za-z0-9_]{1,64}$` via `validate_pool_name()` in [xinas_menu/utils/xiraid_names.py](../../xinas_menu/utils/xiraid_names.py) — the **array character set, hyphens included in the ban**, over the control path's incumbent 64-character bound.
+
+   The xiRAID 4.4 command reference documents no naming rule for `xicli pool create -n` (it says only "The name of the spare pool"), so unlike the array rule this is a xiNAS choice. The character set is deliberately conservative: pool names are engine identifiers handed to the same `xicli` binary, hyphens are not accepted anywhere xiRAID naming *is* documented, and the two failure modes are not symmetric — a name rejected here costs the operator one keystroke, while a name accepted here and rejected by the engine fails after the confirmation step, mid-apply. If Xinnor documents a laxer pool rule, relax this one; do not relax it on the assumption that it is lax.
+
+   The **length bound is deliberately not** the array's 28. There is no vendor source for a pool length limit, and xiNAS has positive evidence that longer names work: the array executor creates its own spare pools as `xnsp_<array>` (up to 33 characters for a maximum-length array name, `derivedPoolName()` in [xiNAS-MCP/src/lib/xiraid/validate.ts](../../xiNAS-MCP/src/lib/xiraid/validate.ts)). A 28-character pool rule would outlaw pools this system creates itself, so the incumbent 64 stands; `POOL_NAME_MAX_LEN` must remain ≥ `len("xnsp_") + ARRAY_NAME_MAX_LEN`.
+
+   `power`/`uevent` are **not** reserved for pools. Those two names are prohibited because they collide with sysfs attributes under `/sys/block/xi_<name>/`, and a spare pool is not a block device.
+
+   The `Pool` schema in [api-v1.yaml](../../docs/control-path/api-v1.yaml) intentionally keeps `name` unpatterned. Publishing a pattern there would over-claim — it would present a xiNAS-local precaution as a vendor contract — and would spend a second `oasdiff` breaking-change finding on a rule we are less sure of than the array one. Enforcement lives in `requireName()` in [xiNAS-MCP/src/api/plan/providers/pool.ts](../../xiNAS-MCP/src/api/plan/providers/pool.ts), which returns `INVALID_ARGUMENT` at plan time.
 2. Drive picker with `_get_free_nvme_drives()` as the source.
 3. Confirmation summary.
 4. Names normalised to `/dev/<name>`.

--- a/docs/control-path/adr/0006-xiraid-array.md
+++ b/docs/control-path/adr/0006-xiraid-array.md
@@ -25,6 +25,8 @@ Decisions taken during brainstorming (2026-06-07), which this ADR records:
 
 Array **`id == spec.name`**. xiRAID array names are unique per node, `Filesystem.spec.backing_device` resolves to `/dev/xi_<name>`, and the installer/Ansible day-1 path already keys on the name — so the name is the natural, stable join key. Names match `^[A-Za-z0-9_-]{1,63}$`. Import surfaces a foreign xiRAID UUID; it is mapped to a control-path id at adopt time via the `new_name` field (see *Import*).
 
+> **Correction (2026-08-14).** The `^[A-Za-z0-9_-]{1,63}$` above was never the engine's rule. xiRAID Classic 4.4 accepts **at most 28 characters of Latin letters, digits and underscore — no hyphens** — and prohibits the names `power` and `uevent` ([command reference](https://xinnor.io/docs/xiRAID-4.4.0/E/en/CR/raid.html)). The corrected rule, and the reasoning behind tightening the published `api-v1.yaml` pattern to match it, live in [docs/Storage/raid-management-spec.md](../../Storage/raid-management-spec.md) §4 "Step — name". Everything else in this section stands: the identity decision does not depend on the width of the character class.
+
 ### Agent sandbox prerequisite (transport)
 
 The gRPC client dials the xiRAID daemon over **TCP with TLS** (`host:port` from `/etc/xraid/net.conf`, default `localhost:6066`). The hardened agent unit currently sets `RestrictAddressFamilies=AF_UNIX AF_NETLINK` (`xinas-agent.service`), which blocks any TCP socket — the collector/executor would fail at `connect()` before any logic runs.

--- a/docs/control-path/api-v1.yaml
+++ b/docs/control-path/api-v1.yaml
@@ -590,7 +590,18 @@ components:
           type: object
           required: [name, level, member_disk_ids]
           properties:
-            name: { type: string, pattern: "^[A-Za-z0-9_-]{1,63}$" }
+            name:
+              type: string
+              pattern: "^[A-Za-z0-9_]{1,28}$"
+              description: >-
+                xiRAID Classic 4.4 engine rule for `xicli raid create -n`: at most 28
+                characters, Latin letters/digits/underscore only (no hyphens). The names
+                `power` and `uevent` are additionally rejected by the plan validator
+                (they collide with sysfs attributes under /sys/block/xi_<name>/), and a
+                name that differs from an existing array's name only by trailing digits
+                is warned about — partitions of /dev/xi_test surface as /dev/xi_test1.
+                Tightened from ^[A-Za-z0-9_-]{1,63}$, which advertised names the engine
+                always rejected; see docs/Storage/raid-management-spec.md §4 "Step — name".
             level:
               type: string
               enum: [raid0, raid1, raid5, raid6, raid7, raid10, raid50, raid60, raid70, "n+m"]

--- a/tests/test_xiraid_name_rules.py
+++ b/tests/test_xiraid_name_rules.py
@@ -1,0 +1,164 @@
+"""xiRAID Classic 4.4 array / spare-pool name rules.
+
+The engine rule (`xicli raid create -n`) is at most 28 characters of Latin
+letters, digits and underscore — no hyphens — and the names ``power`` and
+``uevent`` are prohibited. Names that differ from an existing array only by
+trailing digits collide with partition identifiers (`/dev/xi_test1` is both a
+partition of `/dev/xi_test` and a plausible array name) and are warned about,
+not blocked. See docs/Storage/raid-management-spec.md §4 "Step — name".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from xinas_menu.utils.xiraid_names import (
+    ARRAY_NAME_MAX_LEN,
+    ARRAY_NAME_RE,
+    POOL_NAME_RE,
+    RESERVED_ARRAY_NAMES,
+    partition_collision,
+    validate_array_name,
+    validate_pool_name,
+)
+
+
+class TestArrayNameCharset:
+    @pytest.mark.parametrize("name", ["data0", "DATA_0", "a", "_", "9", "xi_raid_5"])
+    def test_accepts_latin_letters_digits_underscore(self, name: str) -> None:
+        assert validate_array_name(name) is None
+
+    def test_rejects_hyphen(self) -> None:
+        err = validate_array_name("my-array")
+        assert err is not None
+        assert "hyphen" in err.lower()
+
+    @pytest.mark.parametrize("name", ["данные", "data.0", "data 0", "data/0", "data+0"])
+    def test_rejects_non_latin_and_punctuation(self, name: str) -> None:
+        assert validate_array_name(name) is not None
+
+    def test_rejects_empty(self) -> None:
+        assert validate_array_name("") is not None
+
+
+class TestArrayNameLength:
+    def test_max_length_is_28(self) -> None:
+        assert ARRAY_NAME_MAX_LEN == 28
+
+    def test_accepts_exactly_28_characters(self) -> None:
+        assert validate_array_name("a" * 28) is None
+
+    def test_rejects_29_characters(self) -> None:
+        err = validate_array_name("a" * 29)
+        assert err is not None
+        assert "28" in err
+
+
+class TestReservedArrayNames:
+    def test_reserved_set_is_power_and_uevent(self) -> None:
+        assert RESERVED_ARRAY_NAMES == frozenset({"power", "uevent"})
+
+    @pytest.mark.parametrize("name", ["power", "uevent"])
+    def test_rejects_reserved_names(self, name: str) -> None:
+        err = validate_array_name(name)
+        assert err is not None
+        assert name in err
+
+    @pytest.mark.parametrize("name", ["powerful", "uevents", "power0"])
+    def test_accepts_names_that_merely_start_with_a_reserved_word(self, name: str) -> None:
+        assert validate_array_name(name) is None
+
+    @pytest.mark.parametrize("name", ["Power", "UEVENT"])
+    def test_reserved_check_is_case_sensitive(self, name: str) -> None:
+        # The prohibition exists because `power` and `uevent` are sysfs
+        # attribute names under /sys/block/xi_<name>/, and those are lowercase.
+        assert validate_array_name(name) is None
+
+
+class TestPartitionCollision:
+    def test_warns_when_new_name_is_existing_name_plus_digits(self) -> None:
+        warning = partition_collision("test1", ["test", "other"])
+        assert warning is not None
+        assert "test" in warning
+
+    def test_warns_when_existing_name_is_new_name_plus_digits(self) -> None:
+        warning = partition_collision("test", ["test1"])
+        assert warning is not None
+        assert "test1" in warning
+
+    def test_no_warning_for_unrelated_names(self) -> None:
+        assert partition_collision("data0", ["test", "scratch"]) is None
+
+    def test_no_warning_when_suffix_is_not_all_digits(self) -> None:
+        assert partition_collision("test_1", ["test"]) is None
+        assert partition_collision("testx1", ["test"]) is None
+
+    def test_no_warning_against_an_identical_name(self) -> None:
+        # A duplicate name is a different error (the API's `name_taken`
+        # blocker); it must not be reported as a partition collision.
+        assert partition_collision("test", ["test"]) is None
+
+    def test_no_warning_with_no_existing_arrays(self) -> None:
+        assert partition_collision("test1", []) is None
+
+
+class TestPoolName:
+    @pytest.mark.parametrize("name", ["spare0", "SPARE_0", "a" * 64])
+    def test_accepts_latin_letters_digits_underscore(self, name: str) -> None:
+        assert validate_pool_name(name) is None
+
+    def test_rejects_hyphen(self) -> None:
+        err = validate_pool_name("spare-0")
+        assert err is not None
+        assert "hyphen" in err.lower()
+
+    def test_rejects_65_characters(self) -> None:
+        assert validate_pool_name("a" * 65) is not None
+
+    def test_admits_the_derived_xnsp_pool_name_of_the_longest_array(self) -> None:
+        # The array executor creates spare pools named `xnsp_<array>`. A pool
+        # rule narrower than that would outlaw the pools xiNAS creates itself.
+        assert validate_pool_name("xnsp_" + "a" * ARRAY_NAME_MAX_LEN) is None
+
+    def test_rejects_empty(self) -> None:
+        assert validate_pool_name("") is not None
+
+    @pytest.mark.parametrize("name", ["power", "uevent"])
+    def test_reserved_array_names_are_allowed_for_pools(self, name: str) -> None:
+        # A spare pool is not a block device, so it has no /sys/block/xi_<name>/
+        # directory to collide with.
+        assert validate_pool_name(name) is None
+
+
+class TestScreensShareTheRule:
+    """The screens must call the shared validators, not re-declare the rule.
+
+    Both screens carried their own ``^[a-zA-Z0-9_-]+$`` for a long time, which
+    is how they came to disagree with the engine and with each other. A local
+    character class is the regression to catch.
+    """
+
+    @pytest.mark.parametrize(
+        ("path", "validator"),
+        [
+            ("xinas_menu/screens/raid.py", "validate_array_name"),
+            ("xinas_menu/screens/spare_pools.py", "validate_pool_name"),
+        ],
+    )
+    def test_screen_defers_to_the_shared_validator(self, path: str, validator: str) -> None:
+        source = (Path(__file__).resolve().parents[1] / path).read_text(encoding="utf-8")
+        assert "from xinas_menu.utils.xiraid_names import" in source
+        assert validator in source
+        for hyphenated in ("[a-zA-Z0-9_-]", "[A-Za-z0-9_-]"):
+            assert hyphenated not in source, (
+                f"{path} declares its own name character class {hyphenated} — "
+                "xiRAID does not accept hyphens in array or pool names"
+            )
+
+    def test_exported_patterns_reject_hyphenated_names(self) -> None:
+        # The patterns are exported for callers that want the raw rule
+        # (e.g. an InputDialog validator); they must agree with the validators.
+        assert ARRAY_NAME_RE.match("my-array") is None
+        assert POOL_NAME_RE.match("my-pool") is None

--- a/xiNAS-MCP/src/__tests__/api/pool-providers.test.ts
+++ b/xiNAS-MCP/src/__tests__/api/pool-providers.test.ts
@@ -37,6 +37,31 @@ const DISK = (path: string, over: Record<string, unknown> = {}): Row => ({
 });
 
 describe('pool providers (S9 T8) — the S4 imperative freshness pattern', () => {
+  // Pool names are engine identifiers handed to the same `xicli` binary as
+  // array names. The 4.4 reference documents no rule for `xicli pool create -n`,
+  // so xiNAS applies the documented array character set: Latin letters, digits
+  // and underscore. Hyphens are not accepted anywhere xiRAID naming is
+  // documented. See docs/Storage/raid-management-spec.md §7.3.
+  it('create: rejects hyphenated names', async () => {
+    await expect(
+      poolCreateProvider.preflight(ctxWith([DISK('/dev/a')]), {
+        name: 'spare-1',
+        drives: ['/dev/a'],
+      }),
+    ).rejects.toThrow(/spec\.name/);
+  });
+
+  it('create: accepts an underscored name of the derived xnsp_<array> width', async () => {
+    // The array executor creates pools named `xnsp_<array>` — up to 33 chars
+    // with a 28-char array name — so the pool rule must not be narrower.
+    const derived = `xnsp_${'a'.repeat(28)}`;
+    const out = await poolCreateProvider.preflight(ctxWith([DISK('/dev/a')]), {
+      name: derived,
+      drives: ['/dev/a'],
+    });
+    expect(out.blockers).toEqual([]);
+  });
+
   it('create: absence pin (revision 0), lease, blockers for dup/system/unsafe', async () => {
     const clean = await poolCreateProvider.preflight(ctxWith([DISK('/dev/a')]), {
       name: 'spare1',

--- a/xiNAS-MCP/src/__tests__/lib/xiraid/validate.test.ts
+++ b/xiNAS-MCP/src/__tests__/lib/xiraid/validate.test.ts
@@ -118,6 +118,26 @@ describe('validateCreateSpec', () => {
     expect(codes(spec({ name: 'taken' }))).toContain('name_taken');
   });
 
+  // The xiRAID Classic 4.4 engine rule for `xicli raid create -n`: <= 28 chars,
+  // Latin letters/digits/underscore, no hyphens. Anything looser is a name the
+  // engine rejects after the operator has confirmed the create.
+  it('rejects hyphens — xicli does not accept them', () => {
+    expect(codes(spec({ name: 'my-array' }))).toContain('name_invalid');
+  });
+
+  it('caps names at 28 characters', () => {
+    expect(codes(spec({ name: 'a'.repeat(28) }))).toEqual([]);
+    expect(codes(spec({ name: 'a'.repeat(29) }))).toContain('name_invalid');
+  });
+
+  it('rejects the names xiRAID prohibits (they collide with sysfs attributes)', () => {
+    expect(codes(spec({ name: 'power' }))).toContain('name_invalid');
+    expect(codes(spec({ name: 'uevent' }))).toContain('name_invalid');
+    // The sysfs attributes are lowercase, so only the exact names collide.
+    expect(codes(spec({ name: 'powerful' }))).toEqual([]);
+    expect(codes(spec({ name: 'Power' }))).toEqual([]);
+  });
+
   it('disk rules — one blocker per offending disk', () => {
     const f = facts({
       disks: [
@@ -166,11 +186,15 @@ describe('validateCreateSpec', () => {
     expect(codes(spec({ spare_disk_ids: ['d1'] }))).toContain('disk_in_use');
   });
 
-  it('derived pool name xnsp_<name> must fit the 63-char namespace', () => {
-    const longName = 'a'.repeat(60); // valid alone, xnsp_+60 = 65 > 63
+  it('the 28-char name cap subsumes the derived xnsp_<name> pool guard on create', () => {
+    // `xnsp_` + 28 = 33 always fits, so no create-time name can trip the
+    // derived-pool guard any more — the name rule rejects it first. The guard
+    // stays reachable on MODIFY, where the array name comes from observed
+    // state (an imported array may carry a name this rule would refuse).
+    const longName = 'a'.repeat(60);
     expect(codes(spec({ name: longName, spare_disk_ids: ['d5'] }))).toContain('name_invalid');
-    // without spares the same name is fine (no pool derived)
-    expect(codes(spec({ name: longName }))).toEqual([]);
+    expect(codes(spec({ name: longName }))).toContain('name_invalid');
+    expect(codes(spec({ name: 'a'.repeat(28), spare_disk_ids: ['d5'] }))).toEqual([]);
   });
 });
 

--- a/xiNAS-MCP/src/api/plan/providers/pool.ts
+++ b/xiNAS-MCP/src/api/plan/providers/pool.ts
@@ -18,7 +18,15 @@ const OBSERVED_POOL_PREFIX = '/xinas/v1/observed/Pool/';
 const OBSERVED_DISK_PREFIX = '/xinas/v1/observed/Disk/';
 const OBSERVED_ARRAY_PREFIX = '/xinas/v1/observed/XiraidArray/';
 
-const NAME_RE = /^[A-Za-z0-9_-]{1,64}$/;
+/**
+ * The 4.4 command reference documents no rule for `xicli pool create -n`, so
+ * xiNAS applies the documented ARRAY character set — Latin letters, digits and
+ * underscore, no hyphens — and keeps the incumbent 64-char bound rather than
+ * inventing a shorter one: the array executor derives pool names as
+ * `xnsp_<array>` (up to 33 chars), so a 28-char rule would outlaw the pools
+ * this system creates itself. See docs/Storage/raid-management-spec.md §7.3.
+ */
+const NAME_RE = /^[A-Za-z0-9_]{1,64}$/;
 
 function invalid(op: string, message: string): ApiException {
   return new ApiException('INVALID_ARGUMENT', `${op}: ${message}`);
@@ -27,7 +35,10 @@ function invalid(op: string, message: string): ApiException {
 function requireName(op: string, raw: unknown): string {
   const name = (raw as { name?: unknown })?.name;
   if (typeof name !== 'string' || !NAME_RE.test(name)) {
-    throw invalid(op, 'spec.name must match [A-Za-z0-9_-]{1,64}');
+    throw invalid(
+      op,
+      'spec.name must match [A-Za-z0-9_]{1,64} — Latin letters, digits and underscore only (no hyphens)',
+    );
   }
   return name;
 }

--- a/xiNAS-MCP/src/lib/xiraid/schema.ts
+++ b/xiNAS-MCP/src/lib/xiraid/schema.ts
@@ -83,7 +83,18 @@ export const LEVEL_CONSTRAINTS: Record<Level, LevelConstraints> = {
 
 export const STRIP_SIZES_KIB = [16, 32, 64, 128, 256] as const;
 export const BLOCK_SIZES = [512, 4096] as const;
-export const NAME_RE = /^[A-Za-z0-9_-]{1,63}$/;
+/**
+ * xiRAID Classic 4.4 rule for `xicli raid create -n/--name`: at most 28
+ * characters of Latin letters, digits and underscore. Hyphens are NOT
+ * accepted. See docs/Storage/raid-management-spec.md §4 "Step — name".
+ */
+export const NAME_RE = /^[A-Za-z0-9_]{1,28}$/;
+
+/**
+ * Names xiRAID prohibits outright — they collide with the sysfs attributes
+ * under /sys/block/xi_<name>/, which are lowercase, so the match is exact.
+ */
+export const RESERVED_NAMES: readonly string[] = ['power', 'uevent'];
 
 export const GROUP_SIZE_MIN = 2;
 export const GROUP_SIZE_MAX = 32;

--- a/xiNAS-MCP/src/lib/xiraid/validate.ts
+++ b/xiNAS-MCP/src/lib/xiraid/validate.ts
@@ -23,6 +23,7 @@ import {
   NAME_RE,
   PRIO_MAX,
   PRIO_MIN,
+  RESERVED_NAMES,
   STRIP_SIZES_KIB,
   SYND_CNT_MAX,
   SYND_CNT_MIN,
@@ -91,7 +92,12 @@ export function validateCreateSpec(spec: XiraidArraySpec, facts: CreateFacts): B
 
   // --- name ---
   if (!NAME_RE.test(spec.name)) {
-    push('name_invalid', `array name '${spec.name}' must match ${NAME_RE}`);
+    push(
+      'name_invalid',
+      `array name '${spec.name}' must match ${NAME_RE} — xiRAID accepts at most 28 characters of Latin letters, digits and underscore (no hyphens)`,
+    );
+  } else if (RESERVED_NAMES.includes(spec.name)) {
+    push('name_invalid', `array name '${spec.name}' is prohibited by xiRAID`);
   } else if (facts.existingArrayNames.includes(spec.name)) {
     push('name_taken', `an array named '${spec.name}' already exists`);
   }

--- a/xinas_menu/screens/raid.py
+++ b/xinas_menu/screens/raid.py
@@ -36,6 +36,7 @@ from xinas_menu.api.control_client import (
 from xinas_menu.api.degraded import degraded_banner
 from xinas_menu.apptype import XiNASAppMixin
 from xinas_menu.utils.xfs_helpers import is_path_under
+from xinas_menu.utils.xiraid_names import partition_collision, validate_array_name
 from xinas_menu.widgets.confirm_dialog import ConfirmDialog
 from xinas_menu.widgets.drive_picker import DrivePickerScreen
 from xinas_menu.widgets.input_dialog import InputDialog
@@ -45,7 +46,6 @@ from xinas_menu.widgets.task_wait_dialog import TaskWaitDialog
 from xinas_menu.widgets.text_view import ScrollableTextView
 from xinas_menu.widgets.wizard import BACK, CANCEL, WizardStep, run_wizard
 
-_ARRAY_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 _RAID_LEVELS = ["0", "1", "5", "6", "10", "50", "60"]
 _STRIP_SIZES = ["16", "32", "64", "128", "256"]
 _CPU_LIST_RE = re.compile(r"^\d+(-\d+)?(,\d+(-\d+)?)*$")
@@ -456,6 +456,15 @@ class RAIDScreen(XiNASAppMixin, Screen):
             p_rows = []
         pools = _pools_by_name(p_rows)
 
+        # Existing array names feed the partition-identifier collision warning
+        # (spec §4). A failed fetch degrades the warning, it does not block the
+        # wizard — the hard name rules do not depend on it.
+        try:
+            a_rows = await asyncio.to_thread(self.app.control.result, "/api/v1/arrays")
+        except ControlPathError:
+            a_rows = []
+        existing_names = list(_arrays_from_api(a_rows))
+
         async def name_step(answers, allow_back, step_no):
             default = answers.get("name", "")
             while True:
@@ -472,17 +481,19 @@ class RAIDScreen(XiNASAppMixin, Screen):
                     return CANCEL
                 if name is BACK:
                     return BACK
-                if len(name) > 64:
-                    self.app.notify("Array name must be 64 characters or fewer.", severity="error")
+                error = validate_array_name(name)
+                if error is not None:
+                    self.app.notify(error, severity="error")
                     default = name
                     continue
-                if not _ARRAY_NAME_RE.match(name):
-                    self.app.notify(
-                        "Array name must contain only letters, digits, hyphens, and underscores.",
-                        severity="error",
+                warning = partition_collision(name, existing_names)
+                if warning is not None:
+                    proceed = await self.app.push_screen_wait(
+                        ConfirmDialog(warning, "Possible Name Collision")
                     )
-                    default = name
-                    continue
+                    if not proceed:
+                        default = name
+                        continue
                 return name
 
         async def level_step(answers, allow_back, step_no):

--- a/xinas_menu/screens/spare_pools.py
+++ b/xinas_menu/screens/spare_pools.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 from typing import Any
 
 _log = logging.getLogger(__name__)
@@ -28,6 +27,7 @@ from textual.widgets import Footer, Label
 from xinas_menu.api.control_client import ControlClient, ControlPathError, quote_id
 from xinas_menu.apptype import XiNASAppMixin
 from xinas_menu.screens.raid import _list_api_disks
+from xinas_menu.utils.xiraid_names import validate_pool_name
 from xinas_menu.widgets.checklist_dialog import ChecklistDialog
 from xinas_menu.widgets.confirm_dialog import ConfirmDialog
 from xinas_menu.widgets.drive_picker import DrivePickerScreen
@@ -35,8 +35,6 @@ from xinas_menu.widgets.input_dialog import InputDialog
 from xinas_menu.widgets.menu_list import MenuItem, NavigableMenu
 from xinas_menu.widgets.select_dialog import SelectDialog
 from xinas_menu.widgets.text_view import ScrollableTextView
-
-_POOL_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 _MENU = [
     MenuItem("1", "View Pools"),
@@ -321,11 +319,9 @@ class SparePoolScreen(XiNASAppMixin, Screen):
             )
             if not name:
                 return
-            if not _POOL_NAME_RE.match(name):
-                self.app.notify(
-                    "Pool name must contain only letters, digits, hyphens, and underscores.",
-                    severity="error",
-                )
+            error = validate_pool_name(name)
+            if error is not None:
+                self.app.notify(error, severity="error")
                 continue
             break
 

--- a/xinas_menu/utils/xiraid_names.py
+++ b/xinas_menu/utils/xiraid_names.py
@@ -1,0 +1,101 @@
+"""xiRAID Classic name rules for arrays and spare pools.
+
+Single source of truth for the constraints the xiRAID engine actually
+enforces, so the TUI stops accepting names that `xicli` rejects after the
+operator has already confirmed the operation.
+
+Array names, per the xiRAID Classic 4.4 command reference for
+``xicli raid create -n/--name``
+(https://xinnor.io/docs/xiRAID-4.4.0/E/en/CR/raid.html):
+
+* at most 28 characters;
+* Latin letters, digits and underscore only — **no hyphens**;
+* ``power`` and ``uevent`` are prohibited;
+* names that could collide with partition identifiers should be avoided —
+  ``/dev/xi_test`` partitions surface as ``/dev/xi_test1``, so an array named
+  ``test1`` next to an existing ``test`` is ambiguous. The reference calls
+  this something to avoid rather than something the engine refuses, so
+  :func:`partition_collision` returns a warning and the caller may override.
+
+Pool names are not documented in the reference; xiNAS applies the array
+character set to them as a conservative choice, but keeps the control path's
+incumbent 64-char bound. See docs/Storage/raid-management-spec.md §4 and §7.3.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+ARRAY_NAME_MAX_LEN = 28
+#: Not a vendor number: the reference documents no pool rule, so xiNAS keeps
+#: the control path's incumbent bound rather than inventing a shorter one. It
+#: must stay >= len("xnsp_") + ARRAY_NAME_MAX_LEN, because the array executor
+#: derives its spare pools as ``xnsp_<array>``.
+POOL_NAME_MAX_LEN = 64
+
+ARRAY_NAME_RE = re.compile(rf"^[A-Za-z0-9_]{{1,{ARRAY_NAME_MAX_LEN}}}$")
+POOL_NAME_RE = re.compile(rf"^[A-Za-z0-9_]{{1,{POOL_NAME_MAX_LEN}}}$")
+
+#: Prohibited by xiRAID: they collide with the sysfs attributes that live
+#: under ``/sys/block/xi_<name>/``. Matched case-sensitively — sysfs attribute
+#: names are lowercase, so ``Power`` collides with nothing.
+RESERVED_ARRAY_NAMES = frozenset({"power", "uevent"})
+
+_CHARSET_MSG = (
+    "may contain only Latin letters, digits, and underscores — hyphens are not allowed by xiRAID"
+)
+
+
+def _charset_error(kind: str, name: str, pattern: re.Pattern[str], max_len: int) -> str | None:
+    if not name:
+        return f"{kind} name must not be empty."
+    if len(name) > max_len:
+        return f"{kind} name must be {max_len} characters or fewer (xiRAID limit)."
+    if not pattern.match(name):
+        return f"{kind} name {_CHARSET_MSG}."
+    return None
+
+
+def validate_array_name(name: str) -> str | None:
+    """Return an operator-facing error for *name*, or ``None`` when it is usable."""
+    error = _charset_error("Array", name, ARRAY_NAME_RE, ARRAY_NAME_MAX_LEN)
+    if error is not None:
+        return error
+    if name in RESERVED_ARRAY_NAMES:
+        return f"'{name}' is a name xiRAID prohibits for arrays. Choose another."
+    return None
+
+
+def validate_pool_name(name: str) -> str | None:
+    """Return an operator-facing error for *name*, or ``None`` when it is usable.
+
+    ``power``/``uevent`` are *not* reserved here: a spare pool is not a block
+    device, so it has no ``/sys/block/xi_<name>/`` directory to collide with.
+    """
+    return _charset_error("Pool", name, POOL_NAME_RE, POOL_NAME_MAX_LEN)
+
+
+def partition_collision(name: str, existing: Iterable[str]) -> str | None:
+    """Return a warning when *name* could be read as a partition of an existing array.
+
+    Digits appended to an array name are how partitions of ``/dev/xi_<name>``
+    are spelled, so ``test`` and ``test1`` are ambiguous in either direction.
+    An exact match is not a collision — that is a duplicate name, which the
+    control path reports separately as ``name_taken``.
+    """
+    for other in existing:
+        if not other or other == name:
+            continue
+        if name.startswith(other) and name[len(other) :].isdigit():
+            return (
+                f"'{name}' looks like a partition of the existing array '{other}' "
+                f"(/dev/xi_{other} partitions appear as /dev/xi_{name}). "
+                "Continue anyway?"
+            )
+        if other.startswith(name) and other[len(name) :].isdigit():
+            return (
+                f"Partitions of '{name}' would appear as /dev/xi_{other}, which "
+                f"collides with the existing array '{other}'. Continue anyway?"
+            )
+    return None


### PR DESCRIPTION
## Problem

The TUI, the published OpenAPI pattern and the xiRAID engine each had a different idea of a legal array name:

| Layer | Rule before | Wrong how |
|---|---|---|
| `xinas_menu/screens/raid.py` | `^[a-zA-Z0-9_-]+$`, ≤ 64 | allows hyphens, 36 chars too long |
| `docs/control-path/api-v1.yaml` | `^[A-Za-z0-9_-]{1,63}$` | allows hyphens, 35 chars too long |
| xiRAID Classic 4.4 engine | `^[A-Za-z0-9_]{1,28}$` | — |

So a name could pass the TUI and be rejected by the API, or pass both and be rejected by `xicli` **after** the operator confirmed the create.

## The rule

Per the [xiRAID 4.4 command reference](https://xinnor.io/docs/xiRAID-4.4.0/E/en/CR/raid.html) for `xicli raid create -n/--name`:

| Rule | Value | Enforcement |
|---|---|---|
| Length | 1–28 characters | hard reject |
| Character set | Latin letters, digits, underscore — **no hyphens** | hard reject |
| Reserved | `power`, `uevent` (sysfs attributes under `/sys/block/xi_<name>/`) | hard reject |
| Partition-identifier collision | `test1` next to an existing `test` | **warn + allow override** |

The reference calls the fourth something to *avoid*, not something the engine refuses, so it is a warning the operator can accept — never a block.

## Contract decision: tightened, and CI stays green

`XiraidArray.spec.name` was tightened to `^[A-Za-z0-9_]{1,28}$`. The old pattern advertised values the system can never accept, and no conforming instance is lost — xiRAID itself refuses to create anything else.

`oasdiff` was run locally against `origin/main` rather than assumed:

```text
2 changes: 0 error, 0 warning, 2 info
info  [response-property-pattern-changed] in API GET /arrays
      the `.../spec/name` response's property pattern was changed
      from `^[A-Za-z0-9_-]{1,63}$` to `^[A-Za-z0-9_]{1,28}$` for the status `200`
```

`XiraidArray` is referenced only from **responses** — `POST /arrays` uses the generic `requestBodies/Mutating` with an untyped `spec` — so this lands as INFO and the gate's `fail-on: ERR` passes. No exclusion added, no rule suppressed. The corollary is written into the spec: since the request side is untyped, the schema pattern is documentation, and `validateCreateSpec()` is the enforcing gate for API clients.

## Spare pools: charset yes, length no

Hyphens are gone (`^[A-Za-z0-9_]{1,64}$`), but the 28-char cap was deliberately **not** copied. The array executor derives its own pools as `xnsp_<array>` — up to 33 characters — so a 28-char pool rule would outlaw pools xiNAS creates itself. There is no vendor source for a pool length limit, so the incumbent 64 stands. `Pool.name` in `api-v1.yaml` stays unpatterned: publishing a xiNAS-local precaution as a vendor contract would over-claim.

## Changes

- **Spec first** — [docs/Storage/raid-management-spec.md](docs/Storage/raid-management-spec.md) §4 / §7.3 is the canonical statement of the rule and carries both decisions with their reasoning. [ADR-0006](docs/control-path/adr/0006-xiraid-array.md) gets a dated correction note rather than a silent rewrite of history.
- **New `xinas_menu/utils/xiraid_names.py`** — the rule implemented once. Both screens' private `_ARRAY_NAME_RE` / `_POOL_NAME_RE` are deleted; two private copies are how the layers drifted.
- **Control path** — `NAME_RE` + `RESERVED_NAMES` in `schema.ts`, reserved-name blocker in `validate.ts`, pool charset in `plan/providers/pool.ts`.
- **TUI** — the create wizard now fetches existing array names (swallowed on failure) to drive the collision warning.

## Tests

Written first and watched fail. `tests/test_xiraid_name_rules.py` (42 cases) covers charset, length boundaries, reserved names, collision detection in both directions, and the pool rule including the `xnsp_` width. The screen guard is a source scan for a hyphenated character class — confirmed against `git show HEAD:` that it flags the pre-change files.

One existing TS test needed rewriting: the `xnsp_<name>` 63-char guard is now unreachable on create (28+5=33), though still reachable on modify, where the array name comes from observed state.

## Verification

pytest 677 passed · vitest 1426 + 8 contracts · ruff, pyright, tsc, biome, spectral (0 errors), yamllint, markdownlint — all clean.

`Requires-Rebuild: xinas_node_build` — `xiNAS-MCP/src/` changed, and `dist/` is not tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)