### PR TITLE
fix(agent): carrier-down interface defers verify instead of failing the pool

### DIFF
--- a/docs/control-path/s6-network-spec.md
+++ b/docs/control-path/s6-network-spec.md
@@ -211,6 +211,41 @@ mixed-revision pool (A at rev 3, B at rev 7) applies cleanly;
 `metadata.revision` overlaid from the desired row when present
 (ADR-0008 §read model).
 
+### 4.4 Verify stage — carrier-aware (shared by §4.1/§4.2)
+
+The final `verify` stage reads `ip -j addr show` and, for each target
+interface, confirms every desired address is live and — when the target
+has addresses — that its PBR rule is installed. The read is **polled**
+until the desired state appears or a settle budget runs out (15 s,
+re-read every 250 ms; both overridable per executor), because `netplan
+apply` returns before systemd-networkd has finished reconfiguring.
+Beyond a plain pass, it distinguishes two outcomes:
+
+- **Carrier-down ⇒ deferred, not failed.** An IPoIB interface whose link
+  is not up (`ip -j addr` reports the `NO-CARRIER` flag / no `LOWER_UP`,
+  `operstate` `DOWN`) cannot bind its address until the port trains — the
+  netplan is correct, the address is merely pending. Verify treats a
+  missing address on a carrier-down interface as **deferred** and does
+  NOT throw; the PBR-rule check is likewise skipped for that interface
+  (the source rule only installs once the address is live). The address
+  binds automatically when carrier returns — no re-apply needed. The
+  deferral is decided on the first read, without waiting out the settle
+  budget: polling cannot train a dead link, and a pool of down ports
+  would otherwise stall the apply by the full budget per interface.
+- **Carrier-up ⇒ strict.** A carrier-up interface (`LOWER_UP`) still
+  missing a desired address, or missing its PBR rule, is a real apply
+  failure and throws
+  `verify: <dev> is missing <cidr> after apply (live: …)` /
+  `verify: no PBR rule for table <id> after apply` → rollback.
+
+Consequence for `net.pool.apply` (§4.2): the pool verify loops over ALL
+managed interfaces, so a single dead port would otherwise throw and roll
+the WHOLE pool back, reverting every healthy interface too. With
+carrier-aware verify a down port is deferred and the pool apply commits
+the healthy interfaces; the down port's address binds when its link comes
+up. The executor emits a `deferred (no carrier …): <devs>` progress line
+naming the deferred interfaces.
+
 ---
 
 ## 5. NetHost seam (T4)
@@ -241,7 +276,11 @@ the flush verbs are what remove); `netplanGenerate` rejects when any file
 fails YAML parse or a stanza has no addresses while enabled
 (deterministic `-invalid` hook: a file containing the string
 `INVALID-NETPLAN` rejects). `-fail` stem hooks on `netplanApply` /
-`ipAddrFlush` targets for rollback paths.
+`ipAddrFlush` targets for rollback paths. A `sys_class_net` entry marked
+`no_carrier: true` models a link-down interface: `ipAddrShow` reports it
+with the `NO-CARRIER` flag / `operstate DOWN`, and `netplanApply` does
+NOT bind its addresses or PBR rule (the kernel can't program a down
+link) — the fixture for the carrier-aware verify deferral in §4.4.
 
 ## 6. Observe enrichment (T5)
 

--- a/xiNAS-MCP/src/__tests__/agent/task/net-executor.test.ts
+++ b/xiNAS-MCP/src/__tests__/agent/task/net-executor.test.ts
@@ -218,6 +218,40 @@ describe('net.iface.update executor', () => {
     await executor.rollback(ctx).catch(() => {});
     expect(host.files()[XINAS_NETPLAN]).toBe(PRIOR_XINAS);
   });
+
+  it('carrier-down target is DEFERRED, not failed (config committed, no rollback)', async () => {
+    // The target's IB link is down (NO-CARRIER) — netplan is correct but the
+    // kernel can't bind the address until the port trains. Defer, don't fail.
+    writeFileSync(
+      join(dir, 'net-host-state.json'),
+      JSON.stringify({
+        netplan_files: {
+          [XINAS_NETPLAN]: PRIOR_XINAS,
+          '/etc/netplan/50-cloud-init.yaml': CLOUD_INIT,
+        },
+        kernel: { addrs: {}, rules: [], tables: {} },
+        sys_class_net: [
+          { name: 'ibp65s0', driver: 'mlx5_core', no_carrier: true },
+          { name: 'ibp9s0f0', driver: 'mlx5_core' },
+          { name: 'eno1', driver: 'igb' },
+        ],
+        rdma_links: [],
+        ops: [],
+      }),
+    );
+    host = createFakeNetHost(dir);
+    await host.netplanApply();
+    const hash = netplanHashes(await host.readNetplanDir()).world_config_hash;
+
+    const executor = makeNetIfaceUpdateExecutor({ host });
+    const ctx = makeCtx(spec({ world_config_hash: hash }));
+    await runAll(executor, ctx);
+
+    // config committed (not rolled back), address deferred (never bound)
+    expect(host.files()[XINAS_NETPLAN]).toBe(NEW_RENDER);
+    expect(host.kernel().addrs.ibp65s0 ?? []).toEqual([]);
+    expect(ctx.lines.some((l) => l.includes('deferred') && l.includes('ibp65s0'))).toBe(true);
+  });
 });
 
 describe('net.pool.apply executor', () => {
@@ -272,5 +306,75 @@ describe('net.pool.apply executor', () => {
     expect(ops).toContain('ip-route-flush-table:101');
     expect(host.kernel().addrs.ibp65s0).toEqual(['10.20.1.1/24']);
     expect(host.kernel().addrs.ibp9s0f0).toEqual(['10.20.2.1/24']);
+  });
+
+  it('one carrier-down port is DEFERRED — healthy interfaces still apply, no whole-pool rollback', async () => {
+    // The "dead cable in the pool" case: ibp9s0f1's port is link-down. Before
+    // carrier-aware verify, its missing address threw and rolled the WHOLE
+    // pool back, reverting the healthy interface too.
+    writeFileSync(
+      join(dir, 'net-host-state.json'),
+      JSON.stringify({
+        netplan_files: { [XINAS_NETPLAN]: PRIOR_XINAS },
+        kernel: { addrs: {}, rules: [], tables: {} },
+        sys_class_net: [
+          { name: 'ibp65s0', driver: 'mlx5_core' },
+          { name: 'ibp9s0f1', driver: 'mlx5_core', no_carrier: true },
+          { name: 'eno1', driver: 'igb' },
+        ],
+        rdma_links: [],
+        ops: [],
+      }),
+    );
+    host = createFakeNetHost(dir);
+    await host.netplanApply();
+
+    const render = renderNetplan([
+      { name: 'ibp65s0', addresses: ['10.20.1.1/24'], enabled: true, pbr_table_id: 100 },
+      { name: 'ibp9s0f1', addresses: ['10.20.9.1/24'], enabled: true, pbr_table_id: 109 },
+    ]);
+    const executor = makeNetPoolApplyExecutor({ host });
+    const ctx = makeCtx({
+      render,
+      world_config_hash: netplanHashes(await host.readNetplanDir()).world_config_hash,
+      cleanup_files: {},
+      targets: [
+        { dev: 'ibp65s0', addresses: ['10.20.1.1/24'], pbr_table_id: 100 },
+        { dev: 'ibp9s0f1', addresses: ['10.20.9.1/24'], pbr_table_id: 109 },
+      ],
+    });
+    for (const stage of executor.stages) await stage.run(ctx);
+
+    // healthy interface applied; dead port deferred (no address bound)
+    expect(host.kernel().addrs.ibp65s0).toEqual(['10.20.1.1/24']);
+    expect(host.kernel().addrs.ibp9s0f1 ?? []).toEqual([]);
+    // committed — NOT rolled back to the prior file
+    expect(host.files()[XINAS_NETPLAN]).toBe(render);
+    expect(ctx.lines.some((l) => l.includes('deferred') && l.includes('ibp9s0f1'))).toBe(true);
+  });
+
+  it('carrier-UP target missing its address still hard-fails (strictness preserved)', async () => {
+    // Both interfaces are UP; the render only assigns ibp65s0, so ibp9s0f0 is
+    // carrier-up yet never gets its address → a real apply failure, not deferred.
+    // A carrier-up miss is polled for the full settle budget before it throws,
+    // so cap the budget rather than making the suite wait it out.
+    const render = renderNetplan([
+      { name: 'ibp65s0', addresses: ['10.20.1.1/24'], enabled: true, pbr_table_id: 100 },
+    ]);
+    const executor = makeNetPoolApplyExecutor({ host, settleMs: 5, pollMs: 1 });
+    const ctx = makeCtx({
+      render,
+      world_config_hash: netplanHashes(await host.readNetplanDir()).world_config_hash,
+      cleanup_files: {},
+      targets: [
+        { dev: 'ibp65s0', addresses: ['10.20.1.1/24'], pbr_table_id: 100 },
+        { dev: 'ibp9s0f0', addresses: ['10.20.2.1/24'], pbr_table_id: 101 },
+      ],
+    });
+    await expect(
+      (async () => {
+        for (const stage of executor.stages) await stage.run(ctx);
+      })(),
+    ).rejects.toThrow(/ibp9s0f0 is missing 10\.20\.2\.1\/24 after apply/);
   });
 });

--- a/xiNAS-MCP/src/agent/net/fake-host.ts
+++ b/xiNAS-MCP/src/agent/net/fake-host.ts
@@ -37,7 +37,9 @@ interface FakeKernel {
 interface FakeNetState {
   netplan_files: Record<string, string>;
   kernel: FakeKernel;
-  sys_class_net: Array<{ name: string; driver: string }>;
+  // `no_carrier: true` models a link-down interface: netplanApply won't bind
+  // its addresses/PBR rule and ipAddrShow reports it NO-CARRIER / operstate DOWN.
+  sys_class_net: Array<{ name: string; driver: string; no_carrier?: boolean }>;
   rdma_links: Array<{ ifname: string; state: string; physical_state: string }>;
   ops: string[];
 }
@@ -140,10 +142,16 @@ export function createFakeNetHost(dir: string): NetHost & FakeNetHostHandle {
         }
       }
       const parsed = parsedOrThrow(state);
+      // A link-down interface never binds its config: the kernel can't
+      // program addresses/rules on an interface without carrier.
+      const downIfaces = new Set(
+        state.sys_class_net.filter((i) => i.no_carrier).map((i) => i.name),
+      );
       // ADD-ONLY kernel programming (the real netplan-apply quirk):
       // configured addresses/rules/routes are added; stale ones survive
       // until the flush verbs remove them.
       for (const [iface, stanza] of Object.entries(parsed.stanzas)) {
+        if (downIfaces.has(iface)) continue;
         const addrs = (state.kernel.addrs[iface] ??= []);
         for (const cidr of stanza.addresses) {
           if (!addrs.includes(cidr)) addrs.push(cidr);
@@ -209,7 +217,10 @@ export function createFakeNetHost(dir: string): NetHost & FakeNetHostHandle {
       const state = load(dir);
       const json = state.sys_class_net.map((iface) => ({
         ifname: iface.name,
-        operstate: 'UP',
+        operstate: iface.no_carrier ? 'DOWN' : 'UP',
+        flags: iface.no_carrier
+          ? ['NO-CARRIER', 'BROADCAST', 'MULTICAST', 'UP']
+          : ['BROADCAST', 'MULTICAST', 'UP', 'LOWER_UP'],
         addr_info: (state.kernel.addrs[iface.name] ?? []).map((cidr) => ({
           family: 'inet',
           local: cidr.split('/')[0],

--- a/xiNAS-MCP/src/agent/task/net-executor.ts
+++ b/xiNAS-MCP/src/agent/task/net-executor.ts
@@ -216,14 +216,36 @@ export interface VerifySettleOptions {
   sleep?: (ms: number) => Promise<void>;
 }
 
-/** Live CIDRs on `dev`, from `ip -j addr show`. */
-async function liveAddresses(host: NetHost, dev: string): Promise<string[]> {
+/**
+ * Does `ip -j addr` report this interface as carrying link? A NO-CARRIER
+ * (down) IPoIB port can't bind its address until it trains, so verify must
+ * not treat that as a failure. Prefer the kernel flags (`LOWER_UP` ⇔ carrier,
+ * `NO-CARRIER` its negation); fall back to `operstate` for older `ip`. When
+ * neither is reported, assume carrier so the strict path is preserved.
+ */
+function ifaceHasCarrier(entry: { operstate?: string; flags?: string[] }): boolean {
+  const flags = entry.flags ?? [];
+  if (flags.includes('NO-CARRIER')) return false;
+  if (flags.includes('LOWER_UP')) return true;
+  return entry.operstate !== 'DOWN' && entry.operstate !== 'LOWERLAYERDOWN';
+}
+
+/** Live CIDRs and carrier state on `dev`, from `ip -j addr show`. */
+async function liveState(
+  host: NetHost,
+  dev: string,
+): Promise<{ live: string[]; hasCarrier: boolean }> {
   const parsed = JSON.parse(await host.ipAddrShow()) as Array<{
     ifname?: string;
+    operstate?: string;
+    flags?: string[];
     addr_info?: Array<{ local?: string; prefixlen?: number }>;
   }>;
   const entry = parsed.find((e) => e.ifname === dev);
-  return (entry?.addr_info ?? []).map((a) => `${a.local}/${a.prefixlen}`);
+  return {
+    live: (entry?.addr_info ?? []).map((a) => `${a.local}/${a.prefixlen}`),
+    hasCarrier: entry !== undefined && ifaceHasCarrier(entry),
+  };
 }
 
 /**
@@ -235,6 +257,13 @@ async function liveAddresses(host: NetHost, dev: string): Promise<string[]> {
  * absent and networkd re-added it ~0.4 s later. A single immediate read
  * therefore observed the post-flush empty state and failed every legitimate
  * change, rolling it back — the apply path could never succeed.
+ *
+ * Returns `'deferred'` when the interface has no carrier and its address
+ * hasn't bound yet — the netplan is correct, the bind is merely pending the
+ * link, so one dead port does not fail (and roll back) the whole apply. That
+ * verdict is reached without waiting out the settle budget: polling cannot
+ * make a dead port train, and a pool of them would otherwise stall the apply
+ * for settleMs per interface.
  */
 async function verifyDev(
   host: NetHost,
@@ -243,8 +272,8 @@ async function verifyDev(
   tableId: number,
   enabled: boolean,
   opts: VerifySettleOptions = {},
-): Promise<void> {
-  if (!enabled) return; // disabled iface: flushed is the desired end state
+): Promise<'ok' | 'deferred'> {
+  if (!enabled) return 'ok'; // disabled iface: flushed is the desired end state
   const settleMs = opts.settleMs ?? VERIFY_SETTLE_MS;
   const pollMs = opts.pollMs ?? VERIFY_POLL_MS;
   const sleep =
@@ -257,14 +286,23 @@ async function verifyDev(
   let ruleMissing = false;
 
   for (;;) {
-    live = await liveAddresses(host, dev);
+    const state = await liveState(host, dev);
+    live = state.live;
     missing = addresses.find((cidr) => !live.includes(cidr));
     ruleMissing = false;
     if (missing === undefined) {
-      if (addresses.length === 0) return;
+      if (addresses.length === 0) return 'ok';
+      // No carrier: the source rule can't install without a bound address on a
+      // live port, so the rule check can't speak to correctness here.
+      if (!state.hasCarrier) return 'ok';
       const rules = await host.ipRuleShow();
-      if (rules.includes(`lookup ${tableId}`)) return;
+      if (rules.includes(`lookup ${tableId}`)) return 'ok';
       ruleMissing = true;
+    } else if (!state.hasCarrier) {
+      // Link down: the address (and its source PBR rule) can't program until
+      // the port carries. Defer instead of failing; it binds when carrier
+      // returns. No point polling — the settle budget can't train a dead link.
+      return 'deferred';
     }
     if (Date.now() >= deadline) break;
     await sleep(pollMs);
@@ -278,6 +316,7 @@ async function verifyDev(
   if (ruleMissing) {
     throw new Error(`verify: no PBR rule for table ${tableId} after apply (waited ${settleMs}ms)`);
   }
+  return 'ok';
 }
 
 export function makeNetIfaceUpdateExecutor(
@@ -324,7 +363,7 @@ export function makeNetIfaceUpdateExecutor(
     name: 'verify',
     async run(ctx: ExecutorContext): Promise<void> {
       const spec = narrowUpdateSpec(ctx);
-      await verifyDev(
+      const outcome = await verifyDev(
         host,
         spec.surgical.dev,
         spec.desired?.addresses ?? [],
@@ -332,7 +371,13 @@ export function makeNetIfaceUpdateExecutor(
         spec.desired?.enabled !== false,
         settle,
       );
-      ctx.emitOutput(`verified: ${spec.surgical.dev} matches the desired state`);
+      if (outcome === 'deferred') {
+        ctx.emitOutput(
+          `deferred: ${spec.surgical.dev} has no carrier — address binds when the link trains`,
+        );
+      } else {
+        ctx.emitOutput(`verified: ${spec.surgical.dev} matches the desired state`);
+      }
     },
   };
 
@@ -414,10 +459,20 @@ export function makeNetPoolApplyExecutor(opts: { host: NetHost } & VerifySettleO
         name: 'verify',
         async run(ctx: ExecutorContext): Promise<void> {
           const spec = narrowPoolSpec(ctx);
+          const deferred: string[] = [];
           for (const t of spec.targets) {
-            await verifyDev(host, t.dev, t.addresses, t.pbr_table_id, true, settle);
+            const outcome = await verifyDev(host, t.dev, t.addresses, t.pbr_table_id, true, settle);
+            if (outcome === 'deferred') deferred.push(t.dev);
           }
-          ctx.emitOutput(`verified: ${spec.targets.length} interface(s) match the pool`);
+          if (deferred.length > 0) {
+            ctx.emitOutput(
+              `deferred (no carrier, binds when the link trains): ${deferred.join(', ')}`,
+            );
+          }
+          ctx.emitOutput(
+            `verified: ${spec.targets.length} interface(s) match the pool` +
+              (deferred.length > 0 ? ` (${deferred.length} deferred)` : ''),
+          );
         },
       },
     ],


### PR DESCRIPTION
## Summary

Recovered from the stale branch `worktree-net-verify-carrier-aware` (10 Jul), which never landed. The fix is not in `main`: `xiNAS-MCP/src/agent/` contains no reference to carrier at all.

The net executor's post-apply verify treated a missing address as a hard failure. A link-down IPoIB port (`NO-CARRIER`) in a `net.pool.apply` therefore threw and rolled the **whole pool** back, reverting every healthy interface with it. The netplan was correct — the kernel simply cannot bind an address on a port that has not trained.

`verifyDev` is now carrier-aware and returns `'ok' | 'deferred'`:

- **carrier-down + address not bound → deferred**, not failed. Its PBR-rule check is skipped too, since the source rule cannot install without the address.
- **carrier-up + address still missing (or rule missing) → throws**, exactly as before. Strictness is preserved where it means something.
- The pool verify collects deferrals instead of aborting on the first, so healthy interfaces commit and only the dead port is deferred. Both verify stages emit a `deferred …` progress line.

## Reconciliation with current main

The original commit predates the polling verify `main` gained since (`VERIFY_SETTLE_MS`, re-read every 250 ms). This is not a straight cherry-pick — the two were merged rather than one side taken:

- `verifyDev` keeps the settle budget and its poll loop, and additionally returns `'deferred'`.
- A carrier-down miss short-circuits on the **first** read instead of waiting the budget out — polling cannot train a dead link, and a pool of down ports would otherwise stall the apply by the full budget per interface.
- The carrier-up hard-fail test now caps `settleMs`, since that path is polled to the deadline before it throws.

## Spec

`docs/control-path/s6-network-spec.md` §4.4 defines the carrier-aware rule and its consequence for `net.pool.apply`; §5 documents the fake-host `no_carrier` hook. §4.4 also now documents the settle polling itself, which `main` shipped without any spec coverage.

## Verification

From `xiNAS-MCP/`:

- `npm run typecheck` — clean
- `npm test` — 1444 passed (177 files), including 3 new carrier tests
- `npm run test:contracts` — 8 passed
- `npm run lint` — exit 0 (the 3 warnings on touched files are pre-existing `noNodejsModules` in test imports)
- `npm run format:check` — clean
- `markdownlint-cli2` on the spec — 0 issues

`Requires-Rebuild: xinas_node_build` — the agent runs compiled JS from `dist/`, which is not tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)