### PR TITLE
refactor(nfs): drop unused _get_export_paths helper

### DIFF
--- a/xinas_menu/screens/nfs.py
+++ b/xinas_menu/screens/nfs.py
@@ -176,11 +176,6 @@ class NFSScreen(XiNASAppMixin, Screen):
         elif key == "6":
             self._configure_idmapd()
 
-    async def _get_export_paths(self) -> list[str]:
-        """Fetch current export paths from the control-path API."""
-        exports = await self._get_exports()
-        return [e["path"] for e in exports]
-
     async def _get_exports(self) -> list[dict]:
         """Fetch shares from the control-path API, adapted to legacy rows."""
         try:


### PR DESCRIPTION
## Summary

`NFSScreen._get_export_paths()` in `xinas_menu/screens/nfs.py` had no callers anywhere in `xinas_menu/` or `tests/` — a leftover from before the control-path migration. Every call site now uses `_get_exports()` directly, which returns the full rows including the `id` and `fsid` the wizards need.

Removed the method. Code-only change, no externally observable behavior change.

## Notes

- No spec update needed: `docs/Storage/fs-shares-management-spec.md` documents `_get_exports` (§4.1 "Shared share read") and never mentions `_get_export_paths`.
- No `Requires-Rebuild:` trailer: Python TUI logic only.

## Verification

- `pytest` — 712 passed
- `ruff check xinas_menu xinas_history xiNAS-MCP/nfs-helper` — clean
- `ruff format --check xinas_menu xinas_history xiNAS-MCP/nfs-helper` — 113 files already formatted
- `pyright xinas_menu xinas_history xiNAS-MCP/nfs-helper` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)