### PR TITLE
fix(nfs): stop reporting an unreadable share list as an empty one

### DIFF
--- a/docs/Storage/fs-shares-management-spec.md
+++ b/docs/Storage/fs-shares-management-spec.md
@@ -2,15 +2,18 @@
 
 This document covers the two day-2 screens that sit between the operator and the data path: **`FilesystemScreen`** (mounts XFS on xiRAID block devices and toggles quotas) and **`NFSScreen`** (manages `/etc/exports` entries and the kernel server's view of them). It is the counterpart to [Storage/raid-management-spec.md](raid-management-spec.md) — same TUI app, same helper boundary, but a different state surface.
 
-The two screens share a common helper backbone with the RAID screen:
+Like the RAID screen, both have migrated onto the control path: reads are `GET /api/v1/{filesystems,shares,arrays}` and **every write is a `plan_apply_wait`** against `xinas-api`. What is left of the old helper backbone is now a thin residue:
 
-- **`xfs_helpers`** (in-process subprocess wrappers) — `mkfs.xfs`, `findmnt`, `systemctl`, mount-unit templating, quota toggle.
-- **`xinas-nfs-helper`** (out-of-process Unix-socket daemon) — the **only writer** of `/etc/exports` and `/etc/nfs.conf`.
+- **Control-path client** (`app.control`) — the actual service boundary for both screens.
+- **`xfs_helpers`** (in-process subprocess wrappers) — reduced to read/pure helpers: `is_path_under` in both screens, plus `run_async_cmd` + `findmnt` in `NFSScreen`'s path picker. The `mkfs.xfs` / mount-unit / `systemctl` / quota-toggle helpers are **no longer called by either screen** (§2.1).
+- **`xinas-nfs-helper`** (out-of-process Unix-socket daemon) — still the **only writer** of `/etc/exports` and `/etc/nfs.conf`, but now reached *through the agent*. The only direct client call left in these screens is `nfs.list_sessions()` (§4.8).
 - **Audit + snapshot helpers** — every write path logs to `/var/log/xinas/audit.log` and records an advisory snapshot.
 
 Sources:
 
 - Screens: [xinas_menu/screens/filesystem.py](../../xinas_menu/screens/filesystem.py), [nfs.py](../../xinas_menu/screens/nfs.py), [storage.py](../../xinas_menu/screens/storage.py)
+- Control-path client: [xinas_menu/api/control_client.py](../../xinas_menu/api/control_client.py) (`ControlClient.result` / `.get` / `.plan_apply_wait`, `quote_id`)
+- Control-path contract: [docs/control-path/api-v1.yaml](../control-path/api-v1.yaml), [s8-clients-spec.md](../control-path/s8-clients-spec.md), [ADR-0007](../control-path/adr/0007-filesystem.md) (filesystem writability matrix)
 - XFS helpers: [xinas_menu/utils/xfs_helpers.py](../../xinas_menu/utils/xfs_helpers.py)
 - NFS helper client: [xinas_menu/api/nfs_client.py](../../xinas_menu/api/nfs_client.py)
 - NFS helper daemon: [xiNAS-MCP/nfs-helper/nfs_helper.py](../../xiNAS-MCP/nfs-helper/nfs_helper.py), [nfs_exports.py](../../xiNAS-MCP/nfs-helper/nfs_exports.py), [nfs_conf.py](../../xiNAS-MCP/nfs-helper/nfs_conf.py), [nfs_quota.py](../../xiNAS-MCP/nfs-helper/nfs_quota.py), [nfs_sessions.py](../../xiNAS-MCP/nfs-helper/nfs_sessions.py)
@@ -28,37 +31,39 @@ Main Menu → Storage (StorageScreen) → 2 NFS Management   (NFSScreen)
 
 Both screens are pushed onto the Textual stack from `StorageScreen.on_navigable_menu_selected()` (see [storage.py](../../xinas_menu/screens/storage.py)). Closing them with `0` / `Esc` returns to the Storage sub-menu.
 
-Both are mounted on top of the same `app.grpc` (RAID gRPC client), `app.nfs` (helper socket client), `app.audit` (audit logger), `app.snapshots` (snapshot recorder) provided by the `XiNASApp` shell.
+Both are mounted on top of the same `app.control` (control-path client), `app.nfs` (helper socket client), `app.audit` (audit logger), `app.snapshots` (snapshot recorder) provided by the `XiNASApp` shell. `app.grpc` is also on the shell but **neither screen uses it**.
 
 ---
 
-## 2. The two helper boundaries
+## 2. Boundaries these screens cross
 
-The screens never write to `/etc/exports`, `/etc/nfs.conf`, `/proc/fs/nfsd/*` or `/sys/class/block/*` directly. They cross one of two well-defined boundaries:
+The screens never write to `/etc/exports`, `/etc/nfs.conf`, `/etc/systemd/system/*.mount`, `/proc/fs/nfsd/*` or `/sys/class/block/*` directly. Every mutation is a `plan_apply_wait` against `xinas-api`, which dispatches to the agent's executors; the executors are what run `mkfs.xfs`, write mount units, call `systemctl`, and talk to the NFS helper socket. What is left in-process is described below.
 
 ### 2.1 `xfs_helpers` — in-process async subprocess
 
-[utils/xfs_helpers.py](../../xinas_menu/utils/xfs_helpers.py). Every public function returns either `(ok: bool, stdout: str, stderr: str)` for raw subprocess calls or `(ok: bool, err: str)` for higher-level operations — exactly the same `(ok, …, error)` convention the gRPC and NFS clients use.
+[utils/xfs_helpers.py](../../xinas_menu/utils/xfs_helpers.py). Every public function returns either `(ok: bool, stdout: str, stderr: str)` for raw subprocess calls or `(ok: bool, err: str)` for higher-level operations — the same `(ok, …, error)` convention the NFS client uses.
 
-What the FS screen calls:
+**What these two screens still call — read and pure helpers only:**
 
 | Helper | Underlying command | Used by |
 |---|---|---|
-| `run_async_cmd(*args, timeout=…)` | `asyncio.create_subprocess_exec` | every helper below, plus `findmnt` calls in screens |
-| `mkfs_xfs(label, data, log, su, sw, sector, log_size)` | `mkfs.xfs -f -L … -d su=…k,sw=… -l logdev=…,size=… -s size=…k <data>` | Create FS |
-| `get_device_size_bytes(device)` | `blockdev --getsize64 <device>` | log-size clamp inside `mkfs_xfs` |
-| `check_existing_filesystem(device)` | `blkid -s TYPE` + `blkid -s LABEL` | Create FS (sanity warn) |
-| `create_mount_unit(mp, data, log, opts)` | writes `/etc/systemd/system/<mp>.mount` atomically via `mkstemp + os.replace` | Create FS |
-| `mount_filesystem(mp)` | `systemctl daemon-reload` + `systemctl enable --now <unit>` | Create FS, RAID-delete rollback |
-| `unmount_filesystem(mp)` | `systemctl stop` + `disable` + `rm` of the unit file | Delete FS, RAID-delete |
-| `find_mounts_using_raid(name)` | `findmnt /dev/xi_<name>` + `findmnt -t xfs -n -o TARGET,OPTIONS` for `logdev=` matches | Create FS (gate), RAID-delete |
-| `find_mount_for_device(dev)` | `findmnt -n -o TARGET <dev>` | misc lookups |
-| `calculate_parity_disks(level)` / `calculate_stripe_width(count, level)` | pure-Python lookup | Create FS geometry |
-| `build_mount_options(log)` | string concat | Create FS |
-| `get_quota_status(options)` | parse comma-separated opt list | Quotas screen |
-| `update_mount_unit_quota(mp, enable_user, enable_project)` | rewrite the `Options=` line, then `systemctl daemon-reload` + `stop` + `start` | Quotas screen |
+| `is_path_under(path, mountpoint)` | pure-Python containment test | `FilesystemScreen` (Delete FS share scan), `NFSScreen` |
+| `run_async_cmd(*args, timeout=…)` | `asyncio.create_subprocess_exec` | `NFSScreen` only, for the one `findmnt -t xfs -n -o TARGET,SOURCE` that populates the Add-Share path picker |
 
-The mount/unmount helpers operate on systemd `.mount` units, not on `mount(2)` directly. This matches what `raid_fs` lays down at install time — see [Installer/fs-exports-spec.md §1.8](../Installer/fs-exports-spec.md#18-mountpoint-and-systemd-mount-unit). It is the reason the FS lifecycle survives reboots without anything in `/etc/fstab`.
+**What they no longer call.** These helpers still exist in the module — the installer-parity logic they encode has moved to the agent's fs-executor, and calling them from the TUI would bypass the plan/apply, audit, and task-rollback path:
+
+| Helper | Now done by |
+|---|---|
+| `mkfs_xfs`, `get_device_size_bytes`, `check_existing_filesystem` | fs-executor preflight + mkfs stages (`POST /api/v1/filesystems`) |
+| `create_mount_unit`, `mount_filesystem` | fs-executor unit + mount stages |
+| `unmount_filesystem` | `PATCH /api/v1/filesystems/{id}` `{"mounted": false}` + `DELETE` to unmanage |
+| `calculate_parity_disks`, `calculate_stripe_width`, `build_mount_options` | api-side derivation from the array (`su_kb` / `sw` omitted from the spec — §3.3) |
+| `update_mount_unit_quota` | `PATCH /api/v1/filesystems/{id}` `{"quota_mode": …}` → `fs.set_quota_mode` (§3.5) |
+| `find_mounts_using_raid` | still used, but by the **RAID** screen only ([raid-management-spec §2.4](raid-management-spec.md#24-xfs_helpers--async-subprocess-helpers)) |
+
+`_quota_flags(options)` in `filesystem.py` replaced the module's `get_quota_status` for parsing the observed option list.
+
+The executor's mount/unmount work operates on systemd `.mount` units, not on `mount(2)` directly. This matches what `raid_fs` lays down at install time — see [Installer/fs-exports-spec.md §1.8](../Installer/fs-exports-spec.md#18-mountpoint-and-systemd-mount-unit). It is the reason the FS lifecycle survives reboots without anything in `/etc/fstab`.
 
 ### 2.2 `xinas-nfs-helper` — Unix-socket daemon
 
@@ -95,6 +100,8 @@ The daemon also runs a **startup health check** — it warns if `/usr/sbin/expor
 
 The TUI calls it from `loop.run_in_executor(None, …)` since the socket I/O is blocking. The screens never `await self.app.nfs.…` directly — every helper call is wrapped in an executor coroutine so the Textual event loop stays responsive.
 
+**Scope note.** These two screens now reach this client exactly once, in Active Sessions (§4.8); the Users screen also calls `set_quota`. Every share and filesystem *mutation* reaches the same daemon through the agent instead. The client is documented in full because the agent's nfs-executor speaks the identical protocol ([agent/task/nfs-helper-client.ts](../../xiNAS-MCP/src/agent/task/nfs-helper-client.ts)), so these error strings are still what a failing share write ends up carrying.
+
 Error mapping in the client:
 
 | Helper-side failure | What `NFSHelperClient._request` returns |
@@ -105,7 +112,7 @@ Error mapping in the client:
 | Bad JSON response | `(False, None, "bad JSON from NFS helper: …")` |
 | `{"ok": false, "error": "…"}` | `(False, None, "<error string>")` |
 
-The RAID-delete and FS-delete teardown paths use these short-circuits to refuse work cleanly when the helper is down, rather than partially tearing things apart and failing later.
+These short-circuits used to let the RAID-delete and FS-delete teardowns refuse work cleanly when the helper was down. Those paths no longer call the client at all — a teardown's share step is `DELETE /api/v1/shares/{id}`, and a helper that is down now surfaces as that step's task failure, which stops the sequence (§3.4).
 
 ---
 
@@ -117,13 +124,13 @@ The RAID-delete and FS-delete teardown paths use these short-circuits to refuse 
 
 | Key | Action | Handler |
 |---|---|---|
-| 1 | Show Filesystems | `_show_filesystems()` — `findmnt -t xfs -J` |
+| 1 | Show Filesystems | `_show_filesystems()` — `GET /api/v1/filesystems` |
 | 2 | Create Filesystem | `_create_filesystem_wizard()` |
 | 3 | Delete Filesystem | `_delete_filesystem()` |
 | 4 | Manage Quotas | `_manage_quotas()` |
 | 0 | Back | pop screen |
 
-Nothing in this screen calls the xiRAID gRPC for writes — RAID arrays are inputs. The only gRPC call is `raid_show(extended=True)` at the start of the Create wizard, to enumerate available arrays.
+**This screen does not call the xiRAID gRPC client at all.** Reads are control-path `GET`s and every write is a `plan_apply_wait`. RAID arrays are inputs, enumerated by `GET /api/v1/arrays` at the start of the Create wizard (it used to be `raid_show(extended=True)`).
 
 ### 3.2 Show Filesystems
 
@@ -135,9 +142,14 @@ Nothing in this screen calls the xiRAID gRPC for writes — RAID arrays are inpu
 
 The wizard mirrors what the installer's `raid_fs` role does (see [Installer/raid-spec.md §7](../Installer/raid-spec.md#7-raid_fs--license-arrays-filesystem-mount)) but runs against the *current* RAID state.
 
-**Pre-check.** `grpc.raid_show(extended=True)` enumerates arrays. For each array, `find_mounts_using_raid(name)` is called — any array already in use as a data **or** log device is moved into an `in_use` bucket. If fewer than 2 free arrays remain, the wizard aborts with "Filesystem creation requires at least 2 RAID arrays (one for data, one for log)."
+**Pre-check.** Two control-path reads, no `findmnt` and no gRPC:
 
-**Step 1 — pick the data array.** Arrays are sorted with the data-classified ones first (`_classify_role()` maps levels `5 / 6 / 50 / 60` → `data`, anything else → `log`). The label shows `name (RAID-N, M drives, Kk strip) [role]` so the operator can spot the right candidate without remembering levels.
+1. `GET /api/v1/arrays` enumerates arrays (`_arrays_from_api`). A `ControlPathError` here aborts on an OK-only `Failed to query RAID arrays.` dialog.
+2. `GET /api/v1/filesystems` → `_volumes_in_use()` collects every volume path already consumed by a managed filesystem, as a **data device** (`status.backing_device`) *or* as a **log device** (a `logdev=` entry in its effective mount options). Arrays whose `volume_path` is in that set are filtered out. A failure here degrades to an empty set rather than aborting — the wizard then offers arrays that may already be in use, and the executor's preflight is what catches it.
+
+If fewer than 2 free arrays remain, the wizard aborts with "Filesystem creation requires at least 2 RAID arrays (one for data, one for log)."
+
+**Step 1 — pick the data array.** Arrays are sorted with the data-classified ones first (`_classify_role()` maps levels `5 / 6 / 50 / 60` → `data`, anything else → `log`). The label (`_array_label`) shows `name  (RAID-N, M drives, KKB strip)  [role]` so the operator can spot the right candidate without remembering levels.
 
 **Step 2 — pick the log array.** Same picker over the remaining arrays, with log-classified ones first. If only one array is left, the wizard skips the picker and just confirms the auto-pick.
 
@@ -145,30 +157,30 @@ The wizard mirrors what the installer's `raid_fs` role does (see [Installer/raid
 
 **Step 4 — mountpoint.** `InputDialog`, default `/mnt/data`. Must start with `/` — otherwise the wizard aborts with an error notification.
 
-**Geometry derivation.** Same formula as the installer:
+**Geometry is derived server-side.** The screen does **not** compute stripe geometry any more — there is no `calculate_stripe_width` call and no `build_mount_options` call in `filesystem.py`. It sends a structured spec and lets the fs-executor derive what it can from the array:
+
+| Spec field | Value the wizard sends |
+|---|---|
+| `backing_device` | the data array's `volume_path` |
+| `log_device` | the log array's `volume_path` |
+| `mountpoint`, `label` | steps 4 and 3 |
+| `fs_type` | `"xfs"` |
+| `log_size` | `"1G"` (clamped to the log device at mkfs) |
+| `sector_size` | `4096` |
+| `mount_options` | `_DEFAULT_MOUNT_OPTIONS` — `noatime, nodiratime, logbsize=256k, largeio, inode64, swalloc, allocsize=131072k` |
+| `quota_mode` | `"uquota"` |
+
+`su_kb` and `sw` are **omitted**, so the api auto-derives them (`sw` = data drives = members − parity; see the `Filesystem.spec` schema in [api-v1.yaml](../control-path/api-v1.yaml)). `logdev=` and `uquota` are **not** in `mount_options` either: they ride the structured `log_device` / `quota_mode` fields, which is what the fs.create contract expects. The effective result still matches the [Installer/fs-exports-spec.md §1.7](../Installer/fs-exports-spec.md#17-mount-options-decoded) install-time set, so a TUI-created FS is indistinguishable from an Ansible-created one — but it is reconstructed from structured fields, not passed through as one literal string.
+
+The confirmation summary and the success banner render a flat option string for the operator —
 
 ```
-data_device = /dev/xi_<data_name>
-log_device  = /dev/xi_<log_name>
-su_kb       = data_array.strip_size                              (fallback 128)
-sw          = calculate_stripe_width(devices_in_data, level)
-              ├─ RAID-10: device_count // 2
-              ├─ RAID-5:  device_count - 1
-              └─ RAID-6:  device_count - 2
-sector size = 4k                                                  (hardcoded)
-log size    = 1G                                                  (clamped to log device size at mkfs)
-mount opts  = build_mount_options(log_device)                     (matches Ansible)
+defaults,noatime,nodiratime,logbsize=256k,largeio,inode64,swalloc,allocsize=131072k,logdev=<log_device>,uquota
 ```
 
-`build_mount_options` produces:
+— and show `su (strip unit)` from the data array's `strip_size` (fallback `128`) with `sw` printed literally as `derived from array geometry`. **Both are display-only**: neither the string nor `su_kb` is part of the submitted spec.
 
-```
-logdev=<log_device>,noatime,nodiratime,logbsize=256k,largeio,inode64,swalloc,allocsize=131072k,uquota
-```
-
-— byte-identical to the [Installer/fs-exports-spec.md §1.7](../Installer/fs-exports-spec.md#17-mount-options-decoded) install-time set, so a TUI-created FS is indistinguishable from an Ansible-created one.
-
-**Step 5 — confirmation.** Summary shows everything: arrays + roles, mountpoint, derived geometry, full mount option string. On confirm the screen submits **one control-path plan→apply** — `POST /api/v1/filesystems` with the full spec (backing/log device, label, mountpoint, geometry, mount options, `quota_mode: uquota`) via `control.plan_apply_wait`, with a `TaskWaitDialog` showing task-state progress and offering cancel (S10). The executor runs preflight → mkfs → unit → mount as task stages.
+**Step 5 — confirmation.** Summary shows everything: arrays + roles, mountpoint, the geometry above, and that option string. On confirm the screen submits **one control-path plan→apply** — `POST /api/v1/filesystems` with the spec in the table, via `control.plan_apply_wait`, with a `TaskWaitDialog` showing task-state progress and offering cancel (S10). The executor runs preflight → mkfs → unit → mount as task stages.
 
 **Failure handling.** Three distinct exits:
 
@@ -186,52 +198,87 @@ Rollback of a failed create is the task's own (the executor rolls back its compl
 
 ### 3.4 Delete Filesystem
 
-Mirrors the RAID-delete teardown pattern in [Storage/raid-management-spec.md §6](raid-management-spec.md#6-delete-array--ordered-teardown-with-rollback), but only two steps instead of three.
+Same shape as the RAID-delete teardown in [Storage/raid-management-spec.md §6](raid-management-spec.md#6-delete-array--ordered-stop-on-failure-teardown): an ordered, **stop-on-failure sequence of control-path API operations**, each one a `plan_apply_wait`, with **no cross-step rollback**. The authoritative contract for both is [s8-clients-spec §6](../control-path/s8-clients-spec.md#6-tui-composite-teardown-t13). The only structural difference from the RAID flow is that this one has no array to destroy at the end, and no cancellable `TaskWaitDialog` — every step here is short.
 
-**Discovery.** `findmnt -t xfs -J` enumerates all current XFS mounts; the operator picks one from the list (labels show `target (source)`).
+**Discovery.** `_list_filesystems()` (`GET /api/v1/filesystems`, adapted by `_fs_rows_from_api`) enumerates the *managed* filesystems — mount units the control path knows about, not whatever `findmnt` currently reports. The operator picks one from a `SelectDialog` whose labels are `<mountpoint or id>  (<backing_device>)`. A `ControlPathError` aborts on an OK-only `Could not load filesystems.` dialog; an empty list aborts on `No XFS filesystems found.`
 
-**Dependency check.** `nfs.list_exports()` is called (via the executor); every export whose `path.startswith(mountpoint)` is recorded in `affected_shares`. This catches both the root export and any sub-directory exports rooted at the same mount.
+> This picker calls the banner-less `_list_filesystems()`, not `_list_filesystems_with_status()`. Under a degraded backend (`DEGRADED_BACKEND_UNAVAILABLE`) the list arrives empty and the operator is told `No XFS filesystems found.` — the one place in this screen where a degraded read is not distinguished from a genuinely empty one. Show Filesystems (§3.2) does render the banner.
+
+**Dependency check.** `GET /api/v1/shares`; every share whose `spec.path` is under the chosen `mountpoint` (`is_path_under`, not a bare `startswith` — `/mnt/data2` is not under `/mnt/data`) is recorded in `affected_shares` as `{id, path}`. This catches both the root export and any sub-directory exports rooted at the same mount. A `ControlPathError` here degrades to an empty list rather than aborting: the confirmation still appears, with the un-listable shares absent from it. The check is skipped entirely for a filesystem with no mountpoint.
 
 **Confirmation.**
 
-1. First dialog: lists affected shares, ends with the warning that the FS will be unmounted and its unit removed. Note the exact wording: *"Data on disk is NOT erased."* — `unmount_filesystem` does not touch the underlying XFS contents, so re-creating a mount unit on the same `/dev/xi_<name>` would re-attach the existing filesystem.
+1. First dialog: lists affected shares, ends with the warning that the FS will be unmounted and its unit removed. Note the exact wording: *"Data on disk is NOT erased."* — unmanaging removes the mount unit and does not touch the underlying XFS contents, so re-creating a mount unit on the same `/dev/xi_<name>` would re-attach the existing filesystem.
 2. If `affected_shares` is non-empty, a second `FINAL CONFIRMATION` dialog restates the count.
 
-**Teardown order.** Strictly:
+**Teardown order.** Strictly, each step rendered into the teardown progress view with its task's stage transitions:
 
-1. **Remove shares first.** For each `share` in `affected_shares`: `nfs.remove_export(path)` (synchronous via executor). On failure, every previously removed share is re-added via `nfs.add_export(saved_dict)` + `nfs.reload()`, and the dialog reports "Rolled back N share(s)."
-2. **Reload exports** (single `nfs.reload()` call after the loop, not per-iteration — `remove_export` already triggers `exportfs -r`, this is belt-and-braces).
-3. **Unmount.** `unmount_filesystem(mountpoint)`. On failure: re-add the removed shares and reload before raising.
+```
+Step 1: for each affected share   DELETE /api/v1/shares/{id}
+Step 2: the filesystem            PATCH  /api/v1/filesystems/{id} {"mounted": false}   (only if mounted)
+Step 3: the filesystem            DELETE /api/v1/filesystems/{id}                      (unmanage)
+```
 
-**Side effects on full success.**
+Shares go first: unmounting under a live export would orphan it. Step 2 is skipped outright for a filesystem the API already reports as not mounted. Ids are percent-encoded with `quote_id()` like every other id (s8-clients-spec §6).
 
-- Per share removed: `audit.log("nfs.remove", "share=<P> (FS teardown)", "OK")`
-- After unmount: `audit.log("fs.delete", "mountpoint=<M> device=<D>", "OK")`
-- `snapshots.record("fs_delete", diff_summary="...")` with a count of shares removed
-- The view shows a green summary; a toast confirms.
+**Partial teardown — no cross-step rollback.** The sequence stops at the first failing step, and everything already completed stays completed. Step 1 is a plain `for` loop over `plan_apply_wait` calls; a `ControlPathError` from any step calls `_teardown_failed(...)` and returns. There is no bookkeeping of removed shares to undo, and the screen never re-creates a share or re-mounts a filesystem — those paths do not exist in `filesystem.py`. Rollback belongs to the task engine, one apply at a time: each step's apply either lands or rolls itself back where its executor supports that, and the TUI does not stack a second, weaker rollback layer on top of steps that already succeeded.
+
+*What the operator is told.* `_teardown_failed` appends two lines to the progress view —
+
+```
+  FAILED: <error>
+  Teardown stopped — remaining steps were not run.
+```
+
+— and raises an OK-only dialog titled **`Delete Filesystem — Stopped`** naming the step that failed, the error, and, verbatim: *"Teardown stopped at this step. No cross-step rollback; the failed task rolled itself back where supported."* The progress view above it still shows every step that did complete, in order.
+
+*Manual recovery.* Recovery is an ordinary forward operation, not an undo:
+
+| Stopped at | State | Recovery |
+|---|---|---|
+| Step 1, share *k* | shares 1..*k-1* deleted; the filesystem still mounted and managed | Re-create the missing shares from the NFS screen (§4.5), or clear the blocker and re-run Delete Filesystem. |
+| Step 2 (unmount) | all shares deleted; filesystem still mounted and managed | Usually a busy mount. Clear the blocker and re-run Delete Filesystem, or re-create the shares to restore the prior state. |
+| Step 3 (unmanage) | all shares deleted; filesystem unmounted but its unit still managed | The data is intact and the unit still exists, so re-running Delete Filesystem finishes the job once the blocker is cleared. To go the other way, `PATCH {"mounted": true}` re-mounts it — but **no TUI screen offers a remount**, so that path is `xinasctl` / MCP only. |
+
+The audit trail records each completed step, so the boundary between "done" and "not run" is reconstructable after the fact.
+
+**Side effects per step.** Each line is written only after its own step succeeded:
+
+| Step | Audit action | Snapshot |
+|---|---|---|
+| 1 — `DELETE /api/v1/shares/{id}` | `nfs.remove` with detail `share=<P> (FS teardown)` | — |
+| 2 — `PATCH /api/v1/filesystems/{id}` `{"mounted": false}` | `fs.unmount` with detail `mountpoint=<M> (FS teardown)` | — |
+| 3 — `DELETE /api/v1/filesystems/{id}` | `fs.delete` with detail `mountpoint=<M> device=<D>` (written on full success, after step 3) | `fs_delete` with diff summary |
+
+The `fs_delete` snapshot's `diff_summary` names the mountpoint and device and appends the removed-share count when non-zero. It is recorded **only** after step 3, so a teardown that stops early records **no** snapshot. On full success the view shows a green summary (mountpoint, device, share count) and a toast confirms.
 
 ### 3.5 Manage Quotas
 
-Decides on **mount options**, not on user-level limits. Setting per-user / per-project byte limits is a separate code path (the helper's `set_quota` op via `xfs_quota -x`) and is **not** currently exposed in any TUI screen — it's available only to MCP callers.
+Decides on the filesystem's **quota mode**, not on user-level limits. Setting per-user / per-project byte limits is a separate code path (the helper's `set_quota` op via `xfs_quota -x`) and is **not** currently exposed in this screen.
 
-What this menu does:
+The screen no longer edits the mount unit itself. It reads the mode out of the observed mount options and writes it with a **one-intent `PATCH`**; the remount is the executor's job.
 
-1. `findmnt -t xfs -J` enumerates XFS mounts. For each, `get_quota_status(options)` parses the option list and returns `{user, project, group}` booleans.
-2. The view shows a status header per mount: `<mp> [quotas: user, project]` (green for enabled, yellow `none` if neither).
-3. The operator picks a mount. The action menu is constructed dynamically based on current state: only `Enable User Quotas` shows when user quota is off; only `Disable User Quotas` shows when it's on; etc. If both are off, a third option `Enable Both (user + project)` appears.
-4. Confirmation includes a warning: *"XFS requires a full unmount/mount cycle to change quota settings. Active NFS clients may be briefly disconnected."*
-5. `update_mount_unit_quota(mp, enable_user, enable_project)` does the real work:
-   - Read `/etc/systemd/system/<mp_unit>.mount`.
-   - Parse the existing `Options=` line.
-   - Strip `noquota` if any quota is being enabled (it conflicts with all).
-   - Remove `uquota`/`usrquota` if `enable_user` is set, and `pquota`/`prjquota` if `enable_project` is set.
-   - Append the new flags if `True`, omit them if `False`, leave them alone if `None`.
-   - Rewrite the unit atomically (`mkstemp + os.replace`).
-   - `systemctl daemon-reload` + `stop <unit>` + `start <unit>` — the **full cycle**, not `mount -o remount`, because XFS rejects quota changes via remount.
+1. `_list_filesystems()` (`GET /api/v1/filesystems`) enumerates the managed filesystems. For each, `_quota_flags(options)` parses the effective mount-options list into `{user, project, group}` booleans (`uquota`/`usrquota`, `pquota`/`prjquota`, `gquota`/`grpquota`).
+2. The view shows a status header per filesystem: `<mp> [quotas: user, project]` (green per enabled mode, yellow `none` if neither).
+3. The operator picks one. The action menu is built from current state and always offers **two** entries — the user toggle and the project toggle:
 
-On success: `audit.log("fs.quota", ..., "OK")` + `snapshots.record("fs_modify", diff_summary=...)`.
+   | Current state | Offered |
+   |---|---|
+   | user off | `Enable User Quotas (uquota)` → `quota_mode: uquota` |
+   | user on | `Disable User Quotas` → `quota_mode: none` |
+   | project off | `Enable Project Quotas (pquota)` → `quota_mode: pquota` |
+   | project on | `Disable Project Quotas` → `quota_mode: none` |
 
-Group quotas (`gquota` / `grpquota`) are *parsed* by `get_quota_status` but never *toggled* by the UI — XFS+NFS appliance deployments are expected to use user + project quotas exclusively.
+   **There is no "Enable Both" option any more.** `Filesystem.spec.quota_mode` is a single enum (`none | uquota | gquota | pquota`), so a filesystem holds exactly one mode: enabling one *replaces* the other. The action description says so out loud — `enable user quotas (replaces project quotas)` when project quotas are currently on, and the mirror image for the other direction. A "disable" action of either kind sets `none`, which clears whatever mode was set.
+
+4. Confirmation names the filesystem and the action description, and warns: *"XFS requires a full unmount/mount cycle to change quota settings. Active NFS clients may be briefly disconnected."*
+5. `PATCH /api/v1/filesystems/{id}` with `{"quota_mode": <mode>}` via `plan_apply_wait` — one intent key, which is what the endpoint requires (mixing `quota_mode` with `mounted` or `grow` is `INVALID_ARGUMENT`). The api routes it to `fs.set_quota_mode`, a **client-visible remount**; the unit-file rewrite and the `systemctl` stop/start cycle happen executor-side, not in the TUI. XFS rejects quota changes via `mount -o remount`, which is why the cycle is full rather than in-place.
+
+On failure: an OK-only `Failed to update quotas:` dialog plus a red line in the view; nothing is retried.
+
+On success: `audit.log("fs.quota", "<mp>: <description>", "OK")` + `snapshots.record("fs_modify", diff_summary="Changed quotas on <mp>: <description>")`, and the view confirms the filesystem was remounted.
+
+Group quotas (`gquota` / `grpquota`) are *parsed* by `_quota_flags` and *accepted* by the API enum, but never *offered* by this menu — XFS+NFS appliance deployments are expected to use user or project quotas exclusively.
 
 ---
 
@@ -243,26 +290,38 @@ Group quotas (`gquota` / `grpquota`) are *parsed* by `get_quota_status` but neve
 
 | Key | Action | Backend |
 |---|---|---|
-| 1 | Show NFS Exports | `nfs.list_exports()` + `_format_exports()` |
-| 2 | Add Share | 7-step wizard → `nfs.add_export()` |
-| 3 | Edit Share | 7-step wizard → `nfs.update_export()` |
-| 4 | Remove Share | `nfs.remove_export()` |
-| 5 | Active Sessions | `nfs.list_sessions()` |
-| 6 | Configure idmapd Domain | direct rewrite of `/etc/idmapd.conf` |
+| 1 | Show NFS Exports | `GET /api/v1/shares` → `_rows_from_api()` → `_format_exports()` |
+| 2 | Add Share | 7-step wizard → `POST /api/v1/shares` |
+| 3 | Edit Share | 7-step wizard → `PATCH /api/v1/shares/{id}` |
+| 4 | Remove Share | `DELETE /api/v1/shares/{id}` |
+| 5 | Active Sessions | `nfs.list_sessions()` — the one direct helper-socket call left |
+| 6 | Configure idmapd Domain | direct rewrite of `/etc/idmapd.conf` (§4.9) |
 | 0 | Back | pop screen |
 
-Every write goes through the helper socket, including the `idmapd` step (which is a plain-Python in-screen rewrite — see §4.7). The screen never edits `/etc/exports` itself.
+**Every share write is a `plan_apply_wait`**, not a helper-socket call. The screen still never edits `/etc/exports` — but the writer is now `api → agent → nfs-helper`, two hops further away, and the screen gets plan blockers, task stages, and the api's audit trail for free. Two actions stay outside that path: Active Sessions (a pure read the control path does not model, §4.8) and the idmapd domain (§4.9).
+
+Share ids are percent-encoded with `quote_id()` on every path — a Share id mirrors `encExportId(path)` and **contains internal slashes** (`/mnt/data` → `mnt/data`), so an un-encoded id 404s. See [s8-clients-spec §6](../control-path/s8-clients-spec.md#6-tui-composite-teardown-t13).
+
+**Shared share read.** Every write action first calls `NFSScreen._get_exports()` (`GET /api/v1/shares` → `_rows_from_api`, keeping only rows with both a `path` and an `id`). It **propagates** `ControlPathError` rather than degrading to `[]`, so each caller can tell "the api is unreachable" apart from "this host has no shares" — Edit and Remove show an OK-only `Could not load shares.` dialog for the former and `No shares configured.` for the latter, and Add fails its `fsid` allocation closed (§4.5). Reporting an unreadable list as an empty one is what made the `fsid` allocator restart from `1` against a live host.
+
+**Shared failure rendering.** All three write actions funnel a `ControlPathError` through `NFSScreen._show_control_error(exc)`, which splits one case out of the generic path: a **lease conflict** (the resource is locked by another in-flight task) gets a calm OK-only *Resource Busy* dialog via `lease_conflict_message(exc)`, because the lock is short-lived and the periodic sweep bounds it — retrying is the right advice. Everything else keeps the plain OK-only `Failed: <error>` dialog. `_show_control_error` is deliberately **not** a `@work` worker: callers `await` it inline, and Textual 8.x `Worker` objects are not awaitable.
 
 ### 4.2 Show — structured render with diagnostics
 
-`_load_exports()` runs `nfs.list_exports()` and feeds the result to `_format_exports()`. The renderer is intentionally rich:
+`_load_exports()` runs `GET /api/v1/shares`, adapts the docs with `_rows_from_api()`, and feeds the result to `_format_exports()`. A `ControlPathError` short-circuits before the renderer: the view shows a `Control API: <error>` line and nothing else.
+
+**`_rows_from_api()` is the only place the API shape is known.** API shares are `{id, spec: {path, clients: [{pattern, options}], fsid, sync?, security_mode?}, status}`; the renderer and the Edit wizard both speak the legacy `{path, clients: [{host, options}]}` shape. The adapter renames `pattern` → `host` and **folds the share-level `sync` and `security_mode` back into each client's option list** — mirroring the server's own exports compile — so `_parse_current_export` and the display keep working unchanged. `sync`/`async` is only appended when the client options don't already carry one, and `sec=` only when `security_mode` is set and isn't `sys`. Rows without a `path` are dropped.
+
+The renderer is intentionally rich:
 
 - **Storage line** — `df -h <path>` to show `used / total (pct)`.
 - **Path-missing flag** — `os.path.isdir(path)` — flips the status badge to `[!] PATH MISSING` (red) if the export targets a directory that doesn't exist on disk.
 - **Security label** — translates `sec=krb5` / `krb5i` / `krb5p` → `"Kerberos"` / `"Kerberos+integrity"` / `"Kerberos+encryption"`, defaults to `"Standard (UID/GID)"`.
 - **Per-client explanation** — translates `*` → `"Everyone (all hosts)"`, `10.10.0.0/24` → `"Network: 10.10.0.0/24"`, and flags `no_root_squash` as `"full admin"` next to `rw` / `ro`.
-- **Fallback** — if the helper socket fails (returns `False`), the renderer parses `/etc/exports` directly. The UI shows the same shape, just with the option strings unparsed.
+- **Empty state** — an empty share list renders `(no NFS shares configured)`. The renderer does **not** read `/etc/exports`. It used to: when the row list came back empty it parsed the file directly and displayed its contents as the share list. That made sense while the helper socket was the read path and an empty result meant "the socket failed", but under the control path an empty result means *the api observed no shares* — and the collector already observes `/etc/exports` itself, so anything genuinely exported would have come back as a row. All the fallback could still do was present unmanaged file contents as though they were the managed share list, in exactly the case where the operator most needs to see that the control path has nothing.
 - **Connected hosts** — last block. Reads `/proc/fs/nfsd/clients/*/info` for active v4 connections; if that's empty, falls back to `ss -tn state established ( dport = :2049 )` for v3 / TCP connections. IPs are de-duplicated.
+
+**Degraded-backend honesty.** Like Show Filesystems (§3.2) and the RAID overview, `_load_exports` fetches the **full envelope** (`control.get`, not `control.result`) and inspects its `warnings`. When the envelope carries `DEGRADED_BACKEND_UNAVAILABLE` — the `Share` collector is errored (control-path contract: [s8-clients-spec §5.1](../control-path/s8-clients-spec.md)) — `_format_exports` renders that message as a banner above any rows, and when the list is empty the banner **replaces** the `(no NFS shares configured)` empty state. An unobservable backend must never read as "genuinely no shares". The shared extractor is [api/degraded.py](../../xinas_menu/api/degraded.py) `degraded_banner(envelope)`, the same one the other two screens use.
 
 This is the closest the TUI comes to a dashboard — it's the screen most operators see most often.
 
@@ -321,36 +380,32 @@ it does.
 
 **Steps 2–6.** `self._access_steps("Add Share", total=7)` — see §4.4. A Back button is available on all five.
 
-**Step 7 — confirmation.** `allow_back=True`, so the operator can back up from the summary to revise any earlier answer before committing. The options list is built deterministically:
+**Step 7 — confirmation.** `allow_back=True`, so the operator can back up from the summary to revise any earlier answer before committing.
 
-```
-options = [access, sync_mode, "no_subtree_check", root_squash]
-if sec != "sys":
-    options.append(f"sec={sec}")
-```
+**Submission.** Before submitting, the screen `os.makedirs(path, exist_ok=True)` to be sure the export directory exists; an `OSError` there aborts on an OK-only `Cannot create directory:` dialog. (The helper *could* do this — `add_export` accepts `create_path=true` — but handling it client-side keeps the user-visible error to a single dialog.)
 
-`no_subtree_check` is force-added even though the wizard doesn't ask about it — it's required for any export on an NFS appliance.
-
-**Submission.** Before sending the helper request, the screen `os.makedirs(path, exist_ok=True)` to be sure the export directory exists. (The helper *could* do this — `add_export` accepts `create_path=true` — but the screen handles it client-side so the user-visible error is a single dialog rather than two round-trips.)
-
-The helper request payload uses the structured form:
+Then one `plan_apply_wait` — `POST /api/v1/shares` with the `NfsShare.spec`:
 
 ```json
 {
-  "op": "add_export",
-  "request_id": "<uuid>",
-  "entry": {
-    "path": "/mnt/data/share1",
-    "clients": [
-      { "host": "10.10.0.0/24", "options": ["rw","sync","no_subtree_check","no_root_squash"] }
-    ]
-  }
+  "path": "/mnt/data/share1",
+  "fsid": 3,
+  "clients": [
+    { "pattern": "10.10.0.0/24", "options": ["rw", "no_root_squash", "no_subtree_check"] }
+  ],
+  "sync": "sync"
 }
 ```
 
-This is the canonical internal representation. The helper serialises it to the single-line `/etc/exports` format via `nfs_exports._serialize_exports()`, which also injects the `# Managed by xinas-nfs-helper — do not edit manually` banner at the top of the file.
+Three things to note, because the wizard's five answers do **not** map one-to-one onto that shape:
 
-On success: `audit.log("nfs.add_export", path, "OK")` + `snapshots.record("share_create", diff_summary=…)` + Show is refreshed.
+- **`sync_mode` and `sec` are share-level fields, not client options.** `sync` always carries the wizard's answer; `security_mode` is added **only when `sec != "sys"`**. `_rows_from_api` folds both back into the client option list on read (§4.2), which is why the display and the Edit wizard still see them there.
+- **`no_subtree_check` is force-added** to every client's options even though the wizard doesn't ask — it's required for any export on an NFS appliance.
+- **`fsid` is allocated client-side, and the allocation fails closed.** `Share.spec.fsid` is **required** by the API ([api-v1.yaml](../control-path/api-v1.yaml)) — the server does not assign one — so the screen reads the current shares, collects every integer `fsid` already in use (accepting both int and numeric-string spellings), and assigns `max(used, default=0) + 1`. That read must therefore be **authoritative**: if `GET /api/v1/shares` fails, the wizard aborts on an OK-only `Could not read existing shares` dialog rather than allocating from an empty set. Allocating from a swallowed error would restart numbering at `1` and collide with every existing share — an `fsid` collision silently breaks NFSv4 client mounts, so guessing is worse than refusing.
+
+  What this does **not** fix: two operators adding a share at the same time can still compute the same number, because the allocation is client-side by construction. The api's plan is the backstop there. Moving allocation server-side would need an API change (`fsid` becoming optional), which is tracked separately.
+
+On success: `audit.log("nfs.add_export", path, "OK")` + `snapshots.record("share_create", diff_summary=…)` + Show is refreshed. On `ControlPathError`, `_show_control_error` renders it (§4.1).
 
 ### 4.6 Edit Share — preserve unknown options
 
@@ -360,42 +415,58 @@ On success: `audit.log("nfs.add_export", path, "OK")` + `snapshots.record("share
 
 **Steps 2–6.** `self._access_steps("Edit Share", total=7)` — the same shared steps Add uses (§4.4). Because `answers["_orig"]` was seeded in step 1, every prompt shows the `(Current: …)` hint alongside the pre-selected working value.
 
-**Step 7 — confirmation.** `allow_back=True`. The new options list rebuilds the wizard-managed knobs **plus** appends the preserved `extra_opts` (read from `answers["_orig"]["extra_opts"]`):
+**Step 7 — confirmation.** `allow_back=True`. The summary renders the export the way `/etc/exports` spells it — a flat option list including `sync_mode` and `sec=`, plus the preserved `extra_opts` (read from `answers["_orig"]["extra_opts"]`):
 
 ```python
 extra = answers["_orig"]["extra_opts"]
 options = [access, sync_mode, root_squash]
 if sec != "sys":
     options.append(f"sec={sec}")
-options.extend(extra)
+options.extend(extra)          # display only — see Submission below
 ```
 
 So if the original export had `insecure,no_wdelay,fsid=0` (the appliance baseline from [Installer/fs-exports-spec.md §2.3](../Installer/fs-exports-spec.md#23-decoding-the-default-options)), those three options survive a wizard run unchanged. Note: `no_subtree_check` is *not* in `_WIZARD_MANAGED_OPTS`, so it counts as an extra and is preserved through edits — but unlike Add, Edit doesn't force-add it.
 
-**Submission.** `update_export(path, patch)` with `patch = {"clients": [{"host", "options"}]}`. The helper's `update_export` is a merge-patch: it overwrites the `clients` list but leaves any other fields on the entry untouched (currently there are none, but the protocol is forward-compatible).
+**Submission.** That flat list is **display only**. The submitted patch splits it back apart the way the API models a share — `sync` and `security_mode` are share-level fields, and only `access`, `root_squash` and the extras stay as client options:
 
-On success: `audit.log("nfs.update_export", path, "OK")` + `snapshots.record("share_modify", diff_summary=…)` + Show is refreshed.
+```python
+patch = {
+    "clients": [{"pattern": host, "options": [access, root_squash, *extra]}],
+    "sync": sync_mode,
+    "security_mode": sec,
+}
+```
+
+Unlike Add, Edit sends `security_mode` **unconditionally**, including the value `"sys"` — so an edit is what clears a `sec=krb5` off an existing share. That asymmetry is deliberate: an omitted field on a PATCH means "leave alone", which would make `sec` a one-way door.
+
+One `plan_apply_wait` — `PATCH /api/v1/shares/{quote_id(share_id)}` with that patch. The `share_id` comes from step 1's lookup, not from the path: an id carries internal slashes and must be encoded (§4.1). The PATCH is a merge-patch — fields not named are left as they are, so `path` and `fsid` survive an edit untouched.
+
+On success: `audit.log("nfs.update_export", path, "OK")` + `snapshots.record("share_modify", diff_summary=…)` + Show is refreshed. On `ControlPathError`, `_show_control_error` (§4.1).
 
 ### 4.7 Remove Share
 
 Simple two-prompt flow:
 
-1. `SelectDialog` over current export paths.
+1. `SelectDialog` over current export paths. The chosen path is looked back up to recover its **id**; a share with no id aborts on an OK-only `Share not found.` dialog.
 2. `ConfirmDialog("Remove export {path}?")` — single confirmation, no FINAL prompt (an export has no downstream FS state to worry about, unlike a RAID array or a mount).
 
-Then `nfs.remove_export(path)`. On success: `audit.log("nfs.remove_export", path, "OK")` + `snapshots.record("share_delete", …)` + Show refreshed.
+Then one `plan_apply_wait` — `DELETE /api/v1/shares/{quote_id(share_id)}` with an **empty body**: the delete plan's spec is built server-side from the desired share (`{id, path}`). The risk class is `changing_access`, not `destroying_data`, so **no `dangerous` flag is passed** — the single confirmation is the whole gate, and the api does not demand more.
+
+On success: `audit.log("nfs.remove_export", path, "OK")` + `snapshots.record("share_delete", …)` + Show refreshed. On `ControlPathError`, `_show_control_error` (§4.1).
 
 The export's directory on disk is **not** removed. Anything the share was rooted at stays put.
 
 ### 4.8 Active Sessions
 
-`nfs.list_sessions()` reads `/proc/fs/nfsd/clients/*/info` on the server side, returning a list of `{client_ip, nfs_version, export_path, active_locks}` dicts. The screen prints `client → export_path` per row. The fallback path (when `/proc/fs/nfsd/clients` is empty — older kernels or v3-only servers) parses `/proc/net/rpc/auth.unix.ip`.
+**The one place either screen still calls the helper socket directly.** Session state is a live read of the kernel server, not desired configuration, so the control path does not model it — the screen goes straight to the daemon via `loop.run_in_executor(None, self.app.nfs.list_sessions)`.
+
+`nfs.list_sessions()` reads `/proc/fs/nfsd/clients/*/info` on the server side, returning a list of `{client_ip, nfs_version, export_path, active_locks}` dicts. A failure renders the client's error envelope (§2.3) straight into the view. The screen prints `client → export_path` per row. The fallback path (when `/proc/fs/nfsd/clients` is empty — older kernels or v3-only servers) parses `/proc/net/rpc/auth.unix.ip`.
 
 Per-export filtering is available via `nfs.get_sessions(path)`, but the screen always asks for the global list. Use the MCP tool surface for per-path queries.
 
 ### 4.9 Configure idmapd Domain
 
-The only NFS-screen action that **does not** go through the helper socket. NFSv4 ID mapping (`/etc/idmapd.conf`) is a one-time / rare-edit configuration; rather than adding a `set_idmapd_domain` op to the helper, the screen edits the file directly in an executor:
+The only NFS-screen write that goes through **neither** the control path nor the helper socket. NFSv4 ID mapping (`/etc/idmapd.conf`) is a one-time / rare-edit configuration; rather than modelling it as a control-path resource or adding a `set_idmapd_domain` op to the helper, the screen edits the file directly in an executor:
 
 1. Validate input — `domain` must contain at least one `.`.
 2. Inline executor reads `/etc/idmapd.conf`, replaces the `^Domain\s*=\s*…` line with the new value, writes the file back. No locking, no atomic write — this is an admin-only screen.
@@ -411,15 +482,19 @@ The screen does **not** restart `nfs-idmapd` — the daemon picks up the change 
 
 ```
 FilesystemScreen._create_filesystem_wizard()
-  ├─ grpc.raid_show(extended=True)             — list arrays
-  ├─ for each array:
-  │    └─ find_mounts_using_raid(name)         — findmnt scan (data + logdev)
+  ├─ GET /api/v1/arrays                        — list arrays
+  ├─ GET /api/v1/filesystems                   — _volumes_in_use(): drop
+  │                                              arrays already used as a
+  │                                              data or logdev device
   ├─ SelectDialog (data array)                 — TUI only
   ├─ SelectDialog (log array)                  — TUI only
   ├─ InputDialog (label)                       — TUI only
   ├─ InputDialog (mountpoint)                  — TUI only
-  ├─ build_mount_options + calculate_stripe_width  — pure Python
-  ├─ ConfirmDialog (summary)                   — TUI only
+  ├─ ConfirmDialog (summary)                   — TUI only; su_kb and the
+  │                                              flat option string are
+  │                                              display-only (su_kb/sw are
+  │                                              omitted from the spec and
+  │                                              derived server-side)
   ├─ control.plan_apply_wait(POST /api/v1/filesystems)   — ONE plan→apply
   │    ├─ mode=plan  → plan_id, blockers checked
   │    ├─ mode=apply → task_id
@@ -444,9 +519,14 @@ NFSScreen._add_share_wizard()
   │    ├─ sync_mode (sync/async)
   │    └─ sec (sys/krb5/krb5i/krb5p)
   ├─ ConfirmDialog (summary)
-  ├─ os.makedirs(path, exist_ok=True)
-  ├─ nfs.add_export({"path":..., "clients": [...]})
-  │    └─ Unix socket → xinas-nfs-helper
+  ├─ os.makedirs(path, exist_ok=True)           — client-side, one clear error
+  ├─ GET /api/v1/shares                         — collect used fsids → max+1
+  ├─ control.plan_apply_wait(POST /api/v1/shares)
+  │    ├─ spec: {path, fsid, clients:[{pattern, options}], sync,
+  │    │         security_mode?}   — sync/sec are share-level, not options
+  │    ├─ mode=plan  → plan_id, blockers checked
+  │    ├─ mode=apply → task_id
+  │    └─ agent nfs-executor → Unix socket → xinas-nfs-helper
   │         ├─ validate (abs path, isdir or create_path)
   │         ├─ fcntl LOCK_EX on /run/xinas-exports.lock
   │         ├─ parse /etc/exports
@@ -464,18 +544,19 @@ NFSScreen._add_share_wizard()
 
 ```
 FilesystemScreen._manage_quotas()
-  ├─ findmnt -t xfs -J                          — enumerate mounts
-  ├─ get_quota_status(options)                  — parse current flags
-  ├─ SelectDialog (mountpoint)
-  ├─ SelectDialog (action)                       — dynamic based on current state
+  ├─ GET /api/v1/filesystems                    — enumerate managed FSs
+  ├─ _quota_flags(options)                      — parse current flags
+  ├─ SelectDialog (filesystem)
+  ├─ SelectDialog (action)                       — user toggle + project toggle,
+  │                                                labelled from current state
   ├─ ConfirmDialog (warns about unmount/mount cycle)
-  ├─ update_mount_unit_quota(mp, enable_user=True, enable_project=None)
-  │    ├─ read /etc/systemd/system/mnt-data.mount
-  │    ├─ regex update Options=
-  │    ├─ atomic write (mkstemp + os.replace)
-  │    ├─ systemctl daemon-reload
-  │    ├─ systemctl stop mnt-data.mount         — XFS requires full cycle
-  │    └─ systemctl start mnt-data.mount
+  ├─ control.plan_apply_wait(PATCH /api/v1/filesystems/mnt-data.mount,
+  │                          {"quota_mode": "uquota"})   — ONE intent key
+  │    ├─ mode=plan  → plan_id, blockers checked
+  │    ├─ mode=apply → task_id
+  │    └─ fs.set_quota_mode executor-side: rewrite Options=,
+  │         daemon-reload, stop + start the unit (XFS rejects a
+  │         quota change via `mount -o remount`)
   ├─ audit.log("fs.quota", "<mp>: enable user quotas", "OK")
   └─ snapshots.record("fs_modify", ...)
 ```
@@ -489,13 +570,16 @@ Every write operation in both screens emits two side-channel records — see [St
 | User action | Audit action | Snapshot operation | diff_summary |
 |---|---|---|---|
 | Create FS | `fs.create` | `fs_create` | `Created XFS filesystem '<L>' on <D>, mounted at <M>` |
-| Delete FS | `fs.delete` (+ `nfs.remove` per affected share) | `fs_delete` | `Deleted filesystem at <M> (device <D>) [, removed N share(s)]` |
-| Toggle quota | `fs.quota` | `fs_modify` | `Changed quotas on <M>: enable user quotas, …` |
+| Delete FS | `fs.delete` (+ `nfs.remove` per affected share, + `fs.unmount` when it was mounted) | `fs_delete` | `Deleted filesystem at <M> (device <D>) [, removed N share(s)]` |
+| Toggle quota | `fs.quota` | `fs_modify` | `Changed quotas on <M>: <action description>` (e.g. `enable user quotas (replaces project quotas)`) |
 | Add share | `nfs.add_export` | `share_create` | `Added NFS share <P>` |
 | Edit share | `nfs.update_export` | `share_modify` | `Updated NFS share <P>` |
 | Remove share | `nfs.remove_export` | `share_delete` | `Removed NFS share <P>` |
 | Set idmapd domain | `nfs.idmapd_domain` | `nfs_modify` | `Set idmapd domain to <D>` |
 | Share auto-removed during FS teardown | `nfs.remove` with `(FS teardown)` suffix | (none — rolled into `fs_delete`) | — |
+| FS unmounted during FS teardown | `fs.unmount` with `(FS teardown)` suffix | (none — rolled into `fs_delete`) | — |
+
+Each teardown line is written only after its own step succeeded, and the `fs_delete` snapshot only after the final step. A teardown that stops partway (§3.4) therefore leaves audit lines for the steps that ran and **no** snapshot at all.
 
 Snapshots are best-effort. If `xinas_history` is not installed or `record()` raises, the UI flow is unaffected — the audit line is still written and the user-visible success/failure is determined entirely by the helper response.
 
@@ -513,31 +597,38 @@ YYYY-MM-DD HH:MM:SS | <user> | <action> | OK | <detail>
 
 | Failure | Where | Handling |
 |---|---|---|
-| Helper socket missing / refused | every helper call | `NFSHelperClient` returns `(False, None, "…not found"/"…not running")`. The Show screen falls back to parsing `/etc/exports` directly; write screens surface the error and refuse to proceed. |
-| Helper times out | `socket.timeout` after 10 s | Same `(False, None, …)` envelope; the dialog shows "NFS helper timed out". Write flows stop without partial state. |
-| `exportfs -r` fails with non-`Failed to stat` error | helper `_exportfs_reload()` | Raises `RuntimeError`; the helper returns `{"ok": false, "code": "INTERNAL"}`; the TUI surfaces the message. |
+| `GET /api/v1/shares` unreachable | `_load_exports` / `_get_exports` | `_get_exports` **propagates** the `ControlPathError`; no caller degrades a failed read to "no shares". Show prints `Control API: <error>`; Add aborts its `fsid` scan (§4.5); Edit and Remove abort on an OK-only `Could not load shares.` dialog, distinct from the `No shares configured.` empty case. |
+| `Share` collector degraded behind a healthy api | `GET /api/v1/shares` envelope | `DEGRADED_BACKEND_UNAVAILABLE` warning → Show renders the banner, and an empty list shows the banner instead of `(no NFS shares configured)` (§4.2). |
+| Share write fails (plan blocked, task failed, api down) | `_show_control_error` | OK-only `Failed: <error>` dialog carrying the plan/task message; the flow aborts with no partial state (the apply is one task). |
+| Share write hits a lease conflict | `_show_control_error` → `lease_conflict_message` | OK-only *Resource Busy* dialog instead of the raw error — the resource is locked by another in-flight task and the lock is short-lived, so retrying is the advice (§4.1). |
+| Helper socket missing / refused / timed out | `nfs.list_sessions()` (§4.8), and agent-side for every share write | `NFSHelperClient` returns `(False, None, "…not found"/"…not running"/"NFS helper timed out")`. Active Sessions prints it; a share write fails agent-side and surfaces as a task failure. |
+| `exportfs -r` fails with non-`Failed to stat` error | helper `_exportfs_reload()` | Raises `RuntimeError`; the helper returns `{"ok": false, "code": "INTERNAL"}`; the agent turns that into a task failure and the TUI surfaces the message. |
 | `nfs-kernel-server` not installed | helper startup health check | `xinas-nfs-helper` logs a warning at boot; first export op fails with `exportfs not found`. |
-| Non-absolute `path` to `add_export` | `nfs_helper.handle_add_export` | `INVALID_ARGUMENT` — `"entry.path must be absolute"`. |
+| Non-absolute `path` to `add_export` | `nfs_helper.handle_add_export` | `INVALID_ARGUMENT` — `"entry.path must be absolute"`. The wizard rejects a non-`/` path before submitting, so this is a defence in depth. |
 | Export target directory missing | `nfs_helper.handle_add_export` | `NOT_FOUND` unless `create_path=true`. TUI's Add wizard pre-creates the directory client-side. |
+| Add Share cannot read the existing shares | `fsid` allocation (§4.5) | Fails closed: OK-only `Could not read existing shares` dialog, wizard aborts. It never allocates from an empty set. |
+| Two concurrent Add Shares allocate the same `fsid` | client-side `max(used)+1` allocation (§4.5) | Not prevented by the TUI — allocation is client-side by construction. The api's plan is the backstop. |
 | Quota toggle while NFS clients connected | XFS requires unmount cycle | `_manage_quotas` warns up front; clients are briefly disconnected during the stop/start. |
-| Mount-unit not found during quota toggle | `update_mount_unit_quota` | Returns `(False, "Mount unit not found: …")`; the dialog reports the missing path. |
+| Quota toggle fails (unit missing, remount refused, plan blocked) | `PATCH {"quota_mode": …}` | `ControlPathError` → OK-only `Failed to update quotas:` dialog carrying the task/plan message, plus a red line in the view. No retry. |
 | fs.create task fails (live mountpoint, existing unit, mkfs error, log array too small) | control-path task terminal | `TaskFailed.error_message` carries the failing stage's message; an OK-only dialog shows it. **No force retry** unless the failure is the existing-filesystem destruction gate. |
 | fs.create fails on the destruction gate (device already carries a filesystem) | fs-executor preflight (`blkid` gate) | Yes/No force-recreate consent quoting the task detail; on Yes the spec is re-submitted with `force: true` + `dangerous=True`. |
-| Mount unit fails to start (e.g. xiRAID device not present) | `mount_filesystem` returns `(False, …)` | Wizard aborts after the mount unit was written; the unit stays on disk so the next `systemctl start` can succeed without re-running mkfs. |
-| `findmnt` JSON parse error | Show / Delete / Quotas | Caught; the screen shows `(parse error: …)` but stays interactive. |
-| RAID delete cascades into shares but `add_export` rollback fails | FS-delete rollback | The dialog reports "Rolled back N share(s)"; the failure is noted but rollback does not itself roll back. Audit log captures every step. |
+| Mount stage fails during fs.create (e.g. xiRAID device not present) | fs-executor mount stage | Reaches the wizard as a `TaskFailed` like any other stage failure — OK-only dialog, no force retry. Cleanup is the task's own stage rollback; the screen writes no unit and removes none. |
+| `GET /api/v1/filesystems` fails during the Create pre-check | `_volumes_in_use()` input | Degrades to an empty in-use set (the arrays list is *not* filtered), so an already-consumed array can be offered; the executor's preflight is what rejects it. Contrast the arrays read, which aborts the wizard. |
+| `GET /api/v1/filesystems` unreachable | Show / Delete / Quotas | `ControlPathError`. Show and Quotas render `Could not load filesystems: …` into the view; Delete aborts on an OK-only dialog. (`filesystem.py` no longer runs `findmnt` at all — the whole screen reads the control path.) |
+| Any FS-teardown step fails (busy mount, blocked plan, share delete refused) | `_teardown_failed` | The sequence **stops**. Completed steps stay completed — there is no cross-step rollback. The progress view shows what ran; an OK-only `Delete Filesystem — Stopped` dialog names the failing step and the error (§3.4). |
+| Filesystem backend degraded during Delete Filesystem | `_list_filesystems()` (banner-less) | The list arrives empty and the operator sees `No XFS filesystems found.` — the degraded banner is dropped on this path, unlike Show Filesystems (§3.2). |
 | idmapd file unreadable | `_configure_idmapd` | Returns `(False, str(exc))`; the dialog shows the OS error. |
 
 ---
 
 ## 8. What these screens do **not** do
 
-- They do not run `xicli` or `xfs_quota` directly. The first goes through the gRPC daemon; the second goes through the NFS helper (it's listed as one of the helper's ops but is not currently wired into any TUI screen — only the MCP tool surface uses it).
+- They do not run `xicli`, `mkfs.xfs`, `systemctl`, or `xfs_quota` directly. `FilesystemScreen` reaches storage only through the control-path API — it holds no gRPC client and no longer writes mount units itself. `xfs_quota` (per-user byte limits, as opposed to the filesystem's quota *mode*) remains an NFS-helper op, wired into the Users screen and the MCP tool surface but not into these two.
 - They do not change `/etc/nfs.conf`. That is reachable through `nfs.fix_nfs_conf()` (the helper op) and is invoked by the Health screen's auto-fix and by MCP tools, **not** by the FS or NFS screens.
 - They do not enforce per-export quotas. `uquota` / `pquota` are mount-level switches; assigning per-user / per-project byte limits is a separate operation (helper's `set_quota` op) that the TUI exposes only indirectly via the (not yet implemented) Users / Groups screens.
 - They do not configure firewall rules for NFS ports. `2049/tcp` and `20049/rdma` are assumed open on the storage network — see [Installer/network-spec.md §9](../Installer/network-spec.md#9-what-the-installer-does-not-do).
 - They do not edit `/etc/exports` directly, and they do not preserve hand-edits. The helper writes the file in full on every `add` / `remove` / `update` and re-injects the `# Managed by xinas-nfs-helper — do not edit manually` banner — anything in the file outside the structured format is dropped.
-- They do not delete the on-disk content of a share or FS. Removing a share leaves the directory tree intact; deleting a filesystem removes the mount but leaves the XFS on `/dev/xi_<name>` so a re-mount picks up the existing data. The only place data is destroyed is `mkfs.xfs -f` in the Create wizard, and it's gated by an explicit confirmation when a filesystem is already present.
+- They do not delete the on-disk content of a share or FS. Removing a share leaves the directory tree intact; deleting a filesystem removes the mount but leaves the XFS on `/dev/xi_<name>` so a re-mount picks up the existing data. The only place data is destroyed is the executor's `mkfs.xfs` during `fs.create`, and overwriting an existing filesystem there is gated twice: the executor refuses unless the spec carries `force: true`, and the TUI only re-submits with `force` after the operator accepts the destruction consent (§3.3).
 - They do not export the same path twice. `add_export` removes any existing entry with the same `path` before appending the new one — there is exactly one rule per path at any time.
 
 ## 9. Dialog conventions — informational vs consent

--- a/tests/test_fs_overview.py
+++ b/tests/test_fs_overview.py
@@ -1,4 +1,10 @@
+import inspect
+from pathlib import Path
+
 from xinas_menu.screens.filesystem import _format_filesystems
+
+_REPO = Path(__file__).resolve().parent.parent
+_FS_SCREEN = _REPO / "xinas_menu/screens/filesystem.py"
 
 
 def test_banner_replaces_empty_state():
@@ -27,3 +33,128 @@ def test_rows_render_with_banner():
     out = _format_filesystems(rows, banner="degraded")
     assert "/mnt/data" in out
     assert "degraded" in out
+
+
+# ---- Delete Filesystem teardown (fs-shares-management-spec §3.4,
+#      s8-clients-spec §6) ----
+#
+# The spec used to promise that a failed teardown step re-added the removed
+# shares via nfs.add_export and reported "Rolled back N share(s)". It never
+# did: a step failure stops the sequence and completed steps stay completed.
+# If a rollback is ever added, §3.4 has to be rewritten with it.
+
+
+def test_delete_filesystem_never_restores_a_completed_step():
+    from xinas_menu.screens.filesystem import FilesystemScreen
+
+    src = inspect.getsource(FilesystemScreen._delete_filesystem)
+    for undo in ("add_export", "mount_filesystem", "remount", "rollback(", "Rolled back"):
+        assert undo not in src, f"_delete_filesystem appears to undo a completed step: {undo}"
+
+
+def test_fs_teardown_failure_says_the_sequence_stopped():
+    from xinas_menu.screens.filesystem import FilesystemScreen
+
+    src = inspect.getsource(FilesystemScreen._teardown_failed)
+    assert "remaining steps were not run" in src
+    assert "No cross-step rollback" in src
+    assert "Delete Filesystem — Stopped" in src
+    # Reporting a halt is informational: OK-only, never an unanswerable Yes/No.
+    assert "ok_only=True" in src
+
+
+def test_fs_teardown_uses_the_control_path_endpoints():
+    from xinas_menu.screens.filesystem import FilesystemScreen
+
+    src = inspect.getsource(FilesystemScreen._delete_filesystem)
+    assert "/api/v1/shares/" in src
+    assert "/api/v1/filesystems/" in src
+    assert '"mounted": False' in src
+    assert "app.nfs" not in src
+
+
+def test_filesystem_screen_reads_the_control_path_not_findmnt_or_grpc():
+    # §3.1: the whole screen rides the control path; the direct findmnt /
+    # mkfs / mount-unit helpers and the gRPC client left it.
+    src = _FS_SCREEN.read_text()
+    assert "app.grpc" not in src
+    assert "app.nfs" not in src
+    # No findmnt string literal to hand to a subprocess (the module
+    # docstring mentions it only to say it left).
+    assert '"findmnt"' not in src and "'findmnt'" not in src
+    for helper in ("unmount_filesystem", "mount_filesystem", "update_mount_unit_quota"):
+        assert helper not in src, f"filesystem.py still calls {helper}"
+
+
+# ---- Create wizard: geometry is server-derived (§3.3) ----
+#
+# The spec used to document a client-side calculate_stripe_width /
+# build_mount_options derivation. The screen sends a structured spec and
+# omits su_kb/sw so the api derives them; the flat option string in the
+# summary is display-only.
+
+
+def test_create_wizard_derives_no_geometry_client_side():
+    from xinas_menu.screens.filesystem import FilesystemScreen
+
+    src = inspect.getsource(FilesystemScreen._create_filesystem_wizard)
+    for helper in ("calculate_stripe_width", "calculate_parity_disks", "build_mount_options"):
+        assert helper not in src, f"create wizard computes geometry itself: {helper}"
+    # su_kb is displayed in the summary but must not reach the spec.
+    assert '"su_kb"' not in src and '"sw"' not in src
+
+
+def test_in_use_volumes_cover_log_devices_not_just_backing_devices():
+    # §3.3 pre-check: an array serving as someone's logdev= is as
+    # unavailable as one serving as their data device.
+    from xinas_menu.screens.filesystem import _volumes_in_use
+
+    used = _volumes_in_use(
+        [
+            {
+                "backing_device": "/dev/xi_data",
+                "options": ["rw", "logdev=/dev/xi_log", "noatime"],
+            }
+        ]
+    )
+    assert used == {"/dev/xi_data", "/dev/xi_log"}
+
+
+def test_create_spec_carries_logdev_and_quota_as_structured_fields():
+    from xinas_menu.screens.filesystem import _DEFAULT_MOUNT_OPTIONS, FilesystemScreen
+
+    # logdev= and uquota ride log_device / quota_mode, not mount_options.
+    assert not any("logdev" in o or "quota" in o for o in _DEFAULT_MOUNT_OPTIONS)
+
+    src = inspect.getsource(FilesystemScreen._create_filesystem_wizard)
+    for field in ('"log_device"', '"quota_mode"', '"mount_options"', '"sector_size"'):
+        assert field in src, f"create spec is missing {field}"
+    # The force retry is the only place dangerous consent is submitted.
+    assert "dangerous=True" in src
+
+
+# ---- Manage Quotas: one mode per filesystem (§3.5) ----
+#
+# The API holds a single quota_mode enum, so "Enable Both (user + project)"
+# is gone and enabling one mode replaces the other.
+
+
+def test_quota_toggle_offers_no_enable_both_and_patches_one_intent():
+    from xinas_menu.screens.filesystem import FilesystemScreen
+
+    src = inspect.getsource(FilesystemScreen._manage_quotas)
+    assert "Enable Both" not in src
+    assert '"quota_mode"' in src
+    assert "replaces" in src, "the replace-semantics warning is part of the contract"
+    # One intent key per PATCH — never bundled with mounted/grow.
+    assert '"mounted"' not in src and '"grow"' not in src
+
+
+def test_quota_flags_parse_both_option_spellings():
+    from xinas_menu.screens.filesystem import _quota_flags
+
+    assert _quota_flags(["uquota"]) == {"user": True, "project": False, "group": False}
+    assert _quota_flags(["usrquota"])["user"] is True
+    assert _quota_flags(["prjquota"])["project"] is True
+    assert _quota_flags(["grpquota"])["group"] is True
+    assert _quota_flags(["rw", "noatime"]) == {"user": False, "project": False, "group": False}

--- a/tests/test_nfs_wizard_helpers.py
+++ b/tests/test_nfs_wizard_helpers.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import inspect
+
 from xinas_menu.screens.nfs import (
+    NFSScreen,
+    _format_exports,
     _format_sessions,
     _host_prefill,
+    _parse_current_export,
     _path_prefill,
+    _rows_from_api,
     _xiraid_mount_points,
 )
 
@@ -110,3 +116,201 @@ def test_xiraid_mount_points_none():
 
 def test_xiraid_mount_points_empty_string():
     assert _xiraid_mount_points("") == []
+
+
+# ---- control-path adapter (fs-shares-management-spec §4.2) ----
+#
+# The API keeps sync / security_mode as SHARE-level fields; the renderer and
+# the Edit wizard speak the legacy client-option shape. _rows_from_api folds
+# them back in, so _parse_current_export keeps working unchanged.
+
+
+def _api_share(spec_extra: dict | None = None) -> list[dict]:
+    return [
+        {
+            "id": "mnt/data",
+            "spec": {
+                "path": "/mnt/data",
+                "fsid": 1,
+                "clients": [{"pattern": "10.0.0.0/24", "options": ["rw", "no_root_squash"]}],
+                **(spec_extra or {}),
+            },
+            "status": {},
+        }
+    ]
+
+
+def test_rows_from_api_folds_share_level_sync_and_sec_into_client_options():
+    rows = _rows_from_api(_api_share({"sync": "async", "security_mode": "krb5p"}))
+    assert len(rows) == 1
+    opts = rows[0]["clients"][0]["options"]
+    assert "async" in opts
+    assert "sec=krb5p" in opts
+    # pattern is renamed to the legacy key the renderer/wizard read.
+    assert rows[0]["clients"][0]["host"] == "10.0.0.0/24"
+    assert rows[0]["id"] == "mnt/data"
+
+
+def test_rows_from_api_omits_sec_for_the_default_security_mode():
+    rows = _rows_from_api(_api_share({"sync": "sync", "security_mode": "sys"}))
+    opts = rows[0]["clients"][0]["options"]
+    assert not any(o.startswith("sec=") for o in opts)
+
+
+def test_rows_from_api_does_not_duplicate_an_option_already_present():
+    rows = _rows_from_api(
+        [
+            {
+                "id": "mnt/data",
+                "spec": {
+                    "path": "/mnt/data",
+                    "clients": [{"pattern": "*", "options": ["rw", "sync"]}],
+                    "sync": "sync",
+                },
+            }
+        ]
+    )
+    assert rows[0]["clients"][0]["options"].count("sync") == 1
+
+
+def test_rows_from_api_drops_pathless_and_malformed_docs():
+    assert _rows_from_api([{"id": "x", "spec": {"clients": []}}]) == []
+    assert _rows_from_api(["not-a-dict", {"id": "y"}]) == []
+    assert _rows_from_api("not-a-list") == []
+
+
+def test_adapter_output_round_trips_through_the_edit_parser():
+    # §4.6 depends on this: the wizard reads its five fields back out of the
+    # adapted row, not out of the API doc.
+    rows = _rows_from_api(_api_share({"sync": "async", "security_mode": "krb5"}))
+    parsed = _parse_current_export(rows[0])
+    assert parsed["host"] == "10.0.0.0/24"
+    assert parsed["access"] == "rw"
+    assert parsed["root_squash"] == "no_root_squash"
+    assert parsed["sync_mode"] == "async"
+    assert parsed["sec"] == "krb5"
+
+
+# ---- share writes ride the control path (§4.1, §4.5–4.7) ----
+
+
+def test_share_writes_use_plan_apply_wait_not_the_helper_socket():
+    for name, method, verb in (
+        ("add", NFSScreen._add_share_wizard, "POST"),
+        ("edit", NFSScreen._edit_share, "PATCH"),
+        ("remove", NFSScreen._remove_share, "DELETE"),
+    ):
+        src = inspect.getsource(method)
+        assert "plan_apply_wait" in src, f"{name} does not go through plan/apply"
+        assert verb in src, f"{name} does not use {verb}"
+        assert "/api/v1/shares" in src
+        for op in ("add_export(", "update_export(", "remove_export(", "app.nfs"):
+            assert op not in src, f"{name} still calls the helper socket: {op}"
+
+
+def test_share_ids_are_percent_encoded_on_every_addressed_path():
+    # An NfsShare id carries internal slashes (encExportId), so a raw id 404s.
+    for method in (NFSScreen._edit_share, NFSScreen._remove_share):
+        src = inspect.getsource(method)
+        assert "quote_id(" in src, f"{method.__name__} addresses a share id unencoded"
+
+
+def test_remove_share_passes_no_dangerous_flag():
+    # Risk class is changing_access; the single confirmation is the gate.
+    src = inspect.getsource(NFSScreen._remove_share)
+    assert "dangerous=True" not in src
+
+
+def test_edit_sends_security_mode_unconditionally_but_add_does_not():
+    # §4.6: an omitted PATCH field means "leave alone", so Edit must always
+    # send security_mode or sec=krb5 could never be cleared. Add only sets it
+    # when the operator chose something other than the default.
+    add = inspect.getsource(NFSScreen._add_share_wizard)
+    edit = inspect.getsource(NFSScreen._edit_share)
+    assert 'spec["security_mode"] = sec' in add
+    assert 'if sec != "sys"' in add
+    assert '"security_mode": sec' in edit
+    # Edit's `if sec != "sys"` is the confirmation summary's display list,
+    # never the patch — the patch block must not be conditional on it.
+    patch_block = edit.split("patch: dict[str, Any] = {", 1)[1].split("try:", 1)[0]
+    assert "security_mode" in patch_block
+    assert "if " not in patch_block
+
+
+def test_add_share_keeps_sync_and_sec_out_of_the_client_options():
+    # They are share-level spec fields; _rows_from_api folds them back on read.
+    src = inspect.getsource(NFSScreen._add_share_wizard)
+    assert '"options": [access, root_squash, "no_subtree_check"]' in src
+    assert '"sync": sync_mode' in src
+
+
+# ---- Show: empty is empty, degraded says so (§4.2) ----
+#
+# The renderer used to parse /etc/exports whenever the row list came back
+# empty. Under the control path an empty list means the api observed no
+# shares — and the collector reads /etc/exports itself — so the fallback
+# could only present unmanaged file contents as the managed share list.
+
+
+def test_empty_share_list_renders_an_empty_state_not_etc_exports():
+    out = _format_exports([])
+    assert "no NFS shares configured" in out
+
+
+def test_renderer_never_reads_etc_exports():
+    # No path literal to open. (The prose comment naming the removed fallback
+    # is fine; a quoted path is what a read would need. The renderer does
+    # still open /proc/fs/nfsd/clients/*/info for the Connected-hosts block.)
+    src = inspect.getsource(_format_exports)
+    assert '"/etc/exports"' not in src and "'/etc/exports'" not in src
+
+
+def test_degraded_banner_replaces_the_empty_state():
+    out = _format_exports([], banner="NFS backend unavailable")
+    assert "NFS backend unavailable" in out
+    assert "no NFS shares configured" not in out
+
+
+def test_degraded_banner_shows_above_rows_when_some_are_observed():
+    rows = _rows_from_api(_api_share({"sync": "sync"}))
+    out = _format_exports(rows, banner="NFS backend unavailable")
+    assert "NFS backend unavailable" in out
+    assert "/mnt/data" in out
+
+
+def test_no_banner_keeps_the_plain_empty_state():
+    assert "backend" not in _format_exports([]).lower()
+
+
+def test_load_exports_reads_the_envelope_for_warnings():
+    # control.get, not control.result — .result discards the warnings that
+    # carry DEGRADED_BACKEND_UNAVAILABLE.
+    src = inspect.getsource(NFSScreen._load_exports)
+    assert "control.get" in src
+    assert "degraded_banner" in src
+
+
+# ---- fsid allocation fails closed (§4.5) ----
+#
+# Share.spec.fsid is required by the API, so the TUI must allocate. A
+# swallowed read error made max(used, default=0)+1 restart at 1 and collide
+# with every existing share.
+
+
+def test_get_exports_propagates_a_control_path_error():
+    src = inspect.getsource(NFSScreen._get_exports)
+    assert "except ControlPathError" not in src, "_get_exports must not swallow the read failure"
+
+
+def test_add_share_aborts_when_the_existing_shares_cannot_be_read():
+    src = inspect.getsource(NFSScreen._add_share_wizard)
+    fsid_block = src.split("used: set[int] = set()", 1)
+    assert len(fsid_block) == 2, "fsid allocation block not found"
+    assert "Could not read existing shares" in fsid_block[1]
+
+
+def test_edit_and_remove_distinguish_unreadable_from_empty():
+    for method in (NFSScreen._edit_share, NFSScreen._remove_share):
+        src = inspect.getsource(method)
+        assert "Could not load shares." in src, f"{method.__name__} reports a failed read as empty"
+        assert "No shares configured." in src

--- a/xinas_menu/screens/nfs.py
+++ b/xinas_menu/screens/nfs.py
@@ -17,6 +17,7 @@ from textual.screen import Screen
 from textual.widgets import Footer, Label
 
 from xinas_menu.api.control_client import ControlPathError, lease_conflict_message, quote_id
+from xinas_menu.api.degraded import degraded_banner
 from xinas_menu.apptype import XiNASAppMixin
 from xinas_menu.utils.xfs_helpers import is_path_under
 from xinas_menu.widgets.confirm_dialog import ConfirmDialog
@@ -153,11 +154,11 @@ class NFSScreen(XiNASAppMixin, Screen):
     async def _load_exports(self) -> None:
         view = self.query_one("#nfs-content", ScrollableTextView)
         try:
-            shares = await asyncio.to_thread(self.app.control.result, "/api/v1/shares")
+            env = await asyncio.to_thread(self.app.control.get, "/api/v1/shares")
         except ControlPathError as exc:
-            view.set_content(f"[yellow]Control API: {exc}[/yellow]")
+            view.set_content(f"Control API: {exc}")
             return
-        view.set_content(_format_exports(_rows_from_api(shares)))
+        view.set_content(_format_exports(_rows_from_api(env.get("result")), degraded_banner(env)))
 
     def on_navigable_menu_selected(self, event: NavigableMenu.Selected) -> None:
         key = event.key
@@ -177,11 +178,13 @@ class NFSScreen(XiNASAppMixin, Screen):
             self._configure_idmapd()
 
     async def _get_exports(self) -> list[dict]:
-        """Fetch shares from the control-path API, adapted to legacy rows."""
-        try:
-            shares = await asyncio.to_thread(self.app.control.result, "/api/v1/shares")
-        except ControlPathError:
-            return []
+        """Fetch shares from the control-path API, adapted to legacy rows.
+
+        Raises ControlPathError. Callers MUST NOT degrade a failed read to
+        "no shares": Add allocates the next fsid from this list, and an
+        empty-looking list restarts numbering at 1 against a live host.
+        """
+        shares = await asyncio.to_thread(self.app.control.result, "/api/v1/shares")
         return [e for e in _rows_from_api(shares) if e.get("path") and e.get("id")]
 
     def _task_progress(self, label: str):
@@ -541,8 +544,23 @@ class NFSScreen(XiNASAppMixin, Screen):
             )
             return
 
+        # fsid is REQUIRED by the API and allocated here, so this read must
+        # be authoritative — allocating from a swallowed error would restart
+        # at 1 and collide with every existing share.
         used: set[int] = set()
-        for row in await self._get_exports():
+        try:
+            existing = await self._get_exports()
+        except ControlPathError as exc:
+            await self.app.push_screen_wait(
+                ConfirmDialog(
+                    f"Could not read existing shares, so a new export id "
+                    f"cannot be allocated safely.\n\n{exc}",
+                    "Error",
+                    ok_only=True,
+                )
+            )
+            return
+        for row in existing:
             fsid = row.get("fsid")
             if isinstance(fsid, int):
                 used.add(fsid)
@@ -574,7 +592,13 @@ class NFSScreen(XiNASAppMixin, Screen):
     @work(exclusive=True)
     async def _edit_share(self) -> None:
         """7-step edit share wizard with Back navigation."""
-        exports = await self._get_exports()
+        try:
+            exports = await self._get_exports()
+        except ControlPathError as exc:
+            await self.app.push_screen_wait(
+                ConfirmDialog(f"Could not load shares.\n{exc}", "Edit Share", ok_only=True)
+            )
+            return
         if not exports:
             await self.app.push_screen_wait(
                 ConfirmDialog("No shares configured.", "Edit Share", ok_only=True)
@@ -692,7 +716,13 @@ class NFSScreen(XiNASAppMixin, Screen):
 
     @work(exclusive=True)
     async def _remove_share(self) -> None:
-        exports = await self._get_exports()
+        try:
+            exports = await self._get_exports()
+        except ControlPathError as exc:
+            await self.app.push_screen_wait(
+                ConfirmDialog(f"Could not load shares.\n{exc}", "Remove Share", ok_only=True)
+            )
+            return
         if not exports:
             await self.app.push_screen_wait(
                 ConfirmDialog("No shares configured.", "Remove Share", ok_only=True)
@@ -887,8 +917,8 @@ def _parse_current_export(export: dict) -> dict:
     }
 
 
-def _format_exports(data: Any) -> str:
-    """Format NFS exports — uses socket data if available, falls back to /etc/exports."""
+def _format_exports(data: Any, banner: str | None = None) -> str:
+    """Render adapted share rows; a banner replaces the empty-state."""
     import os
     import shlex
     import subprocess
@@ -975,52 +1005,43 @@ def _format_exports(data: Any) -> str:
     lines.append(f"  {DIM}NFS allows other hosts to access folders on this server.{NC}")
     lines.append("")
 
-    # Build list of (path, raw_client_strings) from socket data or /etc/exports
+    if banner:
+        lines.append(f"  {RED}⚠ {banner}{NC}")
+        lines.append("")
+
+    # Build list of (path, raw_client_strings) from the adapted API rows.
+    # There is deliberately NO /etc/exports fallback: an empty list means the
+    # api observed no shares, and its collector reads /etc/exports itself —
+    # so parsing the file here could only present unmanaged contents as the
+    # managed share list (spec §4.2).
     shares: list[tuple[str, list[str]]] = []
 
-    if data and isinstance(data, list):
-        for exp in data:
-            if not isinstance(exp, dict):
-                continue
-            path = exp.get("path", "")
-            clients = exp.get("clients", [])
-            if not path:
-                continue
-            # clients may be [{"host": "*", "options": [...]}] or ["host(opts)"]
-            raw: list[str] = []
-            client_specs: list = clients or [{"host": "*", "options": []}]
-            for c in client_specs:
-                if isinstance(c, dict):
-                    host = c.get("host", "*")
-                    opts = c.get("options", [])
-                    raw.append(f"{host}({','.join(opts)})" if opts else host)
-                else:
-                    raw.append(str(c))
-            shares.append((path, raw))
-    else:
-        # Fallback: read /etc/exports directly
-        exports_file = "/etc/exports"
-        try:
-            with open(exports_file) as f:
-                for line in f:
-                    line = line.strip()
-                    if not line or line.startswith("#"):
-                        continue
-                    parts = line.split()
-                    if parts:
-                        shares.append((parts[0], parts[1:]))
-        except FileNotFoundError:
-            lines.append("  /etc/exports not found — NFS may not be configured.")
-            lines.append("")
-            return "\n".join(lines)
-        except Exception as exc:
-            lines.append(f"  Error reading /etc/exports: {exc}")
-            return "\n".join(lines)
+    for exp in data if isinstance(data, list) else []:
+        if not isinstance(exp, dict):
+            continue
+        path = exp.get("path", "")
+        clients = exp.get("clients", [])
+        if not path:
+            continue
+        # clients may be [{"host": "*", "options": [...]}] or ["host(opts)"]
+        raw: list[str] = []
+        client_specs: list = clients or [{"host": "*", "options": []}]
+        for c in client_specs:
+            if isinstance(c, dict):
+                host = c.get("host", "*")
+                opts = c.get("options", [])
+                raw.append(f"{host}({','.join(opts)})" if opts else host)
+            else:
+                raw.append(str(c))
+        shares.append((path, raw))
 
     if not shares:
-        lines.append(f"  {DIM}No shares configured.{NC}")
-        lines.append("")
-        lines.append(f"  Use {GRN}'Add Share'{NC} to create an NFS export.")
+        # A degraded backend must never read as "genuinely none" — the
+        # banner above already said so, so don't contradict it.
+        if not banner:
+            lines.append(f"  {DIM}(no NFS shares configured){NC}")
+            lines.append("")
+            lines.append(f"  Use {GRN}'Add Share'{NC} to create an NFS export.")
         lines.append("")
         return "\n".join(lines)
 


### PR DESCRIPTION
Cherry-picked from #283 (`2713b1b`), which cannot be merged as it stands: its other commit tightens array names to the API's 63-character pattern, and `main` already enforces xiRAID's real rule of 28 characters without hyphens (#282, #281). Landing that branch whole would loosen a rule that shipped hours ago. This PR takes the NFS half, which is not superseded by anything and applies to current `main` with no conflicts.

## The bug

Two honesty defects on the NFS screen, both left over from the control-path migration.

**Show NFS Exports** parsed `/etc/exports` and displayed its contents as the share list whenever the adapted row list came back empty. That was right when the helper socket was the read path and an empty result meant the socket had failed. Under the control path an empty result means the api observed no shares — and its collector reads `/etc/exports` itself, so anything genuinely exported would already have come back as a row. All the fallback could still do was present unmanaged file contents as the managed share list.

**`_get_exports()`** swallowed `ControlPathError` into an empty list. Add Share allocates the next fsid as `max(used, default=0) + 1` from that list, so a failed read did not just hide the shares — it made the wizard propose an fsid that was already taken.

## The fix

The empty case now renders an explicit empty state, and the screen adopts the degraded-backend contract the Filesystem and RAID screens already use: fetch the envelope with `control.get` and let a `DEGRADED_BACKEND_UNAVAILABLE` warning render a banner in place of the empty state, so an unobservable backend never reads as "no shares". `_get_exports()` propagates the error instead of returning `[]`.

Same class of defect as #277 and #280, in a third screen: a read that cannot answer was being reported as an answer of "nothing".

## Verification

`pytest` 818 passed · `ruff check` / `format --check` · `markdownlint` 0 issues. `xinas_menu/screens/nfs.py` merged cleanly onto current `main`; the spec and both test files came across untouched.

## Not included

`7dfb63e` from #283 also rewrote parts of `docs/Storage/raid-management-spec.md` — the §6.4 rollback promise, the gRPC-vs-control-path descriptions in §6.1/6.3/6.5, and the spare-pool RPC table in §7. #281 corrected some of that ground independently; the remainder has not been re-checked against current `main` and is deliberately left out of this PR rather than merged blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)