### PR TITLE
fix(fs): fail closed when a filesystem's dependencies cannot be read

### DIFF
--- a/docs/Storage/fs-shares-management-spec.md
+++ b/docs/Storage/fs-shares-management-spec.md
@@ -145,7 +145,9 @@ The wizard mirrors what the installer's `raid_fs` role does (see [Installer/raid
 **Pre-check.** Two control-path reads, no `findmnt` and no gRPC:
 
 1. `GET /api/v1/arrays` enumerates arrays (`_arrays_from_api`). A `ControlPathError` here aborts on an OK-only `Failed to query RAID arrays.` dialog.
-2. `GET /api/v1/filesystems` → `_volumes_in_use()` collects every volume path already consumed by a managed filesystem, as a **data device** (`status.backing_device`) *or* as a **log device** (a `logdev=` entry in its effective mount options). Arrays whose `volume_path` is in that set are filtered out. A failure here degrades to an empty set rather than aborting — the wizard then offers arrays that may already be in use, and the executor's preflight is what catches it.
+2. `_unused_arrays(arr_rows)` runs `GET /api/v1/filesystems` → `_volumes_in_use()`, collecting every volume path already consumed by a managed filesystem, as a **data device** (`status.backing_device`) *or* as a **log device** (a `logdev=` entry in its effective mount options). Arrays whose `volume_path` is in that set are filtered out. A `ControlPathError` **aborts** on an OK-only `Create Filesystem — Aborted` dialog.
+
+   That read used to degrade to an empty set, and the failure it enabled ran through the executor rather than stopping at the screen: the wizard offered arrays that already carried a filesystem, the create failed in the agent's `blkid` preflight, and this screen offers a **force retry** as that failure's remedy (§3.3, *force*) — a retry that overwrites the existing filesystem. The preflight held, but a read that never answered was walking the operator toward a destructive dialog.
 
 If fewer than 2 free arrays remain, the wizard aborts with "Filesystem creation requires at least 2 RAID arrays (one for data, one for log)."
 
@@ -204,7 +206,9 @@ Same shape as the RAID-delete teardown in [Storage/raid-management-spec.md §6](
 
 > This picker calls the banner-less `_list_filesystems()`, not `_list_filesystems_with_status()`. Under a degraded backend (`DEGRADED_BACKEND_UNAVAILABLE`) the list arrives empty and the operator is told `No XFS filesystems found.` — the one place in this screen where a degraded read is not distinguished from a genuinely empty one. Show Filesystems (§3.2) does render the banner.
 
-**Dependency check.** `GET /api/v1/shares`; every share whose `spec.path` is under the chosen `mountpoint` (`is_path_under`, not a bare `startswith` — `/mnt/data2` is not under `/mnt/data`) is recorded in `affected_shares` as `{id, path}`. This catches both the root export and any sub-directory exports rooted at the same mount. A `ControlPathError` here degrades to an empty list rather than aborting: the confirmation still appears, with the un-listable shares absent from it. The check is skipped entirely for a filesystem with no mountpoint.
+**Dependency check — fail-closed.** `_shares_on_mountpoint(mountpoint, fs_label)` runs `GET /api/v1/shares`; every share whose `spec.path` is under the chosen `mountpoint` (`is_path_under`, not a bare `startswith` — `/mnt/data2` is not under `/mnt/data`) is recorded in `affected_shares` as `{id, path}`. This catches both the root export and any sub-directory exports rooted at the same mount. The check is skipped for a filesystem with no mountpoint, which returns an empty list: nothing can be rooted under a mountpoint that does not exist.
+
+A `ControlPathError` **aborts the deletion** — `Delete Filesystem — Aborted`, carrying the underlying error and stating that the filesystem was not deleted and nothing was changed — and the flow returns before the first confirmation. It previously degraded to an empty list, which is not the same as an empty answer, and the rest of the flow reads that list as fact twice over: the second `FINAL CONFIRMATION` renders only when it is non-empty, and step 1 iterates it to remove the shares. A control path that was down therefore downgraded the teardown to a single confirmation, skipped the share removal entirely, and unmounted and unmanaged the filesystem under live NFS exports. There is no server-side backstop for this one — the filesystem plan provider carries no share blocker — so this read is the only gate.
 
 **Confirmation.**
 

--- a/tests/test_fs_delete_dependencies.py
+++ b/tests/test_fs_delete_dependencies.py
@@ -1,0 +1,216 @@
+"""Delete Filesystem dependency discovery must fail CLOSED.
+
+Same defect as the Delete Array one fixed in #277, one screen over. The NFS
+shares rooted under a filesystem's mountpoint are read from the control path,
+and that read's failure was swallowed into an empty list. An empty list is not
+"this filesystem has no shares" — it is "nobody knows". The consequences are
+visible in the flow that follows it: the second, ABSOLUTELY-sure confirmation
+renders only `if affected_shares`, and the share-removal step iterates that
+same list. So a control path that is down downgraded the teardown to a single
+confirmation, skipped the share removal, and unmounted + unmanaged the
+filesystem out from under live NFS exports.
+
+`api/plan/providers/filesystem.ts` carries no share-related blocker, so there
+is no server-side backstop for this one.
+
+Storage/fs-shares-management-spec §Delete Filesystem.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+from xinas_menu.api.control_client import ControlPathError
+from xinas_menu.screens.filesystem import FilesystemScreen
+
+_MOUNTPOINT = "/mnt/data"
+_FS_LABEL = "/mnt/data"
+
+
+def _share(sid: str, path: str) -> dict:
+    return {"id": sid, "spec": {"path": path}}
+
+
+class _FakeControl:
+    """`control.result(path)` stub: canned rows or a raised error per path."""
+
+    def __init__(self, rows: dict[str, Any]) -> None:
+        self._rows = rows
+        self.reads: list[str] = []
+
+    def result(self, path: str) -> Any:
+        self.reads.append(path)
+        value = self._rows.get(path, [])
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    def get(self, path: str) -> Any:
+        """Envelope form, as `_list_filesystems_with_status` reads it."""
+        value = self.result(path)
+        return value if isinstance(value, dict) else {"result": value}
+
+
+class _FakeScreen:
+    """Minimal stand-in for the FilesystemScreen `self` the helpers touch."""
+
+    # Real halt renderer + real list adapter, so both are exercised as shipped.
+    _delete_aborted = FilesystemScreen._delete_aborted
+    _list_filesystems = FilesystemScreen._list_filesystems
+    _list_filesystems_with_status = FilesystemScreen._list_filesystems_with_status
+
+    def __init__(self, control: _FakeControl) -> None:
+        self.app = SimpleNamespace(control=control, push_screen_wait=self._push)
+        self.dialogs: list[Any] = []
+
+    async def _push(self, dialog: Any) -> Any:
+        self.dialogs.append(dialog)
+        return True
+
+    @property
+    def messages(self) -> str:
+        return "\n".join(getattr(d, "_message", "") for d in self.dialogs)
+
+    @property
+    def titles(self) -> str:
+        return "\n".join(getattr(d, "_title", "") for d in self.dialogs)
+
+
+def _discover(control: _FakeControl, mountpoint: str = _MOUNTPOINT):
+    screen = _FakeScreen(control)
+    found = asyncio.run(FilesystemScreen._shares_on_mountpoint(screen, mountpoint, _FS_LABEL))
+    return found, screen
+
+
+# ── the defect ────────────────────────────────────────────────────────────────
+
+
+def test_share_read_failure_aborts_the_teardown():
+    control = _FakeControl({"/api/v1/shares": ControlPathError("503 control path unavailable")})
+    found, screen = _discover(control)
+
+    assert found is None, "a failed shares read must abort, not read as 'no shares'"
+    assert "503 control path unavailable" in screen.messages
+    # The operator has to be told the filesystem survived untouched.
+    assert "not" in screen.messages.lower() and "delet" in screen.messages.lower()
+
+
+def test_abort_names_the_filesystem_and_changes_nothing():
+    control = _FakeControl({"/api/v1/shares": ControlPathError("connection refused")})
+    found, screen = _discover(control)
+
+    assert found is None
+    assert _FS_LABEL in screen.messages
+    assert control.reads == ["/api/v1/shares"], "nothing else may be touched after the abort"
+
+
+# ── the behaviour that must survive the fix ───────────────────────────────────
+
+
+def test_shares_under_the_mountpoint_are_returned():
+    control = _FakeControl(
+        {
+            "/api/v1/shares": [
+                _share("s1", "/mnt/data/share01"),
+                _share("s2", "/mnt/data"),
+                _share("s3", "/srv/elsewhere"),
+            ]
+        }
+    )
+    found, _ = _discover(control)
+
+    assert found is not None
+    assert [s["id"] for s in found] == ["s1", "s2"]
+    assert [s["path"] for s in found] == ["/mnt/data/share01", "/mnt/data"]
+
+
+def test_no_shares_is_an_empty_list_not_an_abort():
+    control = _FakeControl({"/api/v1/shares": []})
+    found, screen = _discover(control)
+
+    assert found == [], "an answered read of zero shares is a real answer"
+    assert screen.dialogs == []
+
+
+def test_unmounted_filesystem_skips_the_read():
+    """Nothing can be rooted under a filesystem that is not mounted."""
+    control = _FakeControl({"/api/v1/shares": ControlPathError("would not be reached")})
+    found, screen = _discover(control, mountpoint="")
+
+    assert found == []
+    assert control.reads == []
+    assert screen.dialogs == []
+
+
+def test_malformed_share_rows_are_skipped_not_fatal():
+    control = _FakeControl(
+        {
+            "/api/v1/shares": [
+                "junk",
+                {"id": "s1"},
+                {"spec": {"path": "/mnt/data/x"}},
+                _share("s2", "/mnt/data/ok"),
+            ]
+        }
+    )
+    found, _ = _discover(control)
+
+    assert found is not None
+    assert [s["id"] for s in found] == ["s2"]
+
+
+# ── the same defect on the create path ────────────────────────────────────────
+#
+# `_create_filesystem` filters out arrays already backing a filesystem. That
+# filter is the only thing keeping an in-use array out of the candidate list;
+# swallowing the read into `[]` offered those arrays, and the create then failed
+# in the agent's blkid preflight — whose remedy this screen offers as a force
+# retry that overwrites the existing filesystem.
+
+
+def _unused(control: _FakeControl, arr_rows):
+    screen = _FakeScreen(control)
+    got = asyncio.run(FilesystemScreen._unused_arrays(screen, arr_rows))
+    return got, screen
+
+
+def _array(name: str) -> dict:
+    return {
+        "id": name,
+        "spec": {"name": name, "level": "raid5", "member_disk_ids": []},
+        "status": {"state": "optimal", "volume_path": f"/dev/xi_{name}"},
+    }
+
+
+def test_create_aborts_when_the_filesystem_list_is_unreadable():
+    control = _FakeControl({"/api/v1/filesystems": ControlPathError("503 unavailable")})
+    got, screen = _unused(control, [_array("data"), _array("log")])
+
+    assert got is None, "an unreadable filesystem list must not read as 'no array is in use'"
+    assert "503 unavailable" in screen.messages
+
+
+def test_create_filters_out_arrays_already_carrying_a_filesystem():
+    control = _FakeControl(
+        {
+            "/api/v1/filesystems": {
+                "result": [
+                    {
+                        "id": "mnt-data.mount",
+                        "status": {
+                            "mountpoint": "/mnt/data",
+                            "backing_device": "/dev/xi_data",
+                            "mounted": True,
+                        },
+                    }
+                ]
+            }
+        }
+    )
+    got, screen = _unused(control, [_array("data"), _array("log")])
+
+    assert got is not None
+    assert [a["volume_path"] for a in got] == ["/dev/xi_log"]
+    assert screen.dialogs == []

--- a/xinas_menu/screens/filesystem.py
+++ b/xinas_menu/screens/filesystem.py
@@ -326,14 +326,10 @@ class FilesystemScreen(XiNASAppMixin, Screen):
             )
             return
 
-        # Filter out arrays already in use as a data OR log device of a
-        # managed filesystem (GET /api/v1/filesystems).
-        try:
-            fs_rows = await self._list_filesystems()
-        except ControlPathError:
-            fs_rows = []
-        used = _volumes_in_use(fs_rows)
-        arrays = [a for a in _arrays_from_api(arr_rows) if a["volume_path"] not in used]
+        candidates = await self._unused_arrays(arr_rows)
+        if candidates is None:
+            return
+        arrays = candidates
 
         if len(arrays) < 2:
             await self.app.push_screen_wait(
@@ -603,6 +599,82 @@ class FilesystemScreen(XiNASAppMixin, Screen):
             )
         )
 
+    async def _unused_arrays(self, arr_rows: Any) -> list[dict[str, Any]] | None:
+        """Arrays not already backing a managed filesystem, or ``None`` when unknowable.
+
+        FAIL-CLOSED: this filter is the only thing keeping an array that already
+        carries a filesystem out of the candidate list. Swallowed into an empty
+        list it offered exactly those arrays; the create then failed in the
+        agent's `blkid` preflight, whose remedy this screen offers as a **force
+        retry that overwrites the existing filesystem**. A read that never
+        answered was walking the operator to a destructive dialog.
+        """
+        try:
+            fs_rows = await self._list_filesystems()
+        except ControlPathError as exc:
+            await self.app.push_screen_wait(
+                ConfirmDialog(
+                    f"Could not read existing filesystems:\n{exc}\n\n"
+                    f"Without that list the wizard cannot tell which arrays are "
+                    f"already in use, so it will not offer any. Retry once the "
+                    f"control path is reachable.",
+                    "Create Filesystem — Aborted",
+                    ok_only=True,
+                )
+            )
+            return None
+        used = _volumes_in_use(fs_rows)
+        return [a for a in _arrays_from_api(arr_rows) if a["volume_path"] not in used]
+
+    async def _delete_aborted(self, reason: str, fs_label: str) -> None:
+        """Halt the deletion before anything is changed, and say why."""
+        await self.app.push_screen_wait(
+            ConfirmDialog(
+                f"{reason}\n\n"
+                f"'{fs_label}' was NOT deleted and nothing was changed. An "
+                f"unreadable dependency list is not evidence that the filesystem "
+                f"has none — retry once the control path is reachable.",
+                "Delete Filesystem — Aborted",
+                ok_only=True,
+            )
+        )
+
+    async def _shares_on_mountpoint(self, mountpoint: str, fs_label: str) -> list[dict] | None:
+        """NFS shares rooted at ``mountpoint``, or ``None`` when unknowable.
+
+        FAIL-CLOSED: the teardown removes these shares before unmounting, and
+        the second confirmation renders only when the list is non-empty. A
+        `ControlPathError` swallowed into `[]` therefore both hid the shares
+        from the operator and skipped their removal, unmounting the filesystem
+        under live exports. There is no server-side backstop — the filesystem
+        plan provider carries no share blocker — so this read is the only gate.
+
+        An unmounted filesystem returns ``[]`` without reading: nothing can be
+        rooted under a mountpoint that does not exist.
+        """
+        if not mountpoint:
+            return []
+        try:
+            share_rows = await asyncio.to_thread(self.app.control.result, "/api/v1/shares")
+        except ControlPathError as exc:
+            await self._delete_aborted(
+                f"Could not read NFS shares from the control path:\n{exc}", fs_label
+            )
+            return None
+
+        affected: list[dict] = []
+        for doc in share_rows if isinstance(share_rows, list) else []:
+            if not isinstance(doc, dict):
+                continue
+            doc_spec = doc.get("spec")
+            path = doc_spec.get("path") if isinstance(doc_spec, dict) else None
+            sid = doc.get("id")
+            if not path or sid is None:
+                continue
+            if is_path_under(str(path), mountpoint):
+                affected.append({"id": str(sid), "path": str(path)})
+        return affected
+
     @work(exclusive=True)
     async def _delete_filesystem(self) -> None:
         """Delete a filesystem: shares delete → unmount PATCH → unmanage DELETE.
@@ -653,23 +725,10 @@ class FilesystemScreen(XiNASAppMixin, Screen):
         mountpoint = target_fs["mountpoint"]
         source_dev = target_fs["backing_device"]
 
-        # ── Check for active NFS shares on this mountpoint ───────────────
-        affected_shares: list[dict] = []  # [{id, path}]
-        if mountpoint:
-            try:
-                share_rows = await asyncio.to_thread(self.app.control.result, "/api/v1/shares")
-            except ControlPathError:
-                share_rows = []
-            for doc in share_rows if isinstance(share_rows, list) else []:
-                if not isinstance(doc, dict):
-                    continue
-                doc_spec = doc.get("spec")
-                path = doc_spec.get("path") if isinstance(doc_spec, dict) else None
-                sid = doc.get("id")
-                if not path or sid is None:
-                    continue
-                if is_path_under(str(path), mountpoint):
-                    affected_shares.append({"id": str(sid), "path": str(path)})
+        # ── Check for active NFS shares on this mountpoint (fail-closed) ──
+        affected_shares = await self._shares_on_mountpoint(mountpoint, mountpoint or fs_id)
+        if affected_shares is None:
+            return
 
         # ── Build warning ────────────────────────────────────────────────
         warning_parts = [


### PR DESCRIPTION
Found by sweeping the codebase for the pattern behind #277, #280 and #285: a read that could not answer being reported as an answer of "nothing". Two more instances, both on the Filesystem screen.

## Delete Filesystem — the serious one

`GET /api/v1/shares` decides which NFS shares sit under the target mountpoint. A `ControlPathError` was swallowed into `[]`, and the rest of the flow treats that list as fact **twice**:

- the second, ABSOLUTELY-sure confirmation renders only `if affected_shares`;
- step 1 iterates that same list to remove the shares.

So with the control path down the teardown lost its second confirmation, skipped share removal entirely, and went on to unmount and unmanage the filesystem **under live NFS exports**. There is no server-side backstop: `api/plan/providers/filesystem.ts` carries no share-related blocker, unlike the array path where the agent's delete preflight reads `/proc/self/mountinfo`. This read was the only gate.

Discovery now aborts — `Delete Filesystem — Aborted`, carrying the error, stating the filesystem was not deleted and nothing changed — before the first confirmation.

## Create Filesystem — the same read, a longer fuse

The wizard filters out arrays already backing a filesystem using the same swallowed read, so an unreadable list offered exactly the arrays that must not be offered.

The agent's `blkid` preflight does refuse that create, so this is not silent data loss. What it is: this screen offers a **force retry** as the documented remedy for that preflight failure, and force overwrites the existing filesystem. The guard held; the swallowed read was walking the operator toward the dialog that removes it. Now aborts instead.

## Shape of the fix

Both reads moved into helpers that return `None` when the answer is unknowable — `_shares_on_mountpoint()` and `_unused_arrays()` — mirroring `RAIDScreen._delete_dependencies()` from #277, so the failure path is testable without a Textual app.

`tests/test_fs_delete_dependencies.py` covers both: the abort paths, and the behaviour that had to survive (shares under the mountpoint still found, an answered zero-share read still an empty list not an abort, an unmounted filesystem skipping the read, malformed rows skipped rather than fatal, in-use arrays still filtered).

## Verification

`pytest` 826 passed · `ruff check` / `format --check` · `pyright` 0 errors · `markdownlint` 0 issues. Spec updated in the same change (`docs/Storage/fs-shares-management-spec.md` §3.3 and §3.4), including why the old create-path behaviour was worse than it looked.

## Also swept, and clean

- **Ansible** — 85 `failed_when: false` tasks; the ones gating destruction (`cleanup_storage.yml`, LVM/MD discovery) key off `stdout_lines | length > 0`, so a failed probe destroys nothing.
- **Agent probes (TS)** — `inventory.ts` and `nfs-profile.ts` return `null` only for `ENOENT`/`EACCES`, distinguishable from empty.
- **`raid.py`** — remaining swallowed reads (drive-picker `claimed`, the pool list, the name-collision list) degrade a hint, not a guard: creates are still blocked api-side by `disk_in_use`, and the collision check is a warning with an override.
- **`main_menu.py` / `network.py`** — display fallbacks (MOTD IP list, interface rows); they assert no fact about storage.
- **`xinas_history`** — `_get_hardware_id()` returns `None`, which is honest for optional snapshot metadata.

Requires-Rebuild: not needed — Python TUI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)