### PR TITLE
fix(storage): realign the day-2 RAID and NFS specs with the code, fixing three defects they hid

### DIFF
--- a/docs/Storage/fs-shares-management-spec.md
+++ b/docs/Storage/fs-shares-management-spec.md
@@ -2,15 +2,18 @@
 
 This document covers the two day-2 screens that sit between the operator and the data path: **`FilesystemScreen`** (mounts XFS on xiRAID block devices and toggles quotas) and **`NFSScreen`** (manages `/etc/exports` entries and the kernel server's view of them). It is the counterpart to [Storage/raid-management-spec.md](raid-management-spec.md) — same TUI app, same helper boundary, but a different state surface.
 
-The two screens share a common helper backbone with the RAID screen:
+Like the RAID screen, both have migrated onto the control path: reads are `GET /api/v1/{filesystems,shares,arrays}` and **every write is a `plan_apply_wait`** against `xinas-api`. What is left of the old helper backbone is now a thin residue:
 
-- **`xfs_helpers`** (in-process subprocess wrappers) — `mkfs.xfs`, `findmnt`, `systemctl`, mount-unit templating, quota toggle.
-- **`xinas-nfs-helper`** (out-of-process Unix-socket daemon) — the **only writer** of `/etc/exports` and `/etc/nfs.conf`.
+- **Control-path client** (`app.control`) — the actual service boundary for both screens.
+- **`xfs_helpers`** (in-process subprocess wrappers) — reduced to read/pure helpers: `is_path_under` in both screens, plus `run_async_cmd` + `findmnt` in `NFSScreen`'s path picker. The `mkfs.xfs` / mount-unit / `systemctl` / quota-toggle helpers are **no longer called by either screen** (§2.1).
+- **`xinas-nfs-helper`** (out-of-process Unix-socket daemon) — still the **only writer** of `/etc/exports` and `/etc/nfs.conf`, but now reached *through the agent*. The only direct client call left in these screens is `nfs.list_sessions()` (§4.8).
 - **Audit + snapshot helpers** — every write path logs to `/var/log/xinas/audit.log` and records an advisory snapshot.
 
 Sources:
 
 - Screens: [xinas_menu/screens/filesystem.py](../../xinas_menu/screens/filesystem.py), [nfs.py](../../xinas_menu/screens/nfs.py), [storage.py](../../xinas_menu/screens/storage.py)
+- Control-path client: [xinas_menu/api/control_client.py](../../xinas_menu/api/control_client.py) (`ControlClient.result` / `.get` / `.plan_apply_wait`, `quote_id`)
+- Control-path contract: [docs/control-path/api-v1.yaml](../control-path/api-v1.yaml), [s8-clients-spec.md](../control-path/s8-clients-spec.md), [ADR-0007](../control-path/adr/0007-filesystem.md) (filesystem writability matrix)
 - XFS helpers: [xinas_menu/utils/xfs_helpers.py](../../xinas_menu/utils/xfs_helpers.py)
 - NFS helper client: [xinas_menu/api/nfs_client.py](../../xinas_menu/api/nfs_client.py)
 - NFS helper daemon: [xiNAS-MCP/nfs-helper/nfs_helper.py](../../xiNAS-MCP/nfs-helper/nfs_helper.py), [nfs_exports.py](../../xiNAS-MCP/nfs-helper/nfs_exports.py), [nfs_conf.py](../../xiNAS-MCP/nfs-helper/nfs_conf.py), [nfs_quota.py](../../xiNAS-MCP/nfs-helper/nfs_quota.py), [nfs_sessions.py](../../xiNAS-MCP/nfs-helper/nfs_sessions.py)
@@ -28,37 +31,39 @@ Main Menu → Storage (StorageScreen) → 2 NFS Management   (NFSScreen)
 
 Both screens are pushed onto the Textual stack from `StorageScreen.on_navigable_menu_selected()` (see [storage.py](../../xinas_menu/screens/storage.py)). Closing them with `0` / `Esc` returns to the Storage sub-menu.
 
-Both are mounted on top of the same `app.grpc` (RAID gRPC client), `app.nfs` (helper socket client), `app.audit` (audit logger), `app.snapshots` (snapshot recorder) provided by the `XiNASApp` shell.
+Both are mounted on top of the same `app.control` (control-path client), `app.nfs` (helper socket client), `app.audit` (audit logger), `app.snapshots` (snapshot recorder) provided by the `XiNASApp` shell. `app.grpc` is also on the shell but **neither screen uses it**.
 
 ---
 
-## 2. The two helper boundaries
+## 2. Boundaries these screens cross
 
-The screens never write to `/etc/exports`, `/etc/nfs.conf`, `/proc/fs/nfsd/*` or `/sys/class/block/*` directly. They cross one of two well-defined boundaries:
+The screens never write to `/etc/exports`, `/etc/nfs.conf`, `/etc/systemd/system/*.mount`, `/proc/fs/nfsd/*` or `/sys/class/block/*` directly. Every mutation is a `plan_apply_wait` against `xinas-api`, which dispatches to the agent's executors; the executors are what run `mkfs.xfs`, write mount units, call `systemctl`, and talk to the NFS helper socket. What is left in-process is described below.
 
 ### 2.1 `xfs_helpers` — in-process async subprocess
 
-[utils/xfs_helpers.py](../../xinas_menu/utils/xfs_helpers.py). Every public function returns either `(ok: bool, stdout: str, stderr: str)` for raw subprocess calls or `(ok: bool, err: str)` for higher-level operations — exactly the same `(ok, …, error)` convention the gRPC and NFS clients use.
+[utils/xfs_helpers.py](../../xinas_menu/utils/xfs_helpers.py). Every public function returns either `(ok: bool, stdout: str, stderr: str)` for raw subprocess calls or `(ok: bool, err: str)` for higher-level operations — the same `(ok, …, error)` convention the NFS client uses.
 
-What the FS screen calls:
+**What these two screens still call — read and pure helpers only:**
 
 | Helper | Underlying command | Used by |
 |---|---|---|
-| `run_async_cmd(*args, timeout=…)` | `asyncio.create_subprocess_exec` | every helper below, plus `findmnt` calls in screens |
-| `mkfs_xfs(label, data, log, su, sw, sector, log_size)` | `mkfs.xfs -f -L … -d su=…k,sw=… -l logdev=…,size=… -s size=…k <data>` | Create FS |
-| `get_device_size_bytes(device)` | `blockdev --getsize64 <device>` | log-size clamp inside `mkfs_xfs` |
-| `check_existing_filesystem(device)` | `blkid -s TYPE` + `blkid -s LABEL` | Create FS (sanity warn) |
-| `create_mount_unit(mp, data, log, opts)` | writes `/etc/systemd/system/<mp>.mount` atomically via `mkstemp + os.replace` | Create FS |
-| `mount_filesystem(mp)` | `systemctl daemon-reload` + `systemctl enable --now <unit>` | Create FS, RAID-delete rollback |
-| `unmount_filesystem(mp)` | `systemctl stop` + `disable` + `rm` of the unit file | Delete FS, RAID-delete |
-| `find_mounts_using_raid(name)` | `findmnt /dev/xi_<name>` + `findmnt -t xfs -n -o TARGET,OPTIONS` for `logdev=` matches | Create FS (gate), RAID-delete |
-| `find_mount_for_device(dev)` | `findmnt -n -o TARGET <dev>` | misc lookups |
-| `calculate_parity_disks(level)` / `calculate_stripe_width(count, level)` | pure-Python lookup | Create FS geometry |
-| `build_mount_options(log)` | string concat | Create FS |
-| `get_quota_status(options)` | parse comma-separated opt list | Quotas screen |
-| `update_mount_unit_quota(mp, enable_user, enable_project)` | rewrite the `Options=` line, then `systemctl daemon-reload` + `stop` + `start` | Quotas screen |
+| `is_path_under(path, mountpoint)` | pure-Python containment test | `FilesystemScreen` (Delete FS share scan), `NFSScreen` |
+| `run_async_cmd(*args, timeout=…)` | `asyncio.create_subprocess_exec` | `NFSScreen` only, for the one `findmnt -t xfs -n -o TARGET,SOURCE` that populates the Add-Share path picker |
 
-The mount/unmount helpers operate on systemd `.mount` units, not on `mount(2)` directly. This matches what `raid_fs` lays down at install time — see [Installer/fs-exports-spec.md §1.8](../Installer/fs-exports-spec.md#18-mountpoint-and-systemd-mount-unit). It is the reason the FS lifecycle survives reboots without anything in `/etc/fstab`.
+**What they no longer call.** These helpers still exist in the module — the installer-parity logic they encode has moved to the agent's fs-executor, and calling them from the TUI would bypass the plan/apply, audit, and task-rollback path:
+
+| Helper | Now done by |
+|---|---|
+| `mkfs_xfs`, `get_device_size_bytes`, `check_existing_filesystem` | fs-executor preflight + mkfs stages (`POST /api/v1/filesystems`) |
+| `create_mount_unit`, `mount_filesystem` | fs-executor unit + mount stages |
+| `unmount_filesystem` | `PATCH /api/v1/filesystems/{id}` `{"mounted": false}` + `DELETE` to unmanage |
+| `calculate_parity_disks`, `calculate_stripe_width`, `build_mount_options` | api-side derivation from the array (`su_kb` / `sw` omitted from the spec — §3.3) |
+| `update_mount_unit_quota` | `PATCH /api/v1/filesystems/{id}` `{"quota_mode": …}` → `fs.set_quota_mode` (§3.5) |
+| `find_mounts_using_raid` | still used, but by the **RAID** screen only ([raid-management-spec §2.4](raid-management-spec.md#24-xfs_helpers--async-subprocess-helpers)) |
+
+`_quota_flags(options)` in `filesystem.py` replaced the module's `get_quota_status` for parsing the observed option list.
+
+The executor's mount/unmount work operates on systemd `.mount` units, not on `mount(2)` directly. This matches what `raid_fs` lays down at install time — see [Installer/fs-exports-spec.md §1.8](../Installer/fs-exports-spec.md#18-mountpoint-and-systemd-mount-unit). It is the reason the FS lifecycle survives reboots without anything in `/etc/fstab`.
 
 ### 2.2 `xinas-nfs-helper` — Unix-socket daemon
 
@@ -95,6 +100,8 @@ The daemon also runs a **startup health check** — it warns if `/usr/sbin/expor
 
 The TUI calls it from `loop.run_in_executor(None, …)` since the socket I/O is blocking. The screens never `await self.app.nfs.…` directly — every helper call is wrapped in an executor coroutine so the Textual event loop stays responsive.
 
+**Scope note.** These two screens now reach this client exactly once, in Active Sessions (§4.8); the Users screen also calls `set_quota`. Every share and filesystem *mutation* reaches the same daemon through the agent instead. The client is documented in full because the agent's nfs-executor speaks the identical protocol ([agent/task/nfs-helper-client.ts](../../xiNAS-MCP/src/agent/task/nfs-helper-client.ts)), so these error strings are still what a failing share write ends up carrying.
+
 Error mapping in the client:
 
 | Helper-side failure | What `NFSHelperClient._request` returns |
@@ -105,7 +112,7 @@ Error mapping in the client:
 | Bad JSON response | `(False, None, "bad JSON from NFS helper: …")` |
 | `{"ok": false, "error": "…"}` | `(False, None, "<error string>")` |
 
-The RAID-delete and FS-delete teardown paths use these short-circuits to refuse work cleanly when the helper is down, rather than partially tearing things apart and failing later.
+These short-circuits used to let the RAID-delete and FS-delete teardowns refuse work cleanly when the helper was down. Those paths no longer call the client at all — a teardown's share step is `DELETE /api/v1/shares/{id}`, and a helper that is down now surfaces as that step's task failure, which stops the sequence (§3.4).
 
 ---
 
@@ -117,13 +124,13 @@ The RAID-delete and FS-delete teardown paths use these short-circuits to refuse 
 
 | Key | Action | Handler |
 |---|---|---|
-| 1 | Show Filesystems | `_show_filesystems()` — `findmnt -t xfs -J` |
+| 1 | Show Filesystems | `_show_filesystems()` — `GET /api/v1/filesystems` |
 | 2 | Create Filesystem | `_create_filesystem_wizard()` |
 | 3 | Delete Filesystem | `_delete_filesystem()` |
 | 4 | Manage Quotas | `_manage_quotas()` |
 | 0 | Back | pop screen |
 
-Nothing in this screen calls the xiRAID gRPC for writes — RAID arrays are inputs. The only gRPC call is `raid_show(extended=True)` at the start of the Create wizard, to enumerate available arrays.
+**This screen does not call the xiRAID gRPC client at all.** Reads are control-path `GET`s and every write is a `plan_apply_wait`. RAID arrays are inputs, enumerated by `GET /api/v1/arrays` at the start of the Create wizard (it used to be `raid_show(extended=True)`).
 
 ### 3.2 Show Filesystems
 
@@ -135,9 +142,14 @@ Nothing in this screen calls the xiRAID gRPC for writes — RAID arrays are inpu
 
 The wizard mirrors what the installer's `raid_fs` role does (see [Installer/raid-spec.md §7](../Installer/raid-spec.md#7-raid_fs--license-arrays-filesystem-mount)) but runs against the *current* RAID state.
 
-**Pre-check.** `grpc.raid_show(extended=True)` enumerates arrays. For each array, `find_mounts_using_raid(name)` is called — any array already in use as a data **or** log device is moved into an `in_use` bucket. If fewer than 2 free arrays remain, the wizard aborts with "Filesystem creation requires at least 2 RAID arrays (one for data, one for log)."
+**Pre-check.** Two control-path reads, no `findmnt` and no gRPC:
 
-**Step 1 — pick the data array.** Arrays are sorted with the data-classified ones first (`_classify_role()` maps levels `5 / 6 / 50 / 60` → `data`, anything else → `log`). The label shows `name (RAID-N, M drives, Kk strip) [role]` so the operator can spot the right candidate without remembering levels.
+1. `GET /api/v1/arrays` enumerates arrays (`_arrays_from_api`). A `ControlPathError` here aborts on an OK-only `Failed to query RAID arrays.` dialog.
+2. `GET /api/v1/filesystems` → `_volumes_in_use()` collects every volume path already consumed by a managed filesystem, as a **data device** (`status.backing_device`) *or* as a **log device** (a `logdev=` entry in its effective mount options). Arrays whose `volume_path` is in that set are filtered out. A failure here degrades to an empty set rather than aborting — the wizard then offers arrays that may already be in use, and the executor's preflight is what catches it.
+
+If fewer than 2 free arrays remain, the wizard aborts with "Filesystem creation requires at least 2 RAID arrays (one for data, one for log)."
+
+**Step 1 — pick the data array.** Arrays are sorted with the data-classified ones first (`_classify_role()` maps levels `5 / 6 / 50 / 60` → `data`, anything else → `log`). The label (`_array_label`) shows `name  (RAID-N, M drives, KKB strip)  [role]` so the operator can spot the right candidate without remembering levels.
 
 **Step 2 — pick the log array.** Same picker over the remaining arrays, with log-classified ones first. If only one array is left, the wizard skips the picker and just confirms the auto-pick.
 
@@ -145,30 +157,30 @@ The wizard mirrors what the installer's `raid_fs` role does (see [Installer/raid
 
 **Step 4 — mountpoint.** `InputDialog`, default `/mnt/data`. Must start with `/` — otherwise the wizard aborts with an error notification.
 
-**Geometry derivation.** Same formula as the installer:
+**Geometry is derived server-side.** The screen does **not** compute stripe geometry any more — there is no `calculate_stripe_width` call and no `build_mount_options` call in `filesystem.py`. It sends a structured spec and lets the fs-executor derive what it can from the array:
+
+| Spec field | Value the wizard sends |
+|---|---|
+| `backing_device` | the data array's `volume_path` |
+| `log_device` | the log array's `volume_path` |
+| `mountpoint`, `label` | steps 4 and 3 |
+| `fs_type` | `"xfs"` |
+| `log_size` | `"1G"` (clamped to the log device at mkfs) |
+| `sector_size` | `4096` |
+| `mount_options` | `_DEFAULT_MOUNT_OPTIONS` — `noatime, nodiratime, logbsize=256k, largeio, inode64, swalloc, allocsize=131072k` |
+| `quota_mode` | `"uquota"` |
+
+`su_kb` and `sw` are **omitted**, so the api auto-derives them (`sw` = data drives = members − parity; see the `Filesystem.spec` schema in [api-v1.yaml](../control-path/api-v1.yaml)). `logdev=` and `uquota` are **not** in `mount_options` either: they ride the structured `log_device` / `quota_mode` fields, which is what the fs.create contract expects. The effective result still matches the [Installer/fs-exports-spec.md §1.7](../Installer/fs-exports-spec.md#17-mount-options-decoded) install-time set, so a TUI-created FS is indistinguishable from an Ansible-created one — but it is reconstructed from structured fields, not passed through as one literal string.
+
+The confirmation summary and the success banner render a flat option string for the operator —
 
 ```
-data_device = /dev/xi_<data_name>
-log_device  = /dev/xi_<log_name>
-su_kb       = data_array.strip_size                              (fallback 128)
-sw          = calculate_stripe_width(devices_in_data, level)
-              ├─ RAID-10: device_count // 2
-              ├─ RAID-5:  device_count - 1
-              └─ RAID-6:  device_count - 2
-sector size = 4k                                                  (hardcoded)
-log size    = 1G                                                  (clamped to log device size at mkfs)
-mount opts  = build_mount_options(log_device)                     (matches Ansible)
+defaults,noatime,nodiratime,logbsize=256k,largeio,inode64,swalloc,allocsize=131072k,logdev=<log_device>,uquota
 ```
 
-`build_mount_options` produces:
+— and show `su (strip unit)` from the data array's `strip_size` (fallback `128`) with `sw` printed literally as `derived from array geometry`. **Both are display-only**: neither the string nor `su_kb` is part of the submitted spec.
 
-```
-logdev=<log_device>,noatime,nodiratime,logbsize=256k,largeio,inode64,swalloc,allocsize=131072k,uquota
-```
-
-— byte-identical to the [Installer/fs-exports-spec.md §1.7](../Installer/fs-exports-spec.md#17-mount-options-decoded) install-time set, so a TUI-created FS is indistinguishable from an Ansible-created one.
-
-**Step 5 — confirmation.** Summary shows everything: arrays + roles, mountpoint, derived geometry, full mount option string. On confirm the screen submits **one control-path plan→apply** — `POST /api/v1/filesystems` with the full spec (backing/log device, label, mountpoint, geometry, mount options, `quota_mode: uquota`) via `control.plan_apply_wait`, with a `TaskWaitDialog` showing task-state progress and offering cancel (S10). The executor runs preflight → mkfs → unit → mount as task stages.
+**Step 5 — confirmation.** Summary shows everything: arrays + roles, mountpoint, the geometry above, and that option string. On confirm the screen submits **one control-path plan→apply** — `POST /api/v1/filesystems` with the spec in the table, via `control.plan_apply_wait`, with a `TaskWaitDialog` showing task-state progress and offering cancel (S10). The executor runs preflight → mkfs → unit → mount as task stages.
 
 **Failure handling.** Three distinct exits:
 
@@ -186,52 +198,87 @@ Rollback of a failed create is the task's own (the executor rolls back its compl
 
 ### 3.4 Delete Filesystem
 
-Mirrors the RAID-delete teardown pattern in [Storage/raid-management-spec.md §6](raid-management-spec.md#6-delete-array--ordered-teardown-with-rollback), but only two steps instead of three.
+Same shape as the RAID-delete teardown in [Storage/raid-management-spec.md §6](raid-management-spec.md#6-delete-array--ordered-stop-on-failure-teardown): an ordered, **stop-on-failure sequence of control-path API operations**, each one a `plan_apply_wait`, with **no cross-step rollback**. The authoritative contract for both is [s8-clients-spec §6](../control-path/s8-clients-spec.md#6-tui-composite-teardown-t13). The only structural difference from the RAID flow is that this one has no array to destroy at the end, and no cancellable `TaskWaitDialog` — every step here is short.
 
-**Discovery.** `findmnt -t xfs -J` enumerates all current XFS mounts; the operator picks one from the list (labels show `target (source)`).
+**Discovery.** `_list_filesystems()` (`GET /api/v1/filesystems`, adapted by `_fs_rows_from_api`) enumerates the *managed* filesystems — mount units the control path knows about, not whatever `findmnt` currently reports. The operator picks one from a `SelectDialog` whose labels are `<mountpoint or id>  (<backing_device>)`. A `ControlPathError` aborts on an OK-only `Could not load filesystems.` dialog; an empty list aborts on `No XFS filesystems found.`
 
-**Dependency check.** `nfs.list_exports()` is called (via the executor); every export whose `path.startswith(mountpoint)` is recorded in `affected_shares`. This catches both the root export and any sub-directory exports rooted at the same mount.
+> This picker calls the banner-less `_list_filesystems()`, not `_list_filesystems_with_status()`. Under a degraded backend (`DEGRADED_BACKEND_UNAVAILABLE`) the list arrives empty and the operator is told `No XFS filesystems found.` — the one place in this screen where a degraded read is not distinguished from a genuinely empty one. Show Filesystems (§3.2) does render the banner.
+
+**Dependency check.** `GET /api/v1/shares`; every share whose `spec.path` is under the chosen `mountpoint` (`is_path_under`, not a bare `startswith` — `/mnt/data2` is not under `/mnt/data`) is recorded in `affected_shares` as `{id, path}`. This catches both the root export and any sub-directory exports rooted at the same mount. A `ControlPathError` here degrades to an empty list rather than aborting: the confirmation still appears, with the un-listable shares absent from it. The check is skipped entirely for a filesystem with no mountpoint.
 
 **Confirmation.**
 
-1. First dialog: lists affected shares, ends with the warning that the FS will be unmounted and its unit removed. Note the exact wording: *"Data on disk is NOT erased."* — `unmount_filesystem` does not touch the underlying XFS contents, so re-creating a mount unit on the same `/dev/xi_<name>` would re-attach the existing filesystem.
+1. First dialog: lists affected shares, ends with the warning that the FS will be unmounted and its unit removed. Note the exact wording: *"Data on disk is NOT erased."* — unmanaging removes the mount unit and does not touch the underlying XFS contents, so re-creating a mount unit on the same `/dev/xi_<name>` would re-attach the existing filesystem.
 2. If `affected_shares` is non-empty, a second `FINAL CONFIRMATION` dialog restates the count.
 
-**Teardown order.** Strictly:
+**Teardown order.** Strictly, each step rendered into the teardown progress view with its task's stage transitions:
 
-1. **Remove shares first.** For each `share` in `affected_shares`: `nfs.remove_export(path)` (synchronous via executor). On failure, every previously removed share is re-added via `nfs.add_export(saved_dict)` + `nfs.reload()`, and the dialog reports "Rolled back N share(s)."
-2. **Reload exports** (single `nfs.reload()` call after the loop, not per-iteration — `remove_export` already triggers `exportfs -r`, this is belt-and-braces).
-3. **Unmount.** `unmount_filesystem(mountpoint)`. On failure: re-add the removed shares and reload before raising.
+```
+Step 1: for each affected share   DELETE /api/v1/shares/{id}
+Step 2: the filesystem            PATCH  /api/v1/filesystems/{id} {"mounted": false}   (only if mounted)
+Step 3: the filesystem            DELETE /api/v1/filesystems/{id}                      (unmanage)
+```
 
-**Side effects on full success.**
+Shares go first: unmounting under a live export would orphan it. Step 2 is skipped outright for a filesystem the API already reports as not mounted. Ids are percent-encoded with `quote_id()` like every other id (s8-clients-spec §6).
 
-- Per share removed: `audit.log("nfs.remove", "share=<P> (FS teardown)", "OK")`
-- After unmount: `audit.log("fs.delete", "mountpoint=<M> device=<D>", "OK")`
-- `snapshots.record("fs_delete", diff_summary="...")` with a count of shares removed
-- The view shows a green summary; a toast confirms.
+**Partial teardown — no cross-step rollback.** The sequence stops at the first failing step, and everything already completed stays completed. Step 1 is a plain `for` loop over `plan_apply_wait` calls; a `ControlPathError` from any step calls `_teardown_failed(...)` and returns. There is no bookkeeping of removed shares to undo, and the screen never re-creates a share or re-mounts a filesystem — those paths do not exist in `filesystem.py`. Rollback belongs to the task engine, one apply at a time: each step's apply either lands or rolls itself back where its executor supports that, and the TUI does not stack a second, weaker rollback layer on top of steps that already succeeded.
+
+*What the operator is told.* `_teardown_failed` appends two lines to the progress view —
+
+```
+  FAILED: <error>
+  Teardown stopped — remaining steps were not run.
+```
+
+— and raises an OK-only dialog titled **`Delete Filesystem — Stopped`** naming the step that failed, the error, and, verbatim: *"Teardown stopped at this step. No cross-step rollback; the failed task rolled itself back where supported."* The progress view above it still shows every step that did complete, in order.
+
+*Manual recovery.* Recovery is an ordinary forward operation, not an undo:
+
+| Stopped at | State | Recovery |
+|---|---|---|
+| Step 1, share *k* | shares 1..*k-1* deleted; the filesystem still mounted and managed | Re-create the missing shares from the NFS screen (§4.5), or clear the blocker and re-run Delete Filesystem. |
+| Step 2 (unmount) | all shares deleted; filesystem still mounted and managed | Usually a busy mount. Clear the blocker and re-run Delete Filesystem, or re-create the shares to restore the prior state. |
+| Step 3 (unmanage) | all shares deleted; filesystem unmounted but its unit still managed | The data is intact and the unit still exists, so re-running Delete Filesystem finishes the job once the blocker is cleared. To go the other way, `PATCH {"mounted": true}` re-mounts it — but **no TUI screen offers a remount**, so that path is `xinasctl` / MCP only. |
+
+The audit trail records each completed step, so the boundary between "done" and "not run" is reconstructable after the fact.
+
+**Side effects per step.** Each line is written only after its own step succeeded:
+
+| Step | Audit action | Snapshot |
+|---|---|---|
+| 1 — `DELETE /api/v1/shares/{id}` | `nfs.remove` with detail `share=<P> (FS teardown)` | — |
+| 2 — `PATCH /api/v1/filesystems/{id}` `{"mounted": false}` | `fs.unmount` with detail `mountpoint=<M> (FS teardown)` | — |
+| 3 — `DELETE /api/v1/filesystems/{id}` | `fs.delete` with detail `mountpoint=<M> device=<D>` (written on full success, after step 3) | `fs_delete` with diff summary |
+
+The `fs_delete` snapshot's `diff_summary` names the mountpoint and device and appends the removed-share count when non-zero. It is recorded **only** after step 3, so a teardown that stops early records **no** snapshot. On full success the view shows a green summary (mountpoint, device, share count) and a toast confirms.
 
 ### 3.5 Manage Quotas
 
-Decides on **mount options**, not on user-level limits. Setting per-user / per-project byte limits is a separate code path (the helper's `set_quota` op via `xfs_quota -x`) and is **not** currently exposed in any TUI screen — it's available only to MCP callers.
+Decides on the filesystem's **quota mode**, not on user-level limits. Setting per-user / per-project byte limits is a separate code path (the helper's `set_quota` op via `xfs_quota -x`) and is **not** currently exposed in this screen.
 
-What this menu does:
+The screen no longer edits the mount unit itself. It reads the mode out of the observed mount options and writes it with a **one-intent `PATCH`**; the remount is the executor's job.
 
-1. `findmnt -t xfs -J` enumerates XFS mounts. For each, `get_quota_status(options)` parses the option list and returns `{user, project, group}` booleans.
-2. The view shows a status header per mount: `<mp> [quotas: user, project]` (green for enabled, yellow `none` if neither).
-3. The operator picks a mount. The action menu is constructed dynamically based on current state: only `Enable User Quotas` shows when user quota is off; only `Disable User Quotas` shows when it's on; etc. If both are off, a third option `Enable Both (user + project)` appears.
-4. Confirmation includes a warning: *"XFS requires a full unmount/mount cycle to change quota settings. Active NFS clients may be briefly disconnected."*
-5. `update_mount_unit_quota(mp, enable_user, enable_project)` does the real work:
-   - Read `/etc/systemd/system/<mp_unit>.mount`.
-   - Parse the existing `Options=` line.
-   - Strip `noquota` if any quota is being enabled (it conflicts with all).
-   - Remove `uquota`/`usrquota` if `enable_user` is set, and `pquota`/`prjquota` if `enable_project` is set.
-   - Append the new flags if `True`, omit them if `False`, leave them alone if `None`.
-   - Rewrite the unit atomically (`mkstemp + os.replace`).
-   - `systemctl daemon-reload` + `stop <unit>` + `start <unit>` — the **full cycle**, not `mount -o remount`, because XFS rejects quota changes via remount.
+1. `_list_filesystems()` (`GET /api/v1/filesystems`) enumerates the managed filesystems. For each, `_quota_flags(options)` parses the effective mount-options list into `{user, project, group}` booleans (`uquota`/`usrquota`, `pquota`/`prjquota`, `gquota`/`grpquota`).
+2. The view shows a status header per filesystem: `<mp> [quotas: user, project]` (green per enabled mode, yellow `none` if neither).
+3. The operator picks one. The action menu is built from current state and always offers **two** entries — the user toggle and the project toggle:
 
-On success: `audit.log("fs.quota", ..., "OK")` + `snapshots.record("fs_modify", diff_summary=...)`.
+   | Current state | Offered |
+   |---|---|
+   | user off | `Enable User Quotas (uquota)` → `quota_mode: uquota` |
+   | user on | `Disable User Quotas` → `quota_mode: none` |
+   | project off | `Enable Project Quotas (pquota)` → `quota_mode: pquota` |
+   | project on | `Disable Project Quotas` → `quota_mode: none` |
 
-Group quotas (`gquota` / `grpquota`) are *parsed* by `get_quota_status` but never *toggled* by the UI — XFS+NFS appliance deployments are expected to use user + project quotas exclusively.
+   **There is no "Enable Both" option any more.** `Filesystem.spec.quota_mode` is a single enum (`none | uquota | gquota | pquota`), so a filesystem holds exactly one mode: enabling one *replaces* the other. The action description says so out loud — `enable user quotas (replaces project quotas)` when project quotas are currently on, and the mirror image for the other direction. A "disable" action of either kind sets `none`, which clears whatever mode was set.
+
+4. Confirmation names the filesystem and the action description, and warns: *"XFS requires a full unmount/mount cycle to change quota settings. Active NFS clients may be briefly disconnected."*
+5. `PATCH /api/v1/filesystems/{id}` with `{"quota_mode": <mode>}` via `plan_apply_wait` — one intent key, which is what the endpoint requires (mixing `quota_mode` with `mounted` or `grow` is `INVALID_ARGUMENT`). The api routes it to `fs.set_quota_mode`, a **client-visible remount**; the unit-file rewrite and the `systemctl` stop/start cycle happen executor-side, not in the TUI. XFS rejects quota changes via `mount -o remount`, which is why the cycle is full rather than in-place.
+
+On failure: an OK-only `Failed to update quotas:` dialog plus a red line in the view; nothing is retried.
+
+On success: `audit.log("fs.quota", "<mp>: <description>", "OK")` + `snapshots.record("fs_modify", diff_summary="Changed quotas on <mp>: <description>")`, and the view confirms the filesystem was remounted.
+
+Group quotas (`gquota` / `grpquota`) are *parsed* by `_quota_flags` and *accepted* by the API enum, but never *offered* by this menu — XFS+NFS appliance deployments are expected to use user or project quotas exclusively.
 
 ---
 
@@ -243,26 +290,38 @@ Group quotas (`gquota` / `grpquota`) are *parsed* by `get_quota_status` but neve
 
 | Key | Action | Backend |
 |---|---|---|
-| 1 | Show NFS Exports | `nfs.list_exports()` + `_format_exports()` |
-| 2 | Add Share | 7-step wizard → `nfs.add_export()` |
-| 3 | Edit Share | 7-step wizard → `nfs.update_export()` |
-| 4 | Remove Share | `nfs.remove_export()` |
-| 5 | Active Sessions | `nfs.list_sessions()` |
-| 6 | Configure idmapd Domain | direct rewrite of `/etc/idmapd.conf` |
+| 1 | Show NFS Exports | `GET /api/v1/shares` → `_rows_from_api()` → `_format_exports()` |
+| 2 | Add Share | 7-step wizard → `POST /api/v1/shares` |
+| 3 | Edit Share | 7-step wizard → `PATCH /api/v1/shares/{id}` |
+| 4 | Remove Share | `DELETE /api/v1/shares/{id}` |
+| 5 | Active Sessions | `nfs.list_sessions()` — the one direct helper-socket call left |
+| 6 | Configure idmapd Domain | direct rewrite of `/etc/idmapd.conf` (§4.9) |
 | 0 | Back | pop screen |
 
-Every write goes through the helper socket, including the `idmapd` step (which is a plain-Python in-screen rewrite — see §4.7). The screen never edits `/etc/exports` itself.
+**Every share write is a `plan_apply_wait`**, not a helper-socket call. The screen still never edits `/etc/exports` — but the writer is now `api → agent → nfs-helper`, two hops further away, and the screen gets plan blockers, task stages, and the api's audit trail for free. Two actions stay outside that path: Active Sessions (a pure read the control path does not model, §4.8) and the idmapd domain (§4.9).
+
+Share ids are percent-encoded with `quote_id()` on every path — a Share id mirrors `encExportId(path)` and **contains internal slashes** (`/mnt/data` → `mnt/data`), so an un-encoded id 404s. See [s8-clients-spec §6](../control-path/s8-clients-spec.md#6-tui-composite-teardown-t13).
+
+**Shared share read.** Every write action first calls `NFSScreen._get_exports()` (`GET /api/v1/shares` → `_rows_from_api`, keeping only rows with both a `path` and an `id`). It **propagates** `ControlPathError` rather than degrading to `[]`, so each caller can tell "the api is unreachable" apart from "this host has no shares" — Edit and Remove show an OK-only `Could not load shares.` dialog for the former and `No shares configured.` for the latter, and Add fails its `fsid` allocation closed (§4.5). Reporting an unreadable list as an empty one is what made the `fsid` allocator restart from `1` against a live host.
+
+**Shared failure rendering.** All three write actions funnel a `ControlPathError` through `NFSScreen._show_control_error(exc)`, which splits one case out of the generic path: a **lease conflict** (the resource is locked by another in-flight task) gets a calm OK-only *Resource Busy* dialog via `lease_conflict_message(exc)`, because the lock is short-lived and the periodic sweep bounds it — retrying is the right advice. Everything else keeps the plain OK-only `Failed: <error>` dialog. `_show_control_error` is deliberately **not** a `@work` worker: callers `await` it inline, and Textual 8.x `Worker` objects are not awaitable.
 
 ### 4.2 Show — structured render with diagnostics
 
-`_load_exports()` runs `nfs.list_exports()` and feeds the result to `_format_exports()`. The renderer is intentionally rich:
+`_load_exports()` runs `GET /api/v1/shares`, adapts the docs with `_rows_from_api()`, and feeds the result to `_format_exports()`. A `ControlPathError` short-circuits before the renderer: the view shows a `Control API: <error>` line and nothing else.
+
+**`_rows_from_api()` is the only place the API shape is known.** API shares are `{id, spec: {path, clients: [{pattern, options}], fsid, sync?, security_mode?}, status}`; the renderer and the Edit wizard both speak the legacy `{path, clients: [{host, options}]}` shape. The adapter renames `pattern` → `host` and **folds the share-level `sync` and `security_mode` back into each client's option list** — mirroring the server's own exports compile — so `_parse_current_export` and the display keep working unchanged. `sync`/`async` is only appended when the client options don't already carry one, and `sec=` only when `security_mode` is set and isn't `sys`. Rows without a `path` are dropped.
+
+The renderer is intentionally rich:
 
 - **Storage line** — `df -h <path>` to show `used / total (pct)`.
 - **Path-missing flag** — `os.path.isdir(path)` — flips the status badge to `[!] PATH MISSING` (red) if the export targets a directory that doesn't exist on disk.
 - **Security label** — translates `sec=krb5` / `krb5i` / `krb5p` → `"Kerberos"` / `"Kerberos+integrity"` / `"Kerberos+encryption"`, defaults to `"Standard (UID/GID)"`.
 - **Per-client explanation** — translates `*` → `"Everyone (all hosts)"`, `10.10.0.0/24` → `"Network: 10.10.0.0/24"`, and flags `no_root_squash` as `"full admin"` next to `rw` / `ro`.
-- **Fallback** — if the helper socket fails (returns `False`), the renderer parses `/etc/exports` directly. The UI shows the same shape, just with the option strings unparsed.
+- **Empty state** — an empty share list renders `(no NFS shares configured)`. The renderer does **not** read `/etc/exports`. It used to: when the row list came back empty it parsed the file directly and displayed its contents as the share list. That made sense while the helper socket was the read path and an empty result meant "the socket failed", but under the control path an empty result means *the api observed no shares* — and the collector already observes `/etc/exports` itself, so anything genuinely exported would have come back as a row. All the fallback could still do was present unmanaged file contents as though they were the managed share list, in exactly the case where the operator most needs to see that the control path has nothing.
 - **Connected hosts** — last block. Reads `/proc/fs/nfsd/clients/*/info` for active v4 connections; if that's empty, falls back to `ss -tn state established ( dport = :2049 )` for v3 / TCP connections. IPs are de-duplicated.
+
+**Degraded-backend honesty.** Like Show Filesystems (§3.2) and the RAID overview, `_load_exports` fetches the **full envelope** (`control.get`, not `control.result`) and inspects its `warnings`. When the envelope carries `DEGRADED_BACKEND_UNAVAILABLE` — the `Share` collector is errored (control-path contract: [s8-clients-spec §5.1](../control-path/s8-clients-spec.md)) — `_format_exports` renders that message as a banner above any rows, and when the list is empty the banner **replaces** the `(no NFS shares configured)` empty state. An unobservable backend must never read as "genuinely no shares". The shared extractor is [api/degraded.py](../../xinas_menu/api/degraded.py) `degraded_banner(envelope)`, the same one the other two screens use.
 
 This is the closest the TUI comes to a dashboard — it's the screen most operators see most often.
 
@@ -321,36 +380,32 @@ it does.
 
 **Steps 2–6.** `self._access_steps("Add Share", total=7)` — see §4.4. A Back button is available on all five.
 
-**Step 7 — confirmation.** `allow_back=True`, so the operator can back up from the summary to revise any earlier answer before committing. The options list is built deterministically:
+**Step 7 — confirmation.** `allow_back=True`, so the operator can back up from the summary to revise any earlier answer before committing.
 
-```
-options = [access, sync_mode, "no_subtree_check", root_squash]
-if sec != "sys":
-    options.append(f"sec={sec}")
-```
+**Submission.** Before submitting, the screen `os.makedirs(path, exist_ok=True)` to be sure the export directory exists; an `OSError` there aborts on an OK-only `Cannot create directory:` dialog. (The helper *could* do this — `add_export` accepts `create_path=true` — but handling it client-side keeps the user-visible error to a single dialog.)
 
-`no_subtree_check` is force-added even though the wizard doesn't ask about it — it's required for any export on an NFS appliance.
-
-**Submission.** Before sending the helper request, the screen `os.makedirs(path, exist_ok=True)` to be sure the export directory exists. (The helper *could* do this — `add_export` accepts `create_path=true` — but the screen handles it client-side so the user-visible error is a single dialog rather than two round-trips.)
-
-The helper request payload uses the structured form:
+Then one `plan_apply_wait` — `POST /api/v1/shares` with the `NfsShare.spec`:
 
 ```json
 {
-  "op": "add_export",
-  "request_id": "<uuid>",
-  "entry": {
-    "path": "/mnt/data/share1",
-    "clients": [
-      { "host": "10.10.0.0/24", "options": ["rw","sync","no_subtree_check","no_root_squash"] }
-    ]
-  }
+  "path": "/mnt/data/share1",
+  "fsid": 3,
+  "clients": [
+    { "pattern": "10.10.0.0/24", "options": ["rw", "no_root_squash", "no_subtree_check"] }
+  ],
+  "sync": "sync"
 }
 ```
 
-This is the canonical internal representation. The helper serialises it to the single-line `/etc/exports` format via `nfs_exports._serialize_exports()`, which also injects the `# Managed by xinas-nfs-helper — do not edit manually` banner at the top of the file.
+Three things to note, because the wizard's five answers do **not** map one-to-one onto that shape:
 
-On success: `audit.log("nfs.add_export", path, "OK")` + `snapshots.record("share_create", diff_summary=…)` + Show is refreshed.
+- **`sync_mode` and `sec` are share-level fields, not client options.** `sync` always carries the wizard's answer; `security_mode` is added **only when `sec != "sys"`**. `_rows_from_api` folds both back into the client option list on read (§4.2), which is why the display and the Edit wizard still see them there.
+- **`no_subtree_check` is force-added** to every client's options even though the wizard doesn't ask — it's required for any export on an NFS appliance.
+- **`fsid` is allocated client-side, and the allocation fails closed.** `Share.spec.fsid` is **required** by the API ([api-v1.yaml](../control-path/api-v1.yaml)) — the server does not assign one — so the screen reads the current shares, collects every integer `fsid` already in use (accepting both int and numeric-string spellings), and assigns `max(used, default=0) + 1`. That read must therefore be **authoritative**: if `GET /api/v1/shares` fails, the wizard aborts on an OK-only `Could not read existing shares` dialog rather than allocating from an empty set. Allocating from a swallowed error would restart numbering at `1` and collide with every existing share — an `fsid` collision silently breaks NFSv4 client mounts, so guessing is worse than refusing.
+
+  What this does **not** fix: two operators adding a share at the same time can still compute the same number, because the allocation is client-side by construction. The api's plan is the backstop there. Moving allocation server-side would need an API change (`fsid` becoming optional), which is tracked separately.
+
+On success: `audit.log("nfs.add_export", path, "OK")` + `snapshots.record("share_create", diff_summary=…)` + Show is refreshed. On `ControlPathError`, `_show_control_error` renders it (§4.1).
 
 ### 4.6 Edit Share — preserve unknown options
 
@@ -360,42 +415,58 @@ On success: `audit.log("nfs.add_export", path, "OK")` + `snapshots.record("share
 
 **Steps 2–6.** `self._access_steps("Edit Share", total=7)` — the same shared steps Add uses (§4.4). Because `answers["_orig"]` was seeded in step 1, every prompt shows the `(Current: …)` hint alongside the pre-selected working value.
 
-**Step 7 — confirmation.** `allow_back=True`. The new options list rebuilds the wizard-managed knobs **plus** appends the preserved `extra_opts` (read from `answers["_orig"]["extra_opts"]`):
+**Step 7 — confirmation.** `allow_back=True`. The summary renders the export the way `/etc/exports` spells it — a flat option list including `sync_mode` and `sec=`, plus the preserved `extra_opts` (read from `answers["_orig"]["extra_opts"]`):
 
 ```python
 extra = answers["_orig"]["extra_opts"]
 options = [access, sync_mode, root_squash]
 if sec != "sys":
     options.append(f"sec={sec}")
-options.extend(extra)
+options.extend(extra)          # display only — see Submission below
 ```
 
 So if the original export had `insecure,no_wdelay,fsid=0` (the appliance baseline from [Installer/fs-exports-spec.md §2.3](../Installer/fs-exports-spec.md#23-decoding-the-default-options)), those three options survive a wizard run unchanged. Note: `no_subtree_check` is *not* in `_WIZARD_MANAGED_OPTS`, so it counts as an extra and is preserved through edits — but unlike Add, Edit doesn't force-add it.
 
-**Submission.** `update_export(path, patch)` with `patch = {"clients": [{"host", "options"}]}`. The helper's `update_export` is a merge-patch: it overwrites the `clients` list but leaves any other fields on the entry untouched (currently there are none, but the protocol is forward-compatible).
+**Submission.** That flat list is **display only**. The submitted patch splits it back apart the way the API models a share — `sync` and `security_mode` are share-level fields, and only `access`, `root_squash` and the extras stay as client options:
 
-On success: `audit.log("nfs.update_export", path, "OK")` + `snapshots.record("share_modify", diff_summary=…)` + Show is refreshed.
+```python
+patch = {
+    "clients": [{"pattern": host, "options": [access, root_squash, *extra]}],
+    "sync": sync_mode,
+    "security_mode": sec,
+}
+```
+
+Unlike Add, Edit sends `security_mode` **unconditionally**, including the value `"sys"` — so an edit is what clears a `sec=krb5` off an existing share. That asymmetry is deliberate: an omitted field on a PATCH means "leave alone", which would make `sec` a one-way door.
+
+One `plan_apply_wait` — `PATCH /api/v1/shares/{quote_id(share_id)}` with that patch. The `share_id` comes from step 1's lookup, not from the path: an id carries internal slashes and must be encoded (§4.1). The PATCH is a merge-patch — fields not named are left as they are, so `path` and `fsid` survive an edit untouched.
+
+On success: `audit.log("nfs.update_export", path, "OK")` + `snapshots.record("share_modify", diff_summary=…)` + Show is refreshed. On `ControlPathError`, `_show_control_error` (§4.1).
 
 ### 4.7 Remove Share
 
 Simple two-prompt flow:
 
-1. `SelectDialog` over current export paths.
+1. `SelectDialog` over current export paths. The chosen path is looked back up to recover its **id**; a share with no id aborts on an OK-only `Share not found.` dialog.
 2. `ConfirmDialog("Remove export {path}?")` — single confirmation, no FINAL prompt (an export has no downstream FS state to worry about, unlike a RAID array or a mount).
 
-Then `nfs.remove_export(path)`. On success: `audit.log("nfs.remove_export", path, "OK")` + `snapshots.record("share_delete", …)` + Show refreshed.
+Then one `plan_apply_wait` — `DELETE /api/v1/shares/{quote_id(share_id)}` with an **empty body**: the delete plan's spec is built server-side from the desired share (`{id, path}`). The risk class is `changing_access`, not `destroying_data`, so **no `dangerous` flag is passed** — the single confirmation is the whole gate, and the api does not demand more.
+
+On success: `audit.log("nfs.remove_export", path, "OK")` + `snapshots.record("share_delete", …)` + Show refreshed. On `ControlPathError`, `_show_control_error` (§4.1).
 
 The export's directory on disk is **not** removed. Anything the share was rooted at stays put.
 
 ### 4.8 Active Sessions
 
-`nfs.list_sessions()` reads `/proc/fs/nfsd/clients/*/info` on the server side, returning a list of `{client_ip, nfs_version, export_path, active_locks}` dicts. The screen prints `client → export_path` per row. The fallback path (when `/proc/fs/nfsd/clients` is empty — older kernels or v3-only servers) parses `/proc/net/rpc/auth.unix.ip`.
+**The one place either screen still calls the helper socket directly.** Session state is a live read of the kernel server, not desired configuration, so the control path does not model it — the screen goes straight to the daemon via `loop.run_in_executor(None, self.app.nfs.list_sessions)`.
+
+`nfs.list_sessions()` reads `/proc/fs/nfsd/clients/*/info` on the server side, returning a list of `{client_ip, nfs_version, export_path, active_locks}` dicts. A failure renders the client's error envelope (§2.3) straight into the view. The screen prints `client → export_path` per row. The fallback path (when `/proc/fs/nfsd/clients` is empty — older kernels or v3-only servers) parses `/proc/net/rpc/auth.unix.ip`.
 
 Per-export filtering is available via `nfs.get_sessions(path)`, but the screen always asks for the global list. Use the MCP tool surface for per-path queries.
 
 ### 4.9 Configure idmapd Domain
 
-The only NFS-screen action that **does not** go through the helper socket. NFSv4 ID mapping (`/etc/idmapd.conf`) is a one-time / rare-edit configuration; rather than adding a `set_idmapd_domain` op to the helper, the screen edits the file directly in an executor:
+The only NFS-screen write that goes through **neither** the control path nor the helper socket. NFSv4 ID mapping (`/etc/idmapd.conf`) is a one-time / rare-edit configuration; rather than modelling it as a control-path resource or adding a `set_idmapd_domain` op to the helper, the screen edits the file directly in an executor:
 
 1. Validate input — `domain` must contain at least one `.`.
 2. Inline executor reads `/etc/idmapd.conf`, replaces the `^Domain\s*=\s*…` line with the new value, writes the file back. No locking, no atomic write — this is an admin-only screen.
@@ -411,15 +482,19 @@ The screen does **not** restart `nfs-idmapd` — the daemon picks up the change 
 
 ```
 FilesystemScreen._create_filesystem_wizard()
-  ├─ grpc.raid_show(extended=True)             — list arrays
-  ├─ for each array:
-  │    └─ find_mounts_using_raid(name)         — findmnt scan (data + logdev)
+  ├─ GET /api/v1/arrays                        — list arrays
+  ├─ GET /api/v1/filesystems                   — _volumes_in_use(): drop
+  │                                              arrays already used as a
+  │                                              data or logdev device
   ├─ SelectDialog (data array)                 — TUI only
   ├─ SelectDialog (log array)                  — TUI only
   ├─ InputDialog (label)                       — TUI only
   ├─ InputDialog (mountpoint)                  — TUI only
-  ├─ build_mount_options + calculate_stripe_width  — pure Python
-  ├─ ConfirmDialog (summary)                   — TUI only
+  ├─ ConfirmDialog (summary)                   — TUI only; su_kb and the
+  │                                              flat option string are
+  │                                              display-only (su_kb/sw are
+  │                                              omitted from the spec and
+  │                                              derived server-side)
   ├─ control.plan_apply_wait(POST /api/v1/filesystems)   — ONE plan→apply
   │    ├─ mode=plan  → plan_id, blockers checked
   │    ├─ mode=apply → task_id
@@ -444,9 +519,14 @@ NFSScreen._add_share_wizard()
   │    ├─ sync_mode (sync/async)
   │    └─ sec (sys/krb5/krb5i/krb5p)
   ├─ ConfirmDialog (summary)
-  ├─ os.makedirs(path, exist_ok=True)
-  ├─ nfs.add_export({"path":..., "clients": [...]})
-  │    └─ Unix socket → xinas-nfs-helper
+  ├─ os.makedirs(path, exist_ok=True)           — client-side, one clear error
+  ├─ GET /api/v1/shares                         — collect used fsids → max+1
+  ├─ control.plan_apply_wait(POST /api/v1/shares)
+  │    ├─ spec: {path, fsid, clients:[{pattern, options}], sync,
+  │    │         security_mode?}   — sync/sec are share-level, not options
+  │    ├─ mode=plan  → plan_id, blockers checked
+  │    ├─ mode=apply → task_id
+  │    └─ agent nfs-executor → Unix socket → xinas-nfs-helper
   │         ├─ validate (abs path, isdir or create_path)
   │         ├─ fcntl LOCK_EX on /run/xinas-exports.lock
   │         ├─ parse /etc/exports
@@ -464,18 +544,19 @@ NFSScreen._add_share_wizard()
 
 ```
 FilesystemScreen._manage_quotas()
-  ├─ findmnt -t xfs -J                          — enumerate mounts
-  ├─ get_quota_status(options)                  — parse current flags
-  ├─ SelectDialog (mountpoint)
-  ├─ SelectDialog (action)                       — dynamic based on current state
+  ├─ GET /api/v1/filesystems                    — enumerate managed FSs
+  ├─ _quota_flags(options)                      — parse current flags
+  ├─ SelectDialog (filesystem)
+  ├─ SelectDialog (action)                       — user toggle + project toggle,
+  │                                                labelled from current state
   ├─ ConfirmDialog (warns about unmount/mount cycle)
-  ├─ update_mount_unit_quota(mp, enable_user=True, enable_project=None)
-  │    ├─ read /etc/systemd/system/mnt-data.mount
-  │    ├─ regex update Options=
-  │    ├─ atomic write (mkstemp + os.replace)
-  │    ├─ systemctl daemon-reload
-  │    ├─ systemctl stop mnt-data.mount         — XFS requires full cycle
-  │    └─ systemctl start mnt-data.mount
+  ├─ control.plan_apply_wait(PATCH /api/v1/filesystems/mnt-data.mount,
+  │                          {"quota_mode": "uquota"})   — ONE intent key
+  │    ├─ mode=plan  → plan_id, blockers checked
+  │    ├─ mode=apply → task_id
+  │    └─ fs.set_quota_mode executor-side: rewrite Options=,
+  │         daemon-reload, stop + start the unit (XFS rejects a
+  │         quota change via `mount -o remount`)
   ├─ audit.log("fs.quota", "<mp>: enable user quotas", "OK")
   └─ snapshots.record("fs_modify", ...)
 ```
@@ -489,13 +570,16 @@ Every write operation in both screens emits two side-channel records — see [St
 | User action | Audit action | Snapshot operation | diff_summary |
 |---|---|---|---|
 | Create FS | `fs.create` | `fs_create` | `Created XFS filesystem '<L>' on <D>, mounted at <M>` |
-| Delete FS | `fs.delete` (+ `nfs.remove` per affected share) | `fs_delete` | `Deleted filesystem at <M> (device <D>) [, removed N share(s)]` |
-| Toggle quota | `fs.quota` | `fs_modify` | `Changed quotas on <M>: enable user quotas, …` |
+| Delete FS | `fs.delete` (+ `nfs.remove` per affected share, + `fs.unmount` when it was mounted) | `fs_delete` | `Deleted filesystem at <M> (device <D>) [, removed N share(s)]` |
+| Toggle quota | `fs.quota` | `fs_modify` | `Changed quotas on <M>: <action description>` (e.g. `enable user quotas (replaces project quotas)`) |
 | Add share | `nfs.add_export` | `share_create` | `Added NFS share <P>` |
 | Edit share | `nfs.update_export` | `share_modify` | `Updated NFS share <P>` |
 | Remove share | `nfs.remove_export` | `share_delete` | `Removed NFS share <P>` |
 | Set idmapd domain | `nfs.idmapd_domain` | `nfs_modify` | `Set idmapd domain to <D>` |
 | Share auto-removed during FS teardown | `nfs.remove` with `(FS teardown)` suffix | (none — rolled into `fs_delete`) | — |
+| FS unmounted during FS teardown | `fs.unmount` with `(FS teardown)` suffix | (none — rolled into `fs_delete`) | — |
+
+Each teardown line is written only after its own step succeeded, and the `fs_delete` snapshot only after the final step. A teardown that stops partway (§3.4) therefore leaves audit lines for the steps that ran and **no** snapshot at all.
 
 Snapshots are best-effort. If `xinas_history` is not installed or `record()` raises, the UI flow is unaffected — the audit line is still written and the user-visible success/failure is determined entirely by the helper response.
 
@@ -513,31 +597,38 @@ YYYY-MM-DD HH:MM:SS | <user> | <action> | OK | <detail>
 
 | Failure | Where | Handling |
 |---|---|---|
-| Helper socket missing / refused | every helper call | `NFSHelperClient` returns `(False, None, "…not found"/"…not running")`. The Show screen falls back to parsing `/etc/exports` directly; write screens surface the error and refuse to proceed. |
-| Helper times out | `socket.timeout` after 10 s | Same `(False, None, …)` envelope; the dialog shows "NFS helper timed out". Write flows stop without partial state. |
-| `exportfs -r` fails with non-`Failed to stat` error | helper `_exportfs_reload()` | Raises `RuntimeError`; the helper returns `{"ok": false, "code": "INTERNAL"}`; the TUI surfaces the message. |
+| `GET /api/v1/shares` unreachable | `_load_exports` / `_get_exports` | `_get_exports` **propagates** the `ControlPathError`; no caller degrades a failed read to "no shares". Show prints `Control API: <error>`; Add aborts its `fsid` scan (§4.5); Edit and Remove abort on an OK-only `Could not load shares.` dialog, distinct from the `No shares configured.` empty case. |
+| `Share` collector degraded behind a healthy api | `GET /api/v1/shares` envelope | `DEGRADED_BACKEND_UNAVAILABLE` warning → Show renders the banner, and an empty list shows the banner instead of `(no NFS shares configured)` (§4.2). |
+| Share write fails (plan blocked, task failed, api down) | `_show_control_error` | OK-only `Failed: <error>` dialog carrying the plan/task message; the flow aborts with no partial state (the apply is one task). |
+| Share write hits a lease conflict | `_show_control_error` → `lease_conflict_message` | OK-only *Resource Busy* dialog instead of the raw error — the resource is locked by another in-flight task and the lock is short-lived, so retrying is the advice (§4.1). |
+| Helper socket missing / refused / timed out | `nfs.list_sessions()` (§4.8), and agent-side for every share write | `NFSHelperClient` returns `(False, None, "…not found"/"…not running"/"NFS helper timed out")`. Active Sessions prints it; a share write fails agent-side and surfaces as a task failure. |
+| `exportfs -r` fails with non-`Failed to stat` error | helper `_exportfs_reload()` | Raises `RuntimeError`; the helper returns `{"ok": false, "code": "INTERNAL"}`; the agent turns that into a task failure and the TUI surfaces the message. |
 | `nfs-kernel-server` not installed | helper startup health check | `xinas-nfs-helper` logs a warning at boot; first export op fails with `exportfs not found`. |
-| Non-absolute `path` to `add_export` | `nfs_helper.handle_add_export` | `INVALID_ARGUMENT` — `"entry.path must be absolute"`. |
+| Non-absolute `path` to `add_export` | `nfs_helper.handle_add_export` | `INVALID_ARGUMENT` — `"entry.path must be absolute"`. The wizard rejects a non-`/` path before submitting, so this is a defence in depth. |
 | Export target directory missing | `nfs_helper.handle_add_export` | `NOT_FOUND` unless `create_path=true`. TUI's Add wizard pre-creates the directory client-side. |
+| Add Share cannot read the existing shares | `fsid` allocation (§4.5) | Fails closed: OK-only `Could not read existing shares` dialog, wizard aborts. It never allocates from an empty set. |
+| Two concurrent Add Shares allocate the same `fsid` | client-side `max(used)+1` allocation (§4.5) | Not prevented by the TUI — allocation is client-side by construction. The api's plan is the backstop. |
 | Quota toggle while NFS clients connected | XFS requires unmount cycle | `_manage_quotas` warns up front; clients are briefly disconnected during the stop/start. |
-| Mount-unit not found during quota toggle | `update_mount_unit_quota` | Returns `(False, "Mount unit not found: …")`; the dialog reports the missing path. |
+| Quota toggle fails (unit missing, remount refused, plan blocked) | `PATCH {"quota_mode": …}` | `ControlPathError` → OK-only `Failed to update quotas:` dialog carrying the task/plan message, plus a red line in the view. No retry. |
 | fs.create task fails (live mountpoint, existing unit, mkfs error, log array too small) | control-path task terminal | `TaskFailed.error_message` carries the failing stage's message; an OK-only dialog shows it. **No force retry** unless the failure is the existing-filesystem destruction gate. |
 | fs.create fails on the destruction gate (device already carries a filesystem) | fs-executor preflight (`blkid` gate) | Yes/No force-recreate consent quoting the task detail; on Yes the spec is re-submitted with `force: true` + `dangerous=True`. |
-| Mount unit fails to start (e.g. xiRAID device not present) | `mount_filesystem` returns `(False, …)` | Wizard aborts after the mount unit was written; the unit stays on disk so the next `systemctl start` can succeed without re-running mkfs. |
-| `findmnt` JSON parse error | Show / Delete / Quotas | Caught; the screen shows `(parse error: …)` but stays interactive. |
-| RAID delete cascades into shares but `add_export` rollback fails | FS-delete rollback | The dialog reports "Rolled back N share(s)"; the failure is noted but rollback does not itself roll back. Audit log captures every step. |
+| Mount stage fails during fs.create (e.g. xiRAID device not present) | fs-executor mount stage | Reaches the wizard as a `TaskFailed` like any other stage failure — OK-only dialog, no force retry. Cleanup is the task's own stage rollback; the screen writes no unit and removes none. |
+| `GET /api/v1/filesystems` fails during the Create pre-check | `_volumes_in_use()` input | Degrades to an empty in-use set (the arrays list is *not* filtered), so an already-consumed array can be offered; the executor's preflight is what rejects it. Contrast the arrays read, which aborts the wizard. |
+| `GET /api/v1/filesystems` unreachable | Show / Delete / Quotas | `ControlPathError`. Show and Quotas render `Could not load filesystems: …` into the view; Delete aborts on an OK-only dialog. (`filesystem.py` no longer runs `findmnt` at all — the whole screen reads the control path.) |
+| Any FS-teardown step fails (busy mount, blocked plan, share delete refused) | `_teardown_failed` | The sequence **stops**. Completed steps stay completed — there is no cross-step rollback. The progress view shows what ran; an OK-only `Delete Filesystem — Stopped` dialog names the failing step and the error (§3.4). |
+| Filesystem backend degraded during Delete Filesystem | `_list_filesystems()` (banner-less) | The list arrives empty and the operator sees `No XFS filesystems found.` — the degraded banner is dropped on this path, unlike Show Filesystems (§3.2). |
 | idmapd file unreadable | `_configure_idmapd` | Returns `(False, str(exc))`; the dialog shows the OS error. |
 
 ---
 
 ## 8. What these screens do **not** do
 
-- They do not run `xicli` or `xfs_quota` directly. The first goes through the gRPC daemon; the second goes through the NFS helper (it's listed as one of the helper's ops but is not currently wired into any TUI screen — only the MCP tool surface uses it).
+- They do not run `xicli`, `mkfs.xfs`, `systemctl`, or `xfs_quota` directly. `FilesystemScreen` reaches storage only through the control-path API — it holds no gRPC client and no longer writes mount units itself. `xfs_quota` (per-user byte limits, as opposed to the filesystem's quota *mode*) remains an NFS-helper op, wired into the Users screen and the MCP tool surface but not into these two.
 - They do not change `/etc/nfs.conf`. That is reachable through `nfs.fix_nfs_conf()` (the helper op) and is invoked by the Health screen's auto-fix and by MCP tools, **not** by the FS or NFS screens.
 - They do not enforce per-export quotas. `uquota` / `pquota` are mount-level switches; assigning per-user / per-project byte limits is a separate operation (helper's `set_quota` op) that the TUI exposes only indirectly via the (not yet implemented) Users / Groups screens.
 - They do not configure firewall rules for NFS ports. `2049/tcp` and `20049/rdma` are assumed open on the storage network — see [Installer/network-spec.md §9](../Installer/network-spec.md#9-what-the-installer-does-not-do).
 - They do not edit `/etc/exports` directly, and they do not preserve hand-edits. The helper writes the file in full on every `add` / `remove` / `update` and re-injects the `# Managed by xinas-nfs-helper — do not edit manually` banner — anything in the file outside the structured format is dropped.
-- They do not delete the on-disk content of a share or FS. Removing a share leaves the directory tree intact; deleting a filesystem removes the mount but leaves the XFS on `/dev/xi_<name>` so a re-mount picks up the existing data. The only place data is destroyed is `mkfs.xfs -f` in the Create wizard, and it's gated by an explicit confirmation when a filesystem is already present.
+- They do not delete the on-disk content of a share or FS. Removing a share leaves the directory tree intact; deleting a filesystem removes the mount but leaves the XFS on `/dev/xi_<name>` so a re-mount picks up the existing data. The only place data is destroyed is the executor's `mkfs.xfs` during `fs.create`, and overwriting an existing filesystem there is gated twice: the executor refuses unless the spec carries `force: true`, and the TUI only re-submits with `force` after the operator accepts the destruction consent (§3.3).
 - They do not export the same path twice. `add_export` removes any existing entry with the same `path` before appending the new one — there is exactly one rule per path at any time.
 
 ## 9. Dialog conventions — informational vs consent

--- a/docs/Storage/raid-management-spec.md
+++ b/docs/Storage/raid-management-spec.md
@@ -1,17 +1,19 @@
 # xiNAS — RAID Management from the TUI
 
-This document covers the *day-2* RAID management surface: the Textual TUI screens, the helpers they call, and the gRPC service those helpers talk to. It is the counterpart to [Installer/raid-spec.md](../Installer/raid-spec.md), which describes how arrays are first created by Ansible.
+This document covers the *day-2* RAID management surface: the Textual TUI screens and the services they call. It is the counterpart to [Installer/raid-spec.md](../Installer/raid-spec.md), which describes how arrays are first created by Ansible.
 
-The TUI never runs `xicli` directly. Every RAID operation is an RPC against the xiRAID gRPC daemon, with two adjuncts: an NFS helper daemon over a Unix socket, and a small XFS helper module that runs `findmnt` / `systemctl` synchronously from the TUI process.
+The TUI never runs `xicli` directly. Since the S8/S9 control-path migration (ADR-0010, ADR-0011), **every array and pool operation — read and write — is a control-path API call** against `xinas-api`; writes go through `plan_apply_wait`. Two adjuncts remain: the xiRAID gRPC client, still used by the Physical Drives screen (§8) for `disk_list` / `drive_locate`, and a small XFS helper module that runs `findmnt` synchronously from the TUI process. The `xinas-nfs-helper` socket is **no longer** on the RAID path at all.
 
 Sources:
 
 - Screens: [xinas_menu/screens/storage.py](../../xinas_menu/screens/storage.py), [raid.py](../../xinas_menu/screens/raid.py), [spare_pools.py](../../xinas_menu/screens/spare_pools.py), [drives.py](../../xinas_menu/screens/drives.py)
+- Control-path client: [xinas_menu/api/control_client.py](../../xinas_menu/api/control_client.py) (`ControlClient.result` / `.get` / `.plan_apply_wait`, `quote_id`)
 - gRPC helper: [xinas_menu/api/grpc_client.py](../../xinas_menu/api/grpc_client.py)
 - NFS helper client: [xinas_menu/api/nfs_client.py](../../xinas_menu/api/nfs_client.py)
 - XFS helpers: [xinas_menu/utils/xfs_helpers.py](../../xinas_menu/utils/xfs_helpers.py)
 - Audit + snapshot helpers: [xinas_menu/utils/audit.py](../../xinas_menu/utils/audit.py), [xinas_menu/utils/snapshot_helper.py](../../xinas_menu/utils/snapshot_helper.py)
 - Drive picker widget: [xinas_menu/widgets/drive_picker.py](../../xinas_menu/widgets/drive_picker.py)
+- Control-path contract: [docs/control-path/api-v1.yaml](../control-path/api-v1.yaml), [s8-clients-spec.md](../control-path/s8-clients-spec.md) (§6 is the authoritative teardown contract), [ADR-0011](../control-path/adr/0011-config-history-audit-pools.md) (pools)
 - gRPC service contract: [xiNAS-MCP/proto/xraid/gRPC/protobuf/service_xraid.proto](../../xiNAS-MCP/proto/xraid/gRPC/protobuf/service_xraid.proto), [message_raid.proto](../../xiNAS-MCP/proto/xraid/gRPC/protobuf/message_raid.proto), [message_pool.proto](../../xiNAS-MCP/proto/xraid/gRPC/protobuf/message_pool.proto)
 - NFS helper daemon: [xiNAS-MCP/nfs-helper/nfs_helper.py](../../xiNAS-MCP/nfs-helper/nfs_helper.py), [xinas-nfs-helper.service](../../xiNAS-MCP/nfs-helper/xinas-nfs-helper.service)
 
@@ -19,7 +21,7 @@ Sources:
 
 ## 1. Where this lives in the TUI
 
-`xinas-menu` (entry point `xinas_menu/__main__.py`) launches the Textual app with `XiRAIDClient` mounted as `self.app.grpc` and `NFSHelperClient` as `self.app.nfs`. The user reaches RAID via:
+`xinas-menu` (entry point `xinas_menu/__main__.py`) launches the Textual app with `ControlClient` mounted as `self.app.control`, `XiRAIDClient` as `self.app.grpc`, and `NFSHelperClient` as `self.app.nfs`. RAID Management and Spare Pools use `self.app.control` exclusively; Physical Drives is the one screen in this document that still uses `self.app.grpc`, and none of the three touch `self.app.nfs`. The user reaches RAID via:
 
 ```
 Main Menu → Storage (StorageScreen) → 1 RAID Management (RAIDScreen)
@@ -41,43 +43,56 @@ Main Menu → Storage (StorageScreen) → 1 RAID Management (RAIDScreen)
 | 5 | Edit Array | `_modify_array()` |
 | 6 | Delete Array | `_delete_array()` |
 
-`on_mount` runs Quick Overview immediately, so opening the screen kicks a `raid_show` against the daemon.
+`on_mount` runs Quick Overview immediately, so opening the screen kicks a `GET /api/v1/arrays` against `xinas-api`.
 
 ---
 
-## 2. The two helpers behind RAID Management
+## 2. The service layer behind RAID Management
 
-Every RAID operation crosses one of two IPC boundaries — neither one is `subprocess('xicli …')`. The TUI is a thin presenter; the **xiRAID gRPC daemon** and the **xinas-nfs-helper** are the actual service layer.
+RAID and pool work crosses exactly one boundary — never `subprocess('xicli …')`. The TUI is a thin presenter; **`xinas-api`** is the service layer, and the agent behind it is what reaches the xiRAID daemon.
 
 ```
 ┌──────────────────────┐
 │  xinas-menu (TUI)    │
-│   Python / Textual    │
-│   runs as root        │
-└─────┬────────┬───────┘
-      │        │
-      │ gRPC   │ JSON over AF_UNIX
-      │ :6066  │ /run/xinas-nfs-helper.sock
-      ▼        ▼
-┌─────────────┐  ┌──────────────────────┐
-│ xRAID gRPC  │  │ xinas-nfs-helper     │
-│ daemon      │  │ Python daemon, root  │
-│ (xiRAID-    │  │ ProtectHome=true     │
-│  Classic)   │  └────────┬─────────────┘
-└──────┬──────┘           │
-       │                  │ writes
-       │ ioctl + xicli    ▼
-       ▼               /etc/exports
-   xiRAID kmod         /etc/nfs.conf
-   /dev/xi_<name>      exportfs -r
-                       systemctl restart nfs-server
+│   Python / Textual   │
+│   runs as root       │
+└─────┬──────────┬─────┘
+      │          │
+      │ HTTP     │ gRPC :6066
+      │ (control │ (Physical Drives
+      │  path)   │  screen only)
+      ▼          │
+┌──────────────┐ │
+│  xinas-api   │ │
+│  plan/apply  │ │
+│  + task wait │ │
+└──────┬───────┘ │
+       │         │
+       ▼         │
+┌──────────────┐ │
+│  xinas-agent │ │
+└──────┬───────┘ │
+       │         │
+       ▼         ▼
+┌────────────────────┐
+│  xRAID gRPC daemon │
+│  (xiRAID-Classic)  │
+└─────────┬──────────┘
+          │ ioctl + xicli
+          ▼
+     xiRAID kmod
+     /dev/xi_<name>
 ```
 
-The third "helper" used during RAID **deletion** is `xinas_menu/utils/xfs_helpers.py` — but that runs in-process inside the TUI (no separate service); it just shells out to `findmnt`, `systemctl`, `mkfs.xfs` etc. via `asyncio.create_subprocess_exec`.
+Writes are never fire-and-forget: `ControlClient.plan_apply_wait(method, path, spec, …)` submits the intent, applies the resulting plan (with `dangerous=True` where the endpoint demands it), and blocks on the task, streaming stage transitions to an `on_progress` callback and honouring a `cancel_check`. Plan blockers surface as `ControlPathError` before anything is touched.
+
+The one in-process helper left on the RAID path is `xinas_menu/utils/xfs_helpers.py` — no separate service; it shells out to `findmnt` via `asyncio.create_subprocess_exec` (§2.4).
 
 ### 2.1 `XiRAIDClient` — gRPC bridge to xiRAID
 
 Source: [xinas_menu/api/grpc_client.py](../../xinas_menu/api/grpc_client.py).
+
+**Scope note.** Of the screens in this document, only Physical Drives (§8) still calls this client — `disk_list()` and `drive_locate()`. RAID Management and Spare Pools do not import it. The client's remaining RAID/pool methods are described below because they are still the contract the *agent* speaks on the far side of `xinas-api`, and because the client keeps them available; they are not the TUI's call path.
 
 - **Address:** `localhost:6066` (hardcoded, `_GRPC_ADDRESS`).
 - **Transport:** `grpc.aio` channel. Secure by default — TLS root cert resolved in this order:
@@ -96,32 +111,41 @@ Source: [xinas_menu/api/grpc_client.py](../../xinas_menu/api/grpc_client.py).
   Errors never raise into the UI layer.
 - **RPC naming gotcha:** the service is `XRAIDService` (capital `XRAID`), but request messages live in `message_*_pb2`, **not** `service_xraid_pb2`. The client's `_import_stubs()` imports the message modules separately.
 
-### 2.2 RAID RPCs the TUI uses
+### 2.2 The RAID/pool endpoints the TUI uses
 
-Direct mapping from `XiRAIDClient` methods to the protos in [service_xraid.proto](../../xiNAS-MCP/proto/xraid/gRPC/protobuf/service_xraid.proto):
+Every array and pool operation in these screens is one of these calls. Reads go through `control.result(path)` (or `control.get(path)` when the screen needs the envelope's `warnings` — §3.1); writes through `control.plan_apply_wait(...)`. Ids are always percent-encoded as a single path segment with `quote_id()` (s8-clients-spec §6).
 
-| Python method | RPC | Request message | Used by |
-|---|---|---|---|
-| `raid_show(units, name, extended)` | `raid_show` | `RaidShow` | Quick / Extended overview, every edit/delete pre-check |
-| `raid_create(name, level, drives, **kwargs)` | `raid_create` | `RaidCreate` | Create wizard |
-| `raid_modify(name, **kwargs)` | `raid_modify` | `RaidModify` | Edit Array |
-| `raid_destroy(name, force)` | `raid_destroy` | `RaidDestroy` | Delete Array (always with `force=True`) |
-| `raid_unload(name)` | `raid_unload` | `RaidUnload` | — (available, not currently used) |
-| `raid_init_start(name)` / `raid_init_stop(name)` | matching RPCs | — | — (available, not currently used) |
-| `raid_recon_start(name)` / `raid_recon_stop(name)` | matching RPCs | — | — (available, not currently used) |
+| Operation | Call | Used by |
+|---|---|---|
+| List arrays | `GET /api/v1/arrays` | Quick / Extended overview, every edit/delete pre-check |
+| Create array | `POST /api/v1/arrays` | Create wizard (§4) |
+| Modify array | `PATCH /api/v1/arrays/{id}` | Edit Array (§5) |
+| Destroy array | `DELETE /api/v1/arrays/{id}` (`dangerous=True`) | Delete Array (§6), teardown step 3 |
+| List disks | `GET /api/v1/disks` | Create wizard, spare-pool drive picker |
+| List shares | `GET /api/v1/shares` | Delete Array dependency discovery |
+| Delete share | `DELETE /api/v1/shares/{id}` | Delete Array, teardown step 1 |
+| List filesystems | `GET /api/v1/filesystems` | Delete Array dependency discovery |
+| Unmount filesystem | `PATCH /api/v1/filesystems/{id}` `{"mounted": false}` | Delete Array, teardown step 2 |
+| Unmanage filesystem | `DELETE /api/v1/filesystems/{id}` | Delete Array, teardown step 2 |
+| Pools | `GET` / `POST` / `PATCH` / `DELETE /api/v1/pools[/{name}]` | Spare Pools (§7), spare-pool pickers in §4 / §5.2 |
 
-For pools:
+The array create spec (`XiraidArray.spec`, [api-v1.yaml](../control-path/api-v1.yaml)) carries `name`, `level` (`"raid<N>"`), `member_disk_ids`, `strip_size_kib`, and optionally `group_size` and `spare_disk_ids`. `force_metadata` is **not** set from the TUI — that flag is reserved for Ansible re-creates where stale metadata is expected.
+
+#### 2.2.1 The daemon-side RPCs behind those endpoints
+
+Retained for reference: the `XiRAIDClient` methods and the protos in [service_xraid.proto](../../xiNAS-MCP/proto/xraid/gRPC/protobuf/service_xraid.proto) that the agent's executors ultimately drive. **No screen in this document calls these** (see the §2.1 scope note) except the two marked *drives screen*.
 
 | Python method | RPC | Request message |
 |---|---|---|
-| `pool_show(name, units)` | `pool_show` | `PoolShow` |
-| `pool_create(name, drives)` | `pool_create` | `PoolCreate` |
-| `pool_delete(name)` | `pool_delete` | `PoolDelete` |
-| `pool_add(name, drives)` | `pool_add` | `PoolAdd` |
-| `pool_remove(name, drives)` | `pool_remove` | `PoolRemove` |
-| `pool_activate(name)` / `pool_deactivate(name)` | matching RPCs | matching messages |
-
-`RaidCreate` accepts the full Xinnor parameter surface — see [message_raid.proto](../../xiNAS-MCP/proto/xraid/gRPC/protobuf/message_raid.proto). The TUI passes `strip_size`, optional `group_size` (RAID 50/60 only), and optional `sparepool`. `force_metadata` is **not** set from the TUI — that flag is reserved for Ansible re-creates where stale metadata is expected.
+| `disk_list()` | `disk_list` | — (*drives screen*, §8) |
+| `drive_locate(drives)` | `drive_locate` | — (*drives screen*, §8) |
+| `raid_show(units, name, extended)` | `raid_show` | `RaidShow` |
+| `raid_create(name, level, drives, **kwargs)` | `raid_create` | `RaidCreate` |
+| `raid_modify(name, **kwargs)` | `raid_modify` | `RaidModify` |
+| `raid_destroy(name, force)` | `raid_destroy` | `RaidDestroy` |
+| `raid_unload(name)` | `raid_unload` | `RaidUnload` |
+| `raid_init_start` / `raid_init_stop` / `raid_recon_start` / `raid_recon_stop` | matching RPCs | — |
+| `pool_show` / `pool_create` / `pool_delete` / `pool_add` / `pool_remove` / `pool_activate` / `pool_deactivate` | matching RPCs | matching messages |
 
 ### 2.3 `NFSHelperClient` — Unix-socket bridge to xinas-nfs-helper
 
@@ -149,25 +173,25 @@ Ops it exposes (one Python handler each, from [nfs_helper.py](../../xiNAS-MCP/nf
 | `reload` | `exportfs -r` |
 | `fix_nfs_conf` | Re-writes the managed block in `/etc/nfs.conf`, restarts `nfs-server` |
 
-In the RAID screen, only `list_exports`, `remove_export`, `add_export`, and `reload` are reached — they are called during teardown when an array being deleted has dependent NFS shares (see §6).
+**No RAID screen reaches this client.** Share removal during a RAID teardown is `DELETE /api/v1/shares/{id}` (§6.3). The helper is documented here because it is still the writer of `/etc/exports` on the far side of that call — the agent's NFS executor talks to the same socket ([agent/task/nfs-helper-client.ts](../../xiNAS-MCP/src/agent/task/nfs-helper-client.ts)) — and because other TUI screens (Shares, Users) call it directly.
 
 ### 2.4 `xfs_helpers` — async subprocess helpers
 
-Source: [xinas_menu/utils/xfs_helpers.py](../../xinas_menu/utils/xfs_helpers.py). Pure Python, no daemon. Used by the RAID screen for two things during deletion:
+Source: [xinas_menu/utils/xfs_helpers.py](../../xinas_menu/utils/xfs_helpers.py). Pure Python, no daemon. The RAID screen imports exactly two of its functions, both **read-only**:
 
-- `find_mounts_using_raid(array_name)` — finds every XFS mount whose **data** device is `/dev/xi_<name>` *or* whose mount options carry `logdev=/dev/xi_<name>`. The second case matters: the data array and the log array are separate xiRAID volumes, and `mnt-data.mount` references the log via `Options=…,logdev=/dev/xi_log,…`. Deleting `xi_log` without unmounting `/mnt/data` first would leave the XFS log dangling.
-- `unmount_filesystem(mountpoint)` and `mount_filesystem(mountpoint)` — wrap `systemctl stop/start <unit>` for the systemd `.mount` units (see [Installer/fs-exports-spec.md §1.8](../Installer/fs-exports-spec.md#18-mountpoint-and-systemd-mount-unit)). Both are used in the rollback path.
+- `find_mounts_using_raid(array_name)` — finds every XFS mount whose **data** device is `/dev/xi_<name>` *or* whose mount options carry `logdev=/dev/xi_<name>`. The second case matters: the data array and the log array are separate xiRAID volumes, and `mnt-data.mount` references the log via `Options=…,logdev=/dev/xi_log,…`. Deleting `xi_log` without unmounting `/mnt/data` first would leave the XFS log dangling. This local `findmnt` read is kept alongside `GET /api/v1/filesystems` because the API does not model log-device usage as a `backing_device` (§6.1).
+- `is_path_under(path, mountpoint)` — the containment test that decides which shares a mountpoint owns.
 
-The geometry / mkfs / mount-unit helpers in the same file are used by the Filesystem screen, not the RAID screen — they replicate the Ansible behavior for runtime FS creation.
+The mutating helpers in the same file — `unmount_filesystem` / `mount_filesystem` (the `systemctl stop/start <unit>` wrappers, see [Installer/fs-exports-spec.md §1.8](../Installer/fs-exports-spec.md#18-mountpoint-and-systemd-mount-unit)) — and the geometry / mkfs / mount-unit helpers belong to the Filesystem screen. The RAID screen does **not** call them: unmounting during a teardown is `PATCH /api/v1/filesystems/{id}` (§6.3), and there is no re-mount path at all (§6.4).
 
 ### 2.5 Cross-cutting helpers: audit + snapshots
 
 Every RAID write (create / modify / destroy) goes through two side-channel helpers:
 
-- **Audit log** ([utils/audit.py](../../xinas_menu/utils/audit.py)) — appends one line per action to `/var/log/xinas/audit.log` in the format `YYYY-MM-DD HH:MM:SS | user | action | STATUS | detail`. `action` strings are stable identifiers like `raid.create`, `raid.modify`, `raid.destroy`, `nfs.remove`, `fs.unmount`. The logger never raises into the UI.
+- **Audit log** ([utils/audit.py](../../xinas_menu/utils/audit.py)) — appends one line per action to `/var/log/xinas/audit.log` in the format `YYYY-MM-DD HH:MM:SS | user | action | STATUS | detail`. `action` strings are stable identifiers like `raid.create`, `raid.modify`, `raid.destroy`, `nfs.remove`, `fs.unmount`, `fs.unmanage`. The logger never raises into the UI.
 - **Snapshot helper** ([utils/snapshot_helper.py](../../xinas_menu/utils/snapshot_helper.py)) — best-effort `await app.snapshots.record("<operation>", diff_summary=…)`. Backed by `xinas_history.SnapshotEngine` (see [Installer/spec.md §3.11](../Installer/spec.md#311-xinas_history--config-snapshots--rollback)). Failures are logged but never propagate; snapshots are advisory, not transactional.
 
-The audit line is written **after** the gRPC reports success. The snapshot is recorded **after** the audit line. Either can fail without affecting the user-visible result.
+The audit line is written **after** the apply task reports success. The snapshot is recorded **after** the audit line. Either can fail without affecting the user-visible result.
 
 ---
 
@@ -280,10 +304,12 @@ only visible symptom.
 
 ### Step — name
 
-`InputDialog` with validation:
+`InputDialog` validated by `_array_name_error(name)`, which returns the operator-facing reason or `None`:
 
-- 1 ≤ length ≤ 64.
+- 1 ≤ length ≤ `_ARRAY_NAME_MAX` = **63**.
 - Matches `_ARRAY_NAME_RE = ^[a-zA-Z0-9_-]+$`.
+
+**The bound is the API contract, not a TUI preference.** `XiraidArray.spec.name` is `^[A-Za-z0-9_-]{1,63}$` ([api-v1.yaml](../control-path/api-v1.yaml)), so the two must agree: the wizard used to accept 64 characters, which meant a 64-character name passed every wizard step and was then rejected by `POST /api/v1/arrays` at dispatch. Any change to either bound must move both. Pinned by `tests/test_raid_overview.py`.
 
 A failed validation re-prompts via the `while True:` loop until the user enters a valid name or cancels. This is the wizard's first step, so its dialog never renders a Back button.
 
@@ -359,10 +385,10 @@ The summary dialog (title `"Confirm Create"`, `allow_back=True`) renders all sel
 
 Steps:
 
-1. **Pick an array.** `grpc.raid_show()` → `SelectDialog` over array names.
-2. **Pick a parameter.** `SelectDialog` over `_MODIFY_PARAMS`, each tuple of `(grpc_key, label, kind, options, value_type)`. Parameters offered, in order: CPU Affinity, Spare Pool, Init Priority, Recon Priority, Scheduler Enabled, Memory Limit, Merge Read Enabled, Merge Write Enabled, Merge Read Max, Merge Write Max. (`resync_enabled` is create-only — xiRAID's `RaidModify` has no such field — so it is not offered.) The two merge-max knobs are **times in microseconds** (the daemon spells them `merge_*_usecs`), so their labels read `(us)` — they were mislabelled `(KB)` until the tuning surface became observable and read and write paths could be compared.
+1. **Pick an array.** `GET /api/v1/arrays` → `SelectDialog` over array names.
+2. **Pick a parameter.** `SelectDialog` over `_MODIFY_PARAMS`, each tuple of `(key, label, kind, options, value_type)`. Parameters offered, in order: CPU Affinity, Spare Pool, Init Priority, Recon Priority, Scheduler Enabled, Memory Limit, Merge Read Enabled, Merge Write Enabled, Merge Read Max, Merge Write Max. (`resync_enabled` is create-only — xiRAID's `RaidModify` has no such field — so it is not offered.) The two merge-max knobs are **times in microseconds** (the daemon spells them `merge_*_usecs`), so their labels read `(us)` — they were mislabelled `(KB)` until the tuning surface became observable and read and write paths could be compared.
 3. **Per-parameter prompt** — see §5.1.
-4. **Confirm + dispatch.** Value is coerced to the declared `vtype` (`int` for the integer knobs, `str` for the rest). `grpc.raid_modify(name, **{key: value})` is invoked. On success: audit (`raid.modify`) + snapshot (`raid_modify`) + Quick Overview refresh.
+4. **Confirm + dispatch.** Value is coerced to the declared `vtype` (`int` for the integer knobs, `str` for the rest) and mapped onto the ADR-0006 writable subset — `sparepool` becomes `{"spare_disk_ids": [...]}`, everything else `{"tuning": {key: value}}`. `PATCH /api/v1/arrays/{name}` is submitted via `plan_apply_wait`. On success: audit (`raid.modify`) + snapshot (`raid_modify`) + Quick Overview refresh. On `ControlPathError`: an OK-only `Edit failed.` dialog.
 
 Step 1 guards the empty case: if the array listing fails or returns no arrays, the flow aborts on an **OK-only** dialog ("No RAID arrays configured." / "No arrays available."). Delete Array (§6) guards the same way. This is one instance of the screen-wide dialog convention — see §12.
 
@@ -378,58 +404,86 @@ This is the only place where the TUI itself reads `/sys` rather than going throu
 
 ### 5.2 Spare-pool selection
 
-`spare_pool` is also dynamic — instead of free-form input, `grpc.pool_show()` is queried and a `SelectDialog` is offered. If no pools exist, the operator is told via `notify(severity="warning")` and the dialog aborts.
+`spare_pool` is also dynamic — instead of free-form input, `GET /api/v1/pools` is queried and a `SelectDialog` is offered. If no pools exist, the operator is told via `notify(severity="warning")` and the dialog aborts. The chosen pool's drive paths are mapped to disk ids (via `GET /api/v1/disks`) to build the PATCH's `spare_disk_ids`; a pool with no drives aborts with a warning rather than sending an empty list.
+
+This is also the only knob in §5 whose PATCH spec is not under `tuning`.
 
 ---
 
-## 6. Delete Array — ordered teardown with rollback
+## 6. Delete Array — ordered, stop-on-failure teardown
 
-This is the most complex flow in the screen because deleting a RAID array can cascade into NFS exports and XFS mounts. The deletion path is implemented as a three-step transaction with point-in-time rollback.
+This is the most complex flow in the screen because deleting a RAID array can cascade into NFS shares and filesystems. The deletion path is a **sequence of control-path API operations**, each one a `plan_apply_wait` of its own; it is *not* a transaction, and there is no cross-step rollback (§6.4). The authoritative contract is [s8-clients-spec §6](../control-path/s8-clients-spec.md#6-tui-composite-teardown-t13).
 
 ### 6.1 Dependency discovery
 
-For the selected array name `arr_name`:
+For the selected array name `arr_name` (whose row already yields `volume_path`, defaulting to `/dev/xi_<name>`):
 
-1. `find_mounts_using_raid(arr_name)` (from `xfs_helpers`) — returns every mount whose data device is `/dev/xi_<name>` *or* whose mount opts carry `logdev=/dev/xi_<name>`. Each result carries a `role` field (`"data"` or `"log"`).
-2. For each discovered mountpoint, the TUI calls `nfs.list_exports()` (synchronous, against the helper socket) and scans for any export whose `path` is rooted at that mountpoint. Matches go into `affected_shares`.
+1. `find_mounts_using_raid(arr_name)` (from `xfs_helpers`) — a **local `findmnt` read**, returning every mount whose data device is `/dev/xi_<name>` *or* whose mount opts carry `logdev=/dev/xi_<name>`. Each result carries a `role` field (`"data"` or `"log"`). This read is kept alongside the API because the control path does not model log-device usage as `backing_device`, so a log array's dependents are invisible to `GET /api/v1/filesystems` alone.
+2. `GET /api/v1/shares` — every share whose `spec.path` is under one of those mountpoints (`is_path_under`) goes into `affected_shares` as `{id, path}`. Skipped entirely when step 1 found no mountpoints.
+3. `GET /api/v1/filesystems` — every filesystem whose `status.backing_device` equals the array's `volume_path`, **or** whose `status.mountpoint` is one of those mountpoints, goes into `affected_fs` as `{id, mountpoint, mounted}`.
+
+A `ControlPathError` on either listing degrades to an empty list rather than aborting: the operator still sees the confirmation, with the un-listable dependents simply absent from it.
 
 ### 6.2 Two-stage confirmation
 
-The first dialog shows the array summary, the list of NFS shares that will be removed, and the list of filesystems that will be unmounted.
+The first dialog shows the array summary, the list of NFS shares that will be removed, and the list of filesystems that will be unmounted/unmanaged. A mount found by `findmnt` but not present in `affected_fs` is still listed, annotated `(<role> device — not API-managed)`.
 
-When the array has dependencies, a **second** `FINAL CONFIRMATION` dialog appears restating the counts. This is the only place in the screen where double confirmation is required.
+When the array has dependencies, a **second** `FINAL CONFIRMATION` dialog appears restating the counts. This is the only place in the screen where double confirmation is required. Together they are the `dangerous=True` consent that the array-delete apply requires — there is no separate dangerous prompt later.
 
 ### 6.3 The teardown order
 
-Once both confirmations pass, the screen runs three steps **in order**:
+Once both confirmations pass, the screen runs three steps **in order**, each rendered into the teardown progress view with its task's stage transitions:
 
 ```
-Step 1: Remove every affected NFS share         (synchronous, helper socket)
-Step 2: Unmount every affected filesystem        (async, systemctl)
-Step 3: Destroy the RAID array                   (gRPC raid_destroy force=True)
+Step 1: for each affected share       DELETE /api/v1/shares/{id}
+Step 2: for each affected filesystem  PATCH  /api/v1/filesystems/{id} {"mounted": false}   (if mounted)
+                                      DELETE /api/v1/filesystems/{id}                      (unmanage)
+Step 3: the array itself              DELETE /api/v1/arrays/{id}  (dangerous=True)
 ```
 
-The order matters: stopping the mount before the export is removed would orphan an active export; destroying the array before the mount is gone would leave systemd holding a stale device reference.
+The order matters: stopping the mount before the share is removed would orphan an active export; destroying the array before the mount is gone would leave systemd holding a stale device reference.
 
-### 6.4 Rollback
+Step 3 additionally raises a `TaskWaitDialog` so the destroy — the long step — is cancellable; its `cancel_requested` is passed as the `cancel_check`.
 
-Each step appends to a per-step bookkeeping list (`removed_shares`, `unmounted_mounts`). On any failure during teardown:
+### 6.4 Partial teardown — no cross-step rollback
 
-- **Step 1 fails** (NFS share won't remove): re-add every previously removed share via `nfs.add_export(saved)`, then `nfs.reload()`. The teardown aborts with `Error — Rollback Complete`.
-- **Step 2 fails** (a mount won't unmount): re-mount every previously unmounted mountpoint via `mount_filesystem()`, then re-add every removed share, then `nfs.reload()`. Teardown aborts.
-- **Step 3 fails** (xiRAID refuses to destroy): same as Step 2 rollback — every removed share and every unmounted FS is restored. The xiRAID error from `grpc_short_error(err)` is shown to the operator.
+**The sequence stops at the first failing step, and everything already completed stays completed.** Steps 1 and 2 are plain `for` loops over `plan_apply_wait` calls; a `ControlPathError` from any of them calls `_teardown_failed(...)` and returns. There is no bookkeeping of removed shares or unmounted filesystems to undo, and the screen never re-creates a share or re-mounts a filesystem — those paths do not exist in `raid.py`.
 
-This is best-effort, not transactional: if rollback itself errors out, the screen shows what was restored and what wasn't, but cannot reverse the rollback. The audit log captures every step, so an operator can reconstruct the sequence after the fact.
+This is deliberate, per s8-clients-spec §6: rollback belongs to the task engine, one apply at a time. Each individual step's apply either lands or rolls itself back where its executor supports that; the TUI does not stack a second, weaker rollback layer on top of steps that already succeeded and were reported as successful.
+
+**What the operator is told.** `_teardown_failed` appends two lines to the progress view —
+
+```
+  FAILED: <error>
+  Teardown stopped — remaining steps were not run.
+```
+
+— and raises an OK-only dialog titled **`Delete Array — Stopped`** naming the step that failed, the error, and, verbatim: *"Teardown stopped at this step. No cross-step rollback; the failed task rolled itself back where supported."* The progress view above it still shows every step that did complete, in order.
+
+Cancelling the step-3 destroy is reported separately: the progress view gets `Destroy CANCELLED — partial work rolled back (shares/filesystems already removed stay removed).` and a warning notification. The cancellation rolls back the destroy task only.
+
+**Manual recovery.** The system is left in a valid but partially-torn-down state, and recovery is an ordinary forward operation, not an undo:
+
+| Stopped at | State | Recovery |
+|---|---|---|
+| Step 1, share *k* | shares 1..*k-1* deleted; everything else intact | Re-create the missing shares from the Shares screen (or `POST /api/v1/shares`), or continue the teardown once the blocker is cleared. |
+| Step 2, filesystem *k* | all shares deleted; filesystems 1..*k-1* unmounted + unmanaged | Fix the blocker (usually a busy mount — see §10), then either re-run Delete Array to finish, or re-manage/re-mount the filesystem and re-create its shares. |
+| Step 3 (destroy) | all shares and filesystems gone; array still present | The array is intact and its data still readable. Re-run Delete Array once the daemon-side blocker is cleared, or re-create the filesystem and shares on top of it. |
+
+The audit log records each completed step (§6.5), so the boundary between "done" and "not run" is reconstructable after the fact — that trail is what a recovery is driven from.
 
 ### 6.5 Side effects per step
 
 | Step | Audit action | Snapshot recorded |
 |---|---|---|
-| 1 — `nfs.remove_export(path)` | `nfs.remove` with detail `share=<path> (RAID teardown)` | — |
-| 2 — `xfs_helpers.unmount_filesystem(mp)` | `fs.unmount` with detail `mountpoint=<mp> (RAID teardown)` | — |
-| 3 — `grpc.raid_destroy(name, force=True)` | `raid.destroy` with detail `<name>` | `raid_delete` with diff summary |
+| 1 — `DELETE /api/v1/shares/{id}` | `nfs.remove` with detail `share=<path> (RAID teardown)` | — |
+| 2a — `PATCH /api/v1/filesystems/{id}` `{"mounted": false}` | `fs.unmount` with detail `mountpoint=<mp> (RAID teardown)` | — |
+| 2b — `DELETE /api/v1/filesystems/{id}` | `fs.unmanage` with detail `unit=<id> (RAID teardown)` | — |
+| 3 — `DELETE /api/v1/arrays/{id}` (`dangerous=True`) | `raid.destroy` with detail `<name>` | `raid_delete` with diff summary |
 
-Snapshots are taken **only** on the final RAID destroy step, since the share + mount changes are subsumed by the array's disappearance. The snapshot's `diff_summary` counts the removed shares and unmounted mountpoints for context.
+Each audit line is written only after its own step succeeded, which is what makes the trail a faithful record of where a stopped teardown got to. Step 2a is skipped (and no `fs.unmount` line written) for a filesystem the API already reports as not mounted.
+
+Snapshots are taken **only** on the final RAID destroy step, since the share + filesystem changes are subsumed by the array's disappearance. The snapshot's `diff_summary` counts the removed shares and filesystems for context. A teardown that stops early therefore records **no** snapshot.
 
 ---
 
@@ -437,25 +491,31 @@ Snapshots are taken **only** on the final RAID destroy step, since the share + m
 
 Source: [xinas_menu/screens/spare_pools.py](../../xinas_menu/screens/spare_pools.py). Reached from RAID Management → 3, or from Storage → 5.
 
+Since S9 T11 (ADR-0011) the screen rides the control-path API end to end — it does not import the gRPC client. Reads are `GET /api/v1/pools`, returning rows of `{name, drives, active, referenced_by}`; every mutation is a `plan_apply_wait`.
+
 ### 7.1 Menu
 
-| Key | Action | gRPC RPC |
+A `PATCH` carries **exactly one** intent — `add_drives`, `remove_drives`, or `active`; the API rejects a body that mixes them.
+
+| Key | Action | Control-path call |
 |---|---|---|
-| 1 | View Pools | `pool_show` |
-| 2 | Create Pool | `pool_create` |
-| 3 | Add Drives | `pool_add` |
-| 4 | Remove Drives | `pool_remove` |
-| 5 | Activate Pool | `pool_activate` |
-| 6 | Deactivate Pool | `pool_deactivate` |
-| 7 | Delete Pool | `pool_delete` |
+| 1 | View Pools | `GET /api/v1/pools` |
+| 2 | Create Pool | `POST /api/v1/pools` `{name, drives}` |
+| 3 | Add Drives | `PATCH /api/v1/pools/{name}` `{add_drives: [...]}` |
+| 4 | Remove Drives | `PATCH /api/v1/pools/{name}` `{remove_drives: [...]}` |
+| 5 | Activate Pool | `PATCH /api/v1/pools/{name}` `{active: true}` |
+| 6 | Deactivate Pool | `PATCH /api/v1/pools/{name}` `{active: false}` |
+| 7 | Delete Pool | `DELETE /api/v1/pools/{name}` |
+
+Pool names reach the path via `quote_id()` like every other id (s8-clients-spec §6). Failures render through `_pool_error(action, err)`, which shows a one-line reason plus the wrapped full error.
 
 ### 7.2 Drive selection rules
 
 `_get_free_nvme_drives()` enforces the "no double-membership" invariant: a drive can be in **either** a RAID array **or** a spare pool, not both. The function:
 
-1. Calls `disk_list()` for all block drives.
-2. Calls `pool_show()` and builds a set of paths already in any pool.
-3. Filters out: anything missing `nvme` in its name, anything with `system=True`, anything with `raid_name` set, anything already in `pool_drives`.
+1. Calls `_list_api_disks()` (`GET /api/v1/disks`, shared with the RAID Create wizard) for all block drives.
+2. Calls `GET /api/v1/pools` and builds a set of paths already in any pool.
+3. Filters out: anything missing `nvme` in its name, anything with `system=True`, anything not `safe_for_use`, anything `claimed` (already a member or spare of an observed array), and anything already in `pool_drives` — matched on both the `/dev/` path and the bare name, since pool rows and disk rows spell drives differently.
 
 The result is fed into `DrivePickerScreen` so the operator can apply the same NUMA/size/text filters as in the RAID Create wizard.
 
@@ -466,10 +526,10 @@ Same flow as RAID Create up to the drive picker, then:
 1. Pool name validated against `_POOL_NAME_RE = ^[a-zA-Z0-9_-]+$`.
 2. Drive picker with `_get_free_nvme_drives()` as the source.
 3. Confirmation summary.
-4. Names normalised to `/dev/<name>`.
-5. `grpc.pool_create(name, drives)`.
+4. Names normalised to `/dev/<name>` (`_to_dev_paths` — the picker returns bare names, the pool spec wants paths).
+5. `POST /api/v1/pools` `{name, drives}` via `plan_apply_wait`.
 
-No audit / snapshot calls are wired in for pool operations at the moment — pool changes are visible in the gRPC state but not recorded in `/var/log/xinas/audit.log`.
+No audit / snapshot calls are wired in the *screen* for pool operations — pool changes are not written to `/var/log/xinas/audit.log` by the TUI. They are recorded control-path-side, in the api's own `GET /audit` trail (ADR-0011), which the View Audit Log screen merges with the local trail (see [Management/audit-log-spec.md](../Management/audit-log-spec.md)).
 
 ### 7.4 Remove Drives — checklist style
 
@@ -487,11 +547,13 @@ Single confirmation (no two-stage gate — pools have no downstream FS / NFS dep
 
 ---
 
-## 8. Physical Drives screen (read-only)
+## 8. Physical Drives screen — inventory, plus LED locate
 
 Source: [xinas_menu/screens/drives.py](../../xinas_menu/screens/drives.py).
 
-This is a read-only inventory view. It uses the same `disk_list()` enrichment (`lsblk` + `raid_show(extended=True)` membership join) as the wizards, plus the role classifier:
+This is an inventory view: **no drive's contents or membership can be changed from it.** It is the one screen in this document that still calls the gRPC client directly (`self.app.grpc`, §2.1), not the control-path API.
+
+It loads `grpc.disk_list()` (`lsblk` + `raid_show(extended=True)` membership join), plus the role classifier:
 
 ```
 system → OS drive (root/boot/EFI partition present)
@@ -500,7 +562,11 @@ pool   → in a spare pool
 free   → none of the above
 ```
 
-No write operations — no RPCs are sent. The screen is the canonical "what does this box see right now" view, and it's the data source the wizards' drive filters depend on.
+Everything else on the screen — sort (`s`), reverse (`r`), text filter (`f`), NUMA filter (`n`), detail (`Enter` / `d`), SMART summary (`m`), SMART full (`Shift+M`) — is local or a read.
+
+**The one exception is `l` — Blink LED.** `action_locate_drive` sends `grpc.drive_locate([name])`, which is a **write RPC**: it changes device state on the enclosure, and on success the screen records an audit event, `audit.log("drive.locate", <name>, "OK")`. It is non-destructive and needs no confirmation dialog, but this screen is not "no RPCs are sent" — describing it that way is what let the claim go stale. A failure is reported through `notify(..., severity="error")` with `grpc_short_error(err)` and writes no audit line.
+
+Apart from `drive_locate`, the screen issues no writes. It is the canonical "what does this box see right now" view, and its data source is what the wizards' drive filters depend on (the wizards read the same inventory through `GET /api/v1/disks`).
 
 ---
 
@@ -533,31 +599,32 @@ RAIDScreen._create_array_wizard()
 
 ```
 RAIDScreen._delete_array()
-  ├─ grpc.raid_show()                   — list arrays
+  ├─ GET /api/v1/arrays                 — list arrays
   ├─ SelectDialog (pick array)
-  ├─ find_mounts_using_raid("data")
+  ├─ find_mounts_using_raid("data")     — local findmnt read
   │    ├─ findmnt /dev/xi_data           → /mnt/data role=data
   │    └─ findmnt -t xfs (logdev scan)   → no extra mounts
-  ├─ nfs.list_exports()                 — Unix socket: list_exports
-  │    └─ helper reads /etc/exports
+  ├─ GET /api/v1/shares                 — filtered to paths under /mnt/data
+  ├─ GET /api/v1/filesystems            — backing_device or mountpoint match
   ├─ first ConfirmDialog (warning)
-  ├─ second ConfirmDialog (FINAL)
-  ├─ for each affected share:
-  │    ├─ nfs.remove_export(path)        — Unix socket: remove_export
-  │    │    └─ helper: edit /etc/exports + exportfs -ra
+  ├─ second ConfirmDialog (FINAL)       — together: the dangerous consent
+  ├─ for each affected share:                                    [step 1]
+  │    ├─ DELETE /api/v1/shares/{id}     — plan_apply_wait
+  │    │    └─ api → agent → nfs-helper: /etc/exports + exportfs -ra
   │    └─ audit.log("nfs.remove", …)
-  ├─ nfs.reload()                        — Unix socket: reload (exportfs -r)
-  ├─ for each mount:
-  │    ├─ unmount_filesystem(mp)         — systemctl stop mnt-data.mount
-  │    │                                   + systemctl disable + rm unit
-  │    └─ audit.log("fs.unmount", …)
-  ├─ grpc.raid_destroy("data", force=True)
-  │    └─ gRPC raid_destroy RPC          → xRAID daemon → xicli raid destroy
+  ├─ for each affected filesystem:                               [step 2]
+  │    ├─ PATCH /api/v1/filesystems/{id} {"mounted": false}       (if mounted)
+  │    │    └─ audit.log("fs.unmount", …)
+  │    ├─ DELETE /api/v1/filesystems/{id}
+  │    └─ audit.log("fs.unmanage", …)
+  ├─ TaskWaitDialog (cancellable)                                [step 3]
+  ├─ DELETE /api/v1/arrays/data          — plan_apply_wait(dangerous=True)
+  │    └─ api → agent → xRAID daemon → xicli raid destroy
   ├─ audit.log("raid.destroy", "data", "OK")
   └─ snapshots.record("raid_delete", diff_summary=…)
 ```
 
-If any step after share-removal fails, the rollback path re-runs `add_export` + `mount_filesystem` to restore prior state before the error dialog appears.
+If any step fails, the sequence **stops there** — `_teardown_failed` renders the error and the remaining steps are not run. Steps that already completed are not undone; see §6.4 for what the operator is told and how to recover.
 
 ---
 
@@ -565,16 +632,18 @@ If any step after share-removal fails, the rollback path re-runs `add_export` + 
 
 | Failure | Where | Handling |
 |---|---|---|
-| gRPC stubs not generated | `XiRAIDClient._import_stubs()` | First RPC returns `(False, None, "gRPC stubs not available: <ImportError>")`. UI shows the message; operator runs `--tags xinas_menu` to regenerate. |
+| `xinas-api` unreachable / apply rejected | every `control.result` / `plan_apply_wait` | Raises `ControlPathError`. Reads that only feed a confirmation degrade to an empty list (§6.1); reads that gate a flow abort on an OK-only dialog; writes abort the step. |
+| xiRAID backend down behind a healthy api | `GET /api/v1/arrays` envelope | `DEGRADED_BACKEND_UNAVAILABLE` warning → the screen renders the degraded banner and never shows an empty list as "no arrays" (§3.1). |
+| Plan blocked (e.g. pool active or referenced on delete) | api-side plan blockers | `plan_apply_wait` raises before anything is applied; Spare Pools renders it through `_pool_error` with the blocker's reason. |
+| gRPC stubs not generated | `XiRAIDClient._import_stubs()` | First RPC returns `(False, None, "gRPC stubs not available: <ImportError>")`. Reaches the operator via the Physical Drives screen (§8); operator runs `--tags xinas_menu` to regenerate. |
 | TLS cert missing | `_load_channel_credentials()` | Falls through to insecure channel with a `UserWarning`. Intended only for dev hosts; production should always find a cert. |
-| xRAID daemon down | every RPC | `grpc.aio` raises `RpcError("StatusCode.UNAVAILABLE")`; `_call()` catches and returns `(False, None, str(exc))`. UI shows the short error. |
-| `xinas-nfs-helper` socket missing or refused | `NFSHelperClient._request()` | Returns `(False, None, "NFS helper socket not found: …")` or `"…not running (connection refused)"`. Delete-array path uses this to short-circuit before touching the array. |
-| Helper response not JSON | `NFSHelperClient._request()` | `(False, None, "bad JSON from NFS helper: …")`. |
-| Pool name / array name contains invalid chars | `_ARRAY_NAME_RE` / `_POOL_NAME_RE` | InputDialog re-prompts; never sent to the daemon. |
-| RAID 10 with no spare pool when one is required | xiRAID's own validation | Caught when `raid_create` returns failure; the operator sees the daemon's reason. |
+| xRAID daemon down | every gRPC RPC (§8 only) | `grpc.aio` raises `RpcError("StatusCode.UNAVAILABLE")`; `_call()` catches and returns `(False, None, str(exc))`. UI shows the short error. |
+| Array / pool name too long or with invalid chars | `_array_name_error()` / `_POOL_NAME_RE` | InputDialog re-prompts. The array bound is the API's own `{1,63}` (§4), so a name that passes the wizard is not rejected downstream. |
+| Under-count of drives for the chosen RAID level | xiRAID's own validation, via the api | Surfaced only after the confirm step, as a create failure carrying the engine's reason (§4). |
+| RAID 10 with no spare pool when one is required | xiRAID's own validation, via the api | Create apply fails; the operator sees the daemon's reason. |
 | Operator picks 0 drives in the picker | `action_confirm()` | Notify `"No drives selected."` and stay on the picker. |
-| Mount unit refuses to unmount during RAID delete (busy FS) | `xfs_helpers.unmount_filesystem` | Returns `(False, "Failed to stop mount: <stderr>")` → triggers Step 2 rollback. |
-| `raid_destroy` fails after FS / NFS already torn down | Step 3 catch | Restores every unmounted FS and re-adds every removed share before reporting the error. Audit log captures the rollback. |
+| Share / filesystem / array step fails mid-teardown (busy FS, blocked plan, daemon refusal) | `_teardown_failed` | The sequence **stops**. Completed steps stay completed — there is no cross-step rollback. Progress view shows what ran; an OK-only `Delete Array — Stopped` dialog names the failing step and the error (§6.4). |
+| Operator cancels the step-3 destroy | `TaskWaitDialog.cancel_requested` → `TaskCancelled` | The destroy task rolls itself back; already-removed shares and filesystems stay removed, and the progress view says so. No snapshot is recorded. |
 | Snapshot creation fails | `SnapshotHelper.record` | Logged via `_log.warning(…)`; UI flow is unaffected (snapshots are advisory). |
 | Audit log can't be written | `AuditLogger.log` | Silently swallowed (`OSError` is caught). The UI flow is never blocked by the audit channel. |
 
@@ -582,10 +651,11 @@ If any step after share-removal fails, the rollback path re-runs `add_export` + 
 
 ## 11. What the TUI does **not** do
 
-- It does not call `xicli` directly. Every RAID, pool, and drive query goes through the gRPC daemon at `localhost:6066`. If the daemon is down, the screen is inert — there is no fallback path.
-- It does not edit `/etc/exports` or `/etc/nfs.conf` itself. NFS state mutations always cross the `/run/xinas-nfs-helper.sock` boundary.
-- It does not perform initialisation control (`raid_init_start` / `raid_init_stop`) or reconstruction control (`raid_recon_start` / `raid_recon_stop`). The RPCs exist in the client but no menu entry calls them — they currently belong to xiRAID's automatic management.
-- It does not delete arrays without `force=True`. Every `_delete_array` path passes `force=True`, on the assumption that the two-stage confirmation gate is the real safety. The non-force destroy semantics are not exposed.
+- It does not call `xicli` directly. Every array and pool operation goes through `xinas-api`; the Physical Drives screen's inventory and LED locate go through the gRPC daemon at `localhost:6066`. If the service behind a screen is down, that screen is inert — there is no fallback path.
+- It does not edit `/etc/exports` or `/etc/nfs.conf` itself, and no longer even speaks to the helper socket: NFS state mutations reached from a RAID teardown go `api → agent → /run/xinas-nfs-helper.sock`.
+- It does not roll back across teardown steps. A failed step stops the sequence and leaves the completed ones in place (§6.4); recovery is a forward operation by the operator.
+- It does not perform initialisation control (`raid_init_start` / `raid_init_stop`) or reconstruction control (`raid_recon_start` / `raid_recon_stop`). The RPCs exist in the gRPC client but no menu entry and no API call reaches them — they currently belong to xiRAID's automatic management.
+- It does not expose non-force destroy semantics. `DELETE /api/v1/arrays/{id}` is always submitted with `dangerous=True`, on the assumption that the two-stage confirmation gate is the real safety.
 - It does not edit `xiraid_arrays` or `xfs_filesystems` Ansible facts. Day-1 (installer) topology is owned by Ansible; day-2 mutations live in the gRPC daemon's state. The two are reconciled via xiraid's persistent config, not via Ansible re-runs.
 - It does not multiplex drives between RAID and pool membership. The drive filters explicitly exclude drives that are already a member of either.
 

--- a/tests/test_fs_overview.py
+++ b/tests/test_fs_overview.py
@@ -1,4 +1,10 @@
+import inspect
+from pathlib import Path
+
 from xinas_menu.screens.filesystem import _format_filesystems
+
+_REPO = Path(__file__).resolve().parent.parent
+_FS_SCREEN = _REPO / "xinas_menu/screens/filesystem.py"
 
 
 def test_banner_replaces_empty_state():
@@ -27,3 +33,128 @@ def test_rows_render_with_banner():
     out = _format_filesystems(rows, banner="degraded")
     assert "/mnt/data" in out
     assert "degraded" in out
+
+
+# ---- Delete Filesystem teardown (fs-shares-management-spec §3.4,
+#      s8-clients-spec §6) ----
+#
+# The spec used to promise that a failed teardown step re-added the removed
+# shares via nfs.add_export and reported "Rolled back N share(s)". It never
+# did: a step failure stops the sequence and completed steps stay completed.
+# If a rollback is ever added, §3.4 has to be rewritten with it.
+
+
+def test_delete_filesystem_never_restores_a_completed_step():
+    from xinas_menu.screens.filesystem import FilesystemScreen
+
+    src = inspect.getsource(FilesystemScreen._delete_filesystem)
+    for undo in ("add_export", "mount_filesystem", "remount", "rollback(", "Rolled back"):
+        assert undo not in src, f"_delete_filesystem appears to undo a completed step: {undo}"
+
+
+def test_fs_teardown_failure_says_the_sequence_stopped():
+    from xinas_menu.screens.filesystem import FilesystemScreen
+
+    src = inspect.getsource(FilesystemScreen._teardown_failed)
+    assert "remaining steps were not run" in src
+    assert "No cross-step rollback" in src
+    assert "Delete Filesystem — Stopped" in src
+    # Reporting a halt is informational: OK-only, never an unanswerable Yes/No.
+    assert "ok_only=True" in src
+
+
+def test_fs_teardown_uses_the_control_path_endpoints():
+    from xinas_menu.screens.filesystem import FilesystemScreen
+
+    src = inspect.getsource(FilesystemScreen._delete_filesystem)
+    assert "/api/v1/shares/" in src
+    assert "/api/v1/filesystems/" in src
+    assert '"mounted": False' in src
+    assert "app.nfs" not in src
+
+
+def test_filesystem_screen_reads_the_control_path_not_findmnt_or_grpc():
+    # §3.1: the whole screen rides the control path; the direct findmnt /
+    # mkfs / mount-unit helpers and the gRPC client left it.
+    src = _FS_SCREEN.read_text()
+    assert "app.grpc" not in src
+    assert "app.nfs" not in src
+    # No findmnt string literal to hand to a subprocess (the module
+    # docstring mentions it only to say it left).
+    assert '"findmnt"' not in src and "'findmnt'" not in src
+    for helper in ("unmount_filesystem", "mount_filesystem", "update_mount_unit_quota"):
+        assert helper not in src, f"filesystem.py still calls {helper}"
+
+
+# ---- Create wizard: geometry is server-derived (§3.3) ----
+#
+# The spec used to document a client-side calculate_stripe_width /
+# build_mount_options derivation. The screen sends a structured spec and
+# omits su_kb/sw so the api derives them; the flat option string in the
+# summary is display-only.
+
+
+def test_create_wizard_derives_no_geometry_client_side():
+    from xinas_menu.screens.filesystem import FilesystemScreen
+
+    src = inspect.getsource(FilesystemScreen._create_filesystem_wizard)
+    for helper in ("calculate_stripe_width", "calculate_parity_disks", "build_mount_options"):
+        assert helper not in src, f"create wizard computes geometry itself: {helper}"
+    # su_kb is displayed in the summary but must not reach the spec.
+    assert '"su_kb"' not in src and '"sw"' not in src
+
+
+def test_in_use_volumes_cover_log_devices_not_just_backing_devices():
+    # §3.3 pre-check: an array serving as someone's logdev= is as
+    # unavailable as one serving as their data device.
+    from xinas_menu.screens.filesystem import _volumes_in_use
+
+    used = _volumes_in_use(
+        [
+            {
+                "backing_device": "/dev/xi_data",
+                "options": ["rw", "logdev=/dev/xi_log", "noatime"],
+            }
+        ]
+    )
+    assert used == {"/dev/xi_data", "/dev/xi_log"}
+
+
+def test_create_spec_carries_logdev_and_quota_as_structured_fields():
+    from xinas_menu.screens.filesystem import _DEFAULT_MOUNT_OPTIONS, FilesystemScreen
+
+    # logdev= and uquota ride log_device / quota_mode, not mount_options.
+    assert not any("logdev" in o or "quota" in o for o in _DEFAULT_MOUNT_OPTIONS)
+
+    src = inspect.getsource(FilesystemScreen._create_filesystem_wizard)
+    for field in ('"log_device"', '"quota_mode"', '"mount_options"', '"sector_size"'):
+        assert field in src, f"create spec is missing {field}"
+    # The force retry is the only place dangerous consent is submitted.
+    assert "dangerous=True" in src
+
+
+# ---- Manage Quotas: one mode per filesystem (§3.5) ----
+#
+# The API holds a single quota_mode enum, so "Enable Both (user + project)"
+# is gone and enabling one mode replaces the other.
+
+
+def test_quota_toggle_offers_no_enable_both_and_patches_one_intent():
+    from xinas_menu.screens.filesystem import FilesystemScreen
+
+    src = inspect.getsource(FilesystemScreen._manage_quotas)
+    assert "Enable Both" not in src
+    assert '"quota_mode"' in src
+    assert "replaces" in src, "the replace-semantics warning is part of the contract"
+    # One intent key per PATCH — never bundled with mounted/grow.
+    assert '"mounted"' not in src and '"grow"' not in src
+
+
+def test_quota_flags_parse_both_option_spellings():
+    from xinas_menu.screens.filesystem import _quota_flags
+
+    assert _quota_flags(["uquota"]) == {"user": True, "project": False, "group": False}
+    assert _quota_flags(["usrquota"])["user"] is True
+    assert _quota_flags(["prjquota"])["project"] is True
+    assert _quota_flags(["grpquota"])["group"] is True
+    assert _quota_flags(["rw", "noatime"]) == {"user": False, "project": False, "group": False}

--- a/tests/test_nfs_wizard_helpers.py
+++ b/tests/test_nfs_wizard_helpers.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import inspect
+
 from xinas_menu.screens.nfs import (
+    NFSScreen,
+    _format_exports,
     _format_sessions,
     _host_prefill,
+    _parse_current_export,
     _path_prefill,
+    _rows_from_api,
     _xiraid_mount_points,
 )
 
@@ -110,3 +116,201 @@ def test_xiraid_mount_points_none():
 
 def test_xiraid_mount_points_empty_string():
     assert _xiraid_mount_points("") == []
+
+
+# ---- control-path adapter (fs-shares-management-spec §4.2) ----
+#
+# The API keeps sync / security_mode as SHARE-level fields; the renderer and
+# the Edit wizard speak the legacy client-option shape. _rows_from_api folds
+# them back in, so _parse_current_export keeps working unchanged.
+
+
+def _api_share(spec_extra: dict | None = None) -> list[dict]:
+    return [
+        {
+            "id": "mnt/data",
+            "spec": {
+                "path": "/mnt/data",
+                "fsid": 1,
+                "clients": [{"pattern": "10.0.0.0/24", "options": ["rw", "no_root_squash"]}],
+                **(spec_extra or {}),
+            },
+            "status": {},
+        }
+    ]
+
+
+def test_rows_from_api_folds_share_level_sync_and_sec_into_client_options():
+    rows = _rows_from_api(_api_share({"sync": "async", "security_mode": "krb5p"}))
+    assert len(rows) == 1
+    opts = rows[0]["clients"][0]["options"]
+    assert "async" in opts
+    assert "sec=krb5p" in opts
+    # pattern is renamed to the legacy key the renderer/wizard read.
+    assert rows[0]["clients"][0]["host"] == "10.0.0.0/24"
+    assert rows[0]["id"] == "mnt/data"
+
+
+def test_rows_from_api_omits_sec_for_the_default_security_mode():
+    rows = _rows_from_api(_api_share({"sync": "sync", "security_mode": "sys"}))
+    opts = rows[0]["clients"][0]["options"]
+    assert not any(o.startswith("sec=") for o in opts)
+
+
+def test_rows_from_api_does_not_duplicate_an_option_already_present():
+    rows = _rows_from_api(
+        [
+            {
+                "id": "mnt/data",
+                "spec": {
+                    "path": "/mnt/data",
+                    "clients": [{"pattern": "*", "options": ["rw", "sync"]}],
+                    "sync": "sync",
+                },
+            }
+        ]
+    )
+    assert rows[0]["clients"][0]["options"].count("sync") == 1
+
+
+def test_rows_from_api_drops_pathless_and_malformed_docs():
+    assert _rows_from_api([{"id": "x", "spec": {"clients": []}}]) == []
+    assert _rows_from_api(["not-a-dict", {"id": "y"}]) == []
+    assert _rows_from_api("not-a-list") == []
+
+
+def test_adapter_output_round_trips_through_the_edit_parser():
+    # §4.6 depends on this: the wizard reads its five fields back out of the
+    # adapted row, not out of the API doc.
+    rows = _rows_from_api(_api_share({"sync": "async", "security_mode": "krb5"}))
+    parsed = _parse_current_export(rows[0])
+    assert parsed["host"] == "10.0.0.0/24"
+    assert parsed["access"] == "rw"
+    assert parsed["root_squash"] == "no_root_squash"
+    assert parsed["sync_mode"] == "async"
+    assert parsed["sec"] == "krb5"
+
+
+# ---- share writes ride the control path (§4.1, §4.5–4.7) ----
+
+
+def test_share_writes_use_plan_apply_wait_not_the_helper_socket():
+    for name, method, verb in (
+        ("add", NFSScreen._add_share_wizard, "POST"),
+        ("edit", NFSScreen._edit_share, "PATCH"),
+        ("remove", NFSScreen._remove_share, "DELETE"),
+    ):
+        src = inspect.getsource(method)
+        assert "plan_apply_wait" in src, f"{name} does not go through plan/apply"
+        assert verb in src, f"{name} does not use {verb}"
+        assert "/api/v1/shares" in src
+        for op in ("add_export(", "update_export(", "remove_export(", "app.nfs"):
+            assert op not in src, f"{name} still calls the helper socket: {op}"
+
+
+def test_share_ids_are_percent_encoded_on_every_addressed_path():
+    # An NfsShare id carries internal slashes (encExportId), so a raw id 404s.
+    for method in (NFSScreen._edit_share, NFSScreen._remove_share):
+        src = inspect.getsource(method)
+        assert "quote_id(" in src, f"{method.__name__} addresses a share id unencoded"
+
+
+def test_remove_share_passes_no_dangerous_flag():
+    # Risk class is changing_access; the single confirmation is the gate.
+    src = inspect.getsource(NFSScreen._remove_share)
+    assert "dangerous=True" not in src
+
+
+def test_edit_sends_security_mode_unconditionally_but_add_does_not():
+    # §4.6: an omitted PATCH field means "leave alone", so Edit must always
+    # send security_mode or sec=krb5 could never be cleared. Add only sets it
+    # when the operator chose something other than the default.
+    add = inspect.getsource(NFSScreen._add_share_wizard)
+    edit = inspect.getsource(NFSScreen._edit_share)
+    assert 'spec["security_mode"] = sec' in add
+    assert 'if sec != "sys"' in add
+    assert '"security_mode": sec' in edit
+    # Edit's `if sec != "sys"` is the confirmation summary's display list,
+    # never the patch — the patch block must not be conditional on it.
+    patch_block = edit.split("patch: dict[str, Any] = {", 1)[1].split("try:", 1)[0]
+    assert "security_mode" in patch_block
+    assert "if " not in patch_block
+
+
+def test_add_share_keeps_sync_and_sec_out_of_the_client_options():
+    # They are share-level spec fields; _rows_from_api folds them back on read.
+    src = inspect.getsource(NFSScreen._add_share_wizard)
+    assert '"options": [access, root_squash, "no_subtree_check"]' in src
+    assert '"sync": sync_mode' in src
+
+
+# ---- Show: empty is empty, degraded says so (§4.2) ----
+#
+# The renderer used to parse /etc/exports whenever the row list came back
+# empty. Under the control path an empty list means the api observed no
+# shares — and the collector reads /etc/exports itself — so the fallback
+# could only present unmanaged file contents as the managed share list.
+
+
+def test_empty_share_list_renders_an_empty_state_not_etc_exports():
+    out = _format_exports([])
+    assert "no NFS shares configured" in out
+
+
+def test_renderer_never_reads_etc_exports():
+    # No path literal to open. (The prose comment naming the removed fallback
+    # is fine; a quoted path is what a read would need. The renderer does
+    # still open /proc/fs/nfsd/clients/*/info for the Connected-hosts block.)
+    src = inspect.getsource(_format_exports)
+    assert '"/etc/exports"' not in src and "'/etc/exports'" not in src
+
+
+def test_degraded_banner_replaces_the_empty_state():
+    out = _format_exports([], banner="NFS backend unavailable")
+    assert "NFS backend unavailable" in out
+    assert "no NFS shares configured" not in out
+
+
+def test_degraded_banner_shows_above_rows_when_some_are_observed():
+    rows = _rows_from_api(_api_share({"sync": "sync"}))
+    out = _format_exports(rows, banner="NFS backend unavailable")
+    assert "NFS backend unavailable" in out
+    assert "/mnt/data" in out
+
+
+def test_no_banner_keeps_the_plain_empty_state():
+    assert "backend" not in _format_exports([]).lower()
+
+
+def test_load_exports_reads_the_envelope_for_warnings():
+    # control.get, not control.result — .result discards the warnings that
+    # carry DEGRADED_BACKEND_UNAVAILABLE.
+    src = inspect.getsource(NFSScreen._load_exports)
+    assert "control.get" in src
+    assert "degraded_banner" in src
+
+
+# ---- fsid allocation fails closed (§4.5) ----
+#
+# Share.spec.fsid is required by the API, so the TUI must allocate. A
+# swallowed read error made max(used, default=0)+1 restart at 1 and collide
+# with every existing share.
+
+
+def test_get_exports_propagates_a_control_path_error():
+    src = inspect.getsource(NFSScreen._get_exports)
+    assert "except ControlPathError" not in src, "_get_exports must not swallow the read failure"
+
+
+def test_add_share_aborts_when_the_existing_shares_cannot_be_read():
+    src = inspect.getsource(NFSScreen._add_share_wizard)
+    fsid_block = src.split("used: set[int] = set()", 1)
+    assert len(fsid_block) == 2, "fsid allocation block not found"
+    assert "Could not read existing shares" in fsid_block[1]
+
+
+def test_edit_and_remove_distinguish_unreadable_from_empty():
+    for method in (NFSScreen._edit_share, NFSScreen._remove_share):
+        src = inspect.getsource(method)
+        assert "Could not load shares." in src, f"{method.__name__} reports a failed read as empty"
+        assert "No shares configured." in src

--- a/tests/test_raid_overview.py
+++ b/tests/test_raid_overview.py
@@ -1,6 +1,12 @@
+import inspect
 import re
+from pathlib import Path
+
+import yaml
 
 from xinas_menu.screens.raid import _arrays_from_api, _format_raid_overview
+
+_REPO = Path(__file__).resolve().parent.parent
 
 
 def test_banner_prepended_and_replaces_empty_state():
@@ -209,3 +215,116 @@ def test_merge_max_edit_params_are_labelled_microseconds_not_kb():
     assert "(us)" in labels["merge_write_max"]
     assert "KB" not in labels["merge_read_max"]
     assert "KB" not in labels["merge_write_max"]
+
+
+# ---- array-name validation vs the API contract (raid-management-spec §4) ----
+#
+# The Create wizard used to accept 64 characters while
+# XiraidArray.spec.name is ^[A-Za-z0-9_-]{1,63}$ — a 64-char name passed
+# every wizard step and was then rejected at dispatch. The two bounds must
+# stay equal; that is what these pin.
+
+
+def _api_array_name_pattern() -> str:
+    doc = yaml.safe_load((_REPO / "docs/control-path/api-v1.yaml").read_text())
+    schema = doc["components"]["schemas"]["XiraidArray"]["properties"]["spec"]
+    return schema["properties"]["name"]["pattern"]
+
+
+def test_array_name_max_matches_the_api_contract():
+    from xinas_menu.screens.raid import _ARRAY_NAME_MAX
+
+    pattern = _api_array_name_pattern()
+    bound = re.search(r"\{1,(\d+)\}\$?$", pattern)
+    assert bound, f"unexpected XiraidArray.spec.name pattern: {pattern!r}"
+    assert int(bound.group(1)) == _ARRAY_NAME_MAX
+
+
+def test_array_name_validator_agrees_with_the_api_pattern():
+    from xinas_menu.screens.raid import _ARRAY_NAME_MAX, _array_name_error
+
+    api_re = re.compile(_api_array_name_pattern())
+    at_limit = "a" * _ARRAY_NAME_MAX
+    over_limit = "a" * (_ARRAY_NAME_MAX + 1)
+
+    # Accepted by the TUI exactly when the API would accept it.
+    assert _array_name_error(at_limit) is None
+    assert api_re.match(at_limit)
+    assert _array_name_error(over_limit) is not None
+    assert not api_re.match(over_limit)
+
+    for bad in ("", "data 0", "data/0", "data.0", "dat@"):
+        assert _array_name_error(bad) is not None, bad
+        assert not api_re.match(bad), bad
+
+    for good in ("data0", "xi_log", "a-b_C9"):
+        assert _array_name_error(good) is None, good
+        assert api_re.match(good), good
+
+
+def test_array_name_error_message_states_the_real_limit():
+    from xinas_menu.screens.raid import _ARRAY_NAME_MAX, _array_name_error
+
+    msg = _array_name_error("a" * (_ARRAY_NAME_MAX + 1))
+    assert msg is not None
+    assert str(_ARRAY_NAME_MAX) in msg
+
+
+# ---- teardown has no cross-step rollback (raid-management-spec §6.4,
+#      s8-clients-spec §6) ----
+#
+# The spec used to promise that a failed teardown step re-added the removed
+# shares and re-mounted the unmounted filesystems. It never did: a step
+# failure stops the sequence and completed steps stay completed. If a
+# rollback is ever added, §6.4 has to be rewritten with it.
+
+
+def test_delete_array_never_restores_a_completed_step():
+    from xinas_menu.screens.raid import RAIDScreen
+
+    src = inspect.getsource(RAIDScreen._delete_array)
+    for undo in ("add_export", "mount_filesystem", "remount", "rollback("):
+        assert undo not in src, f"_delete_array appears to undo a completed step: {undo}"
+
+
+def test_teardown_failure_says_the_sequence_stopped():
+    from xinas_menu.screens.raid import RAIDScreen
+
+    src = inspect.getsource(RAIDScreen._teardown_failed)
+    assert "remaining steps were not run" in src
+    assert "No cross-step rollback" in src
+    # Reporting a halt is informational: OK-only, never an unanswerable Yes/No.
+    assert "ok_only=True" in src
+
+
+def test_raid_screen_does_not_import_the_mutating_xfs_helpers():
+    # §2.4: the RAID screen's only xfs_helpers use is the read side.
+    src = (_REPO / "xinas_menu/screens/raid.py").read_text()
+    imports = [ln for ln in src.splitlines() if "xfs_helpers" in ln and "import" in ln]
+    assert imports
+    for line in imports:
+        assert "unmount_filesystem" not in line
+        assert "mount_filesystem" not in line
+
+
+# ---- control-path, not gRPC (raid-management-spec §2.2, §6.3, §7.1) ----
+
+
+def test_raid_and_pool_screens_do_not_call_the_grpc_client():
+    for rel in ("xinas_menu/screens/raid.py", "xinas_menu/screens/spare_pools.py"):
+        src = (_REPO / rel).read_text()
+        assert "app.grpc" not in src, f"{rel} still calls the gRPC client"
+        for rpc in ("raid_destroy", "raid_create", "raid_modify", "pool_create", "pool_show"):
+            assert f".{rpc}(" not in src, f"{rel} still calls {rpc}"
+
+
+def test_teardown_uses_the_control_path_endpoints():
+    from xinas_menu.screens.raid import RAIDScreen
+
+    src = inspect.getsource(RAIDScreen._delete_array)
+    assert "/api/v1/shares/" in src
+    assert "/api/v1/filesystems/" in src
+    assert "/api/v1/arrays/" in src
+    # The array delete is the dangerous one; the two confirm dialogs are its gate.
+    assert "dangerous=True" in src
+    assert "app.nfs" not in src

--- a/xinas_menu/screens/nfs.py
+++ b/xinas_menu/screens/nfs.py
@@ -17,6 +17,7 @@ from textual.screen import Screen
 from textual.widgets import Footer, Label
 
 from xinas_menu.api.control_client import ControlPathError, lease_conflict_message, quote_id
+from xinas_menu.api.degraded import degraded_banner
 from xinas_menu.apptype import XiNASAppMixin
 from xinas_menu.utils.xfs_helpers import is_path_under
 from xinas_menu.widgets.confirm_dialog import ConfirmDialog
@@ -153,11 +154,11 @@ class NFSScreen(XiNASAppMixin, Screen):
     async def _load_exports(self) -> None:
         view = self.query_one("#nfs-content", ScrollableTextView)
         try:
-            shares = await asyncio.to_thread(self.app.control.result, "/api/v1/shares")
+            env = await asyncio.to_thread(self.app.control.get, "/api/v1/shares")
         except ControlPathError as exc:
-            view.set_content(f"[yellow]Control API: {exc}[/yellow]")
+            view.set_content(f"Control API: {exc}")
             return
-        view.set_content(_format_exports(_rows_from_api(shares)))
+        view.set_content(_format_exports(_rows_from_api(env.get("result")), degraded_banner(env)))
 
     def on_navigable_menu_selected(self, event: NavigableMenu.Selected) -> None:
         key = event.key
@@ -182,11 +183,13 @@ class NFSScreen(XiNASAppMixin, Screen):
         return [e["path"] for e in exports]
 
     async def _get_exports(self) -> list[dict]:
-        """Fetch shares from the control-path API, adapted to legacy rows."""
-        try:
-            shares = await asyncio.to_thread(self.app.control.result, "/api/v1/shares")
-        except ControlPathError:
-            return []
+        """Fetch shares from the control-path API, adapted to legacy rows.
+
+        Raises ControlPathError. Callers MUST NOT degrade a failed read to
+        "no shares": Add allocates the next fsid from this list, and an
+        empty-looking list restarts numbering at 1 against a live host.
+        """
+        shares = await asyncio.to_thread(self.app.control.result, "/api/v1/shares")
         return [e for e in _rows_from_api(shares) if e.get("path") and e.get("id")]
 
     def _task_progress(self, label: str):
@@ -546,8 +549,23 @@ class NFSScreen(XiNASAppMixin, Screen):
             )
             return
 
+        # fsid is REQUIRED by the API and allocated here, so this read must
+        # be authoritative — allocating from a swallowed error would restart
+        # at 1 and collide with every existing share.
         used: set[int] = set()
-        for row in await self._get_exports():
+        try:
+            existing = await self._get_exports()
+        except ControlPathError as exc:
+            await self.app.push_screen_wait(
+                ConfirmDialog(
+                    f"Could not read existing shares, so a new export id "
+                    f"cannot be allocated safely.\n\n{exc}",
+                    "Error",
+                    ok_only=True,
+                )
+            )
+            return
+        for row in existing:
             fsid = row.get("fsid")
             if isinstance(fsid, int):
                 used.add(fsid)
@@ -579,7 +597,13 @@ class NFSScreen(XiNASAppMixin, Screen):
     @work(exclusive=True)
     async def _edit_share(self) -> None:
         """7-step edit share wizard with Back navigation."""
-        exports = await self._get_exports()
+        try:
+            exports = await self._get_exports()
+        except ControlPathError as exc:
+            await self.app.push_screen_wait(
+                ConfirmDialog(f"Could not load shares.\n{exc}", "Edit Share", ok_only=True)
+            )
+            return
         if not exports:
             await self.app.push_screen_wait(
                 ConfirmDialog("No shares configured.", "Edit Share", ok_only=True)
@@ -697,7 +721,13 @@ class NFSScreen(XiNASAppMixin, Screen):
 
     @work(exclusive=True)
     async def _remove_share(self) -> None:
-        exports = await self._get_exports()
+        try:
+            exports = await self._get_exports()
+        except ControlPathError as exc:
+            await self.app.push_screen_wait(
+                ConfirmDialog(f"Could not load shares.\n{exc}", "Remove Share", ok_only=True)
+            )
+            return
         if not exports:
             await self.app.push_screen_wait(
                 ConfirmDialog("No shares configured.", "Remove Share", ok_only=True)
@@ -892,8 +922,8 @@ def _parse_current_export(export: dict) -> dict:
     }
 
 
-def _format_exports(data: Any) -> str:
-    """Format NFS exports — uses socket data if available, falls back to /etc/exports."""
+def _format_exports(data: Any, banner: str | None = None) -> str:
+    """Render adapted share rows; a banner replaces the empty-state."""
     import os
     import shlex
     import subprocess
@@ -980,52 +1010,43 @@ def _format_exports(data: Any) -> str:
     lines.append(f"  {DIM}NFS allows other hosts to access folders on this server.{NC}")
     lines.append("")
 
-    # Build list of (path, raw_client_strings) from socket data or /etc/exports
+    if banner:
+        lines.append(f"  {RED}⚠ {banner}{NC}")
+        lines.append("")
+
+    # Build list of (path, raw_client_strings) from the adapted API rows.
+    # There is deliberately NO /etc/exports fallback: an empty list means the
+    # api observed no shares, and its collector reads /etc/exports itself —
+    # so parsing the file here could only present unmanaged contents as the
+    # managed share list (spec §4.2).
     shares: list[tuple[str, list[str]]] = []
 
-    if data and isinstance(data, list):
-        for exp in data:
-            if not isinstance(exp, dict):
-                continue
-            path = exp.get("path", "")
-            clients = exp.get("clients", [])
-            if not path:
-                continue
-            # clients may be [{"host": "*", "options": [...]}] or ["host(opts)"]
-            raw: list[str] = []
-            client_specs: list = clients or [{"host": "*", "options": []}]
-            for c in client_specs:
-                if isinstance(c, dict):
-                    host = c.get("host", "*")
-                    opts = c.get("options", [])
-                    raw.append(f"{host}({','.join(opts)})" if opts else host)
-                else:
-                    raw.append(str(c))
-            shares.append((path, raw))
-    else:
-        # Fallback: read /etc/exports directly
-        exports_file = "/etc/exports"
-        try:
-            with open(exports_file) as f:
-                for line in f:
-                    line = line.strip()
-                    if not line or line.startswith("#"):
-                        continue
-                    parts = line.split()
-                    if parts:
-                        shares.append((parts[0], parts[1:]))
-        except FileNotFoundError:
-            lines.append("  /etc/exports not found — NFS may not be configured.")
-            lines.append("")
-            return "\n".join(lines)
-        except Exception as exc:
-            lines.append(f"  Error reading /etc/exports: {exc}")
-            return "\n".join(lines)
+    for exp in data if isinstance(data, list) else []:
+        if not isinstance(exp, dict):
+            continue
+        path = exp.get("path", "")
+        clients = exp.get("clients", [])
+        if not path:
+            continue
+        # clients may be [{"host": "*", "options": [...]}] or ["host(opts)"]
+        raw: list[str] = []
+        client_specs: list = clients or [{"host": "*", "options": []}]
+        for c in client_specs:
+            if isinstance(c, dict):
+                host = c.get("host", "*")
+                opts = c.get("options", [])
+                raw.append(f"{host}({','.join(opts)})" if opts else host)
+            else:
+                raw.append(str(c))
+        shares.append((path, raw))
 
     if not shares:
-        lines.append(f"  {DIM}No shares configured.{NC}")
-        lines.append("")
-        lines.append(f"  Use {GRN}'Add Share'{NC} to create an NFS export.")
+        # A degraded backend must never read as "genuinely none" — the
+        # banner above already said so, so don't contradict it.
+        if not banner:
+            lines.append(f"  {DIM}(no NFS shares configured){NC}")
+            lines.append("")
+            lines.append(f"  Use {GRN}'Add Share'{NC} to create an NFS export.")
         lines.append("")
         return "\n".join(lines)
 

--- a/xinas_menu/screens/raid.py
+++ b/xinas_menu/screens/raid.py
@@ -46,6 +46,11 @@ from xinas_menu.widgets.text_view import ScrollableTextView
 from xinas_menu.widgets.wizard import BACK, CANCEL, WizardStep, run_wizard
 
 _ARRAY_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+# The control-path contract for XiraidArray.spec.name is
+# ^[A-Za-z0-9_-]{1,63}$ (docs/control-path/api-v1.yaml). The wizard
+# enforces the same bound so a name the API would reject is caught at the
+# first step instead of after the operator has answered every other one.
+_ARRAY_NAME_MAX = 63
 _RAID_LEVELS = ["0", "1", "5", "6", "10", "50", "60"]
 _STRIP_SIZES = ["16", "32", "64", "128", "256"]
 _CPU_LIST_RE = re.compile(r"^\d+(-\d+)?(,\d+(-\d+)?)*$")
@@ -78,6 +83,19 @@ _MENU = [
     MenuItem("6", "Delete Array"),
     MenuItem("0", "Back"),
 ]
+
+
+def _array_name_error(name: str) -> str | None:
+    """Reason ``name`` is not a valid array name, or ``None`` if it is.
+
+    Mirrors the control-path ``XiraidArray.spec.name`` pattern; see
+    ``_ARRAY_NAME_MAX``.
+    """
+    if len(name) > _ARRAY_NAME_MAX:
+        return f"Array name must be {_ARRAY_NAME_MAX} characters or fewer."
+    if not _ARRAY_NAME_RE.match(name):
+        return "Array name must contain only letters, digits, hyphens, and underscores."
+    return None
 
 
 def _fmt_size(size_bytes: float) -> str:
@@ -472,15 +490,9 @@ class RAIDScreen(XiNASAppMixin, Screen):
                     return CANCEL
                 if name is BACK:
                     return BACK
-                if len(name) > 64:
-                    self.app.notify("Array name must be 64 characters or fewer.", severity="error")
-                    default = name
-                    continue
-                if not _ARRAY_NAME_RE.match(name):
-                    self.app.notify(
-                        "Array name must contain only letters, digits, hyphens, and underscores.",
-                        severity="error",
-                    )
+                problem = _array_name_error(name)
+                if problem:
+                    self.app.notify(problem, severity="error")
                     default = name
                     continue
                 return name


### PR DESCRIPTION
A spec-accuracy pass over the two day-2 Storage specs, which had drifted
badly since the S8/S9 control-path migration. Three of the stale claims
turned out to be describing behavior that *should* exist, so they are
fixed rather than documented.

## Behavior changes

**Array names longer than the API accepts are now rejected at step 1.**
The Create Array wizard allowed 64 characters while
`XiraidArray.spec.name` is `^[A-Za-z0-9_-]{1,63}$`, so a 64-character
name passed every wizard step and was only rejected at dispatch. The
bound now lives in `_ARRAY_NAME_MAX` and is pinned by a test that reads
the pattern out of `api-v1.yaml`.

**Show NFS Exports no longer displays `/etc/exports` as the share list.**
The renderer fell back to parsing the file whenever the row list came
back empty. That was right when the helper socket was the read path and
an empty result meant the socket had failed — but under the control path
an empty result means the api observed no shares, and its collector reads
`/etc/exports` itself, so anything genuinely exported would have come
back as a row. The fallback could only present unmanaged file contents as
the managed share list. Replaced with an explicit empty state plus the
degraded-backend banner the Filesystem and RAID screens already have, so
an unobservable backend never reads as "no shares".

⚠️ **User-visible:** on a host with no managed shares this screen now
prints `(no NFS shares configured)` instead of the file's contents.

**Add Share fails closed instead of allocating a colliding `fsid`.**
`_get_exports()` swallowed `ControlPathError` to `[]`. Add allocates
`max(used, default=0) + 1` from that list — `Share.spec.fsid` is required
by the API, so the server does not assign one — which meant an
unreachable api silently restarted numbering at `1` and collided with
every existing share. An `fsid` collision breaks NFSv4 client mounts, so
refusing beats guessing. Edit and Remove were reporting the same failed
read as `No shares configured.` and now distinguish it.

Not fixed, and documented as such: two concurrent Add Shares can still
compute the same `fsid`, because the allocation is client-side by
construction. Moving it server-side needs `fsid` to become optional in
`api-v1.yaml`.

## Spec corrections

`docs/Storage/raid-management-spec.md`:

- §6.4 promised a cross-step rollback that re-added removed shares and
  re-mounted filesystems on a failed teardown step. No such path exists —
  the teardown is a stop-on-failure sequence per `s8-clients-spec` §6 and
  completed steps stay completed. Rewritten with the real contract, what
  the operator is told, and a per-step manual recovery table. §9.2 and
  §10 repeated the promise and are corrected too.
- §6.1/§6.3/§6.5 described gRPC `raid_destroy` plus helper-socket calls;
  the code runs control-path operations via `plan_apply_wait`.
- §7 listed direct `pool_*` RPCs; `spare_pools.py` uses `/api/v1/pools`.
- §8 was titled "read-only" but `l` binds `drive_locate`, a write RPC
  that also records an audit event.
- §2, §5 and §11 carried the same stale gRPC framing.

`docs/Storage/fs-shares-management-spec.md`:

- §3.4 promised the same non-existent cross-step rollback for Delete
  Filesystem.
- §3.3 documented a client-side mkfs/geometry derivation that no longer
  happens — `su_kb`/`sw` are omitted and derived server-side, and
  `logdev`/`uquota` ride structured fields.
- §3.5 described `update_mount_unit_quota` rewriting the unit file; it is
  a one-intent `PATCH` now, and "Enable Both (user + project)" is gone
  because `quota_mode` holds exactly one mode.
- §4 described `add_export`/`update_export`/`remove_export` over the
  socket; share writes are `plan_apply_wait` against `/api/v1/shares`,
  and Active Sessions is the only direct socket call left.
- §1, §2, §5, §6, §7 and §8 carried the same stale framing.

## Tests

29 new tests across `test_raid_overview.py`, `test_fs_overview.py` and
`test_nfs_wizard_helpers.py`, pinning the claims that can be pinned: the
name bound against the API pattern, the absence of any restore call in
either teardown, the stop-on-failure dialogs, server-side geometry
derivation, single-mode quota semantics, the control-path adapter's
round-trip, and that neither RAID screen calls the gRPC client. The three
fixes were written test-first; each new test was watched failing against
the old behavior.

## Verification

`pytest` (657 passed, 14 skipped), `ruff check`, `ruff format --check`,
`pyright`, and `markdownlint-cli2` over all 140 docs — all clean.

No `Requires-Rebuild:` trailer: Python TUI logic, docs and tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
