### PR TITLE
ci: stop the whole-repo format check from reformatting Markdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,8 @@ jobs:
       - run: pip install -e '.[dev]'
       # Whole-repo, not just the three package dirs: files under tests/ and
       # collection/ kept re-drifting because they were never format-checked.
-      # `.` honors [tool.ruff] extend-exclude (.claude, node_modules).
+      # `.` honors [tool.ruff] extend-exclude (.claude, node_modules, *.md —
+      # ruff formats Python blocks inside Markdown, which docs/ never was).
       - run: ruff format --check .
 
   python-typecheck:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,12 @@ dev = [
 [tool.ruff]
 line-length = 100
 target-version = "py310"
-extend-exclude = [".claude", "node_modules", "xiNAS-MCP/node_modules"]
+# `*.md`: ruff >= 0.14 formats Python code blocks embedded in Markdown, so the
+# whole-repo `ruff format --check .` (see the python-format CI job) started
+# failing on 24 docs files whose snippets were never formatted — 22 of them in
+# docs/plans/, which CLAUDE.md keeps append-only. The check exists to stop
+# drift in real sources, not to reformat illustrations inside landed plans.
+extend-exclude = [".claude", "node_modules", "xiNAS-MCP/node_modules", "*.md"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "UP", "SIM"]


### PR DESCRIPTION
## Summary

`main` has been red on `python-format` since `e2c7dfc` (*ci: format-check the whole repo, not just three dirs*) — run 31839739111 and every push after it, including the #287 merge. Every PR branched off `main` inherits the failure; that is how it surfaced, on #289.

Cause: `e2c7dfc` pointed the job at `.` so drift under `tests/` and `collection/` would stop recurring. But ruff ≥ 0.14 also formats **Python code blocks embedded in Markdown**, so `.` swept in every `docs/**/*.md`. 24 of them have never been formatted and fail the check.

Fix: add `*.md` to `[tool.ruff] extend-exclude` rather than narrowing the paths back.

## Why exclude rather than reformat the 24 files

22 of the 24 live in `docs/plans/`, which CLAUDE.md keeps **append-only** — landed plans are not edited to reflect later changes. A format job that exists to stop drift in real sources should not rewrite illustrative snippets inside historical plans.

## What stays covered

The widening still does the job it was added for:

- `tests/` + `collection/` — 96 files checked, including `tests/test_hwkey_algorithm.py`, the file whose re-drift motivated `e2c7dfc`
- 211 Python files repo-wide (was 381 including Markdown, of which 24 failed)
- No `.py` files exist under `docs/`, so nothing real is hidden by the exclusion

## Verification

Run from the branch, with ruff 0.16.3:

- `ruff format --check .` — `211 files already formatted` (was `24 files would be reformatted, 357 already formatted`)
- `ruff format --check tests/ collection/` — `96 files already formatted`
- `ruff format --check tests/test_hwkey_algorithm.py` — `1 file already formatted`
- `yamllint -c .yamllint.yml .` — exit 0

CI-only change, so no `Requires-Rebuild:` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)