### PR TITLE
fix(client): gate DOCA OFED install on Mellanox/NVIDIA NIC presence

### DIFF
--- a/client_repo/client_setup.sh
+++ b/client_repo/client_setup.sh
@@ -1434,7 +1434,54 @@ Make sure no programs are using this mount."; then
 # DOCA OFED Installation
 # ═══════════════════════════════════════════════════════════════════════════════
 
+# Returns 0 if a Mellanox/NVIDIA NIC (PCI vendor 15b3) is present, 1 otherwise.
+# On success, prints a short description of the first match to stdout.
+detect_mellanox_nic() {
+    local match=""
+    if command -v lspci &>/dev/null; then
+        match=$(lspci -d 15b3: -nn 2>/dev/null | head -n1)
+        [[ -n "$match" ]] && { echo "$match"; return 0; }
+    fi
+    local v
+    for v in /sys/bus/pci/devices/*/vendor; do
+        [[ -r "$v" ]] || continue
+        if grep -qi '^0x15b3$' "$v" 2>/dev/null; then
+            echo "$(basename "$(dirname "$v")") (vendor 0x15b3)"
+            return 0
+        fi
+    done
+    local iface driver
+    for iface in /sys/class/net/*; do
+        [[ -L "$iface/device/driver" ]] || continue
+        driver=$(basename "$(readlink -f "$iface/device/driver")")
+        if [[ "$driver" == "mlx5_core" || "$driver" == "mlx4_core" ]]; then
+            echo "$(basename "$iface") (driver $driver)"
+            return 0
+        fi
+    done
+    if [[ -d /sys/class/infiniband ]] && [[ -n "$(ls /sys/class/infiniband/ 2>/dev/null)" ]]; then
+        echo "IB device(s): $(ls /sys/class/infiniband/ | tr '\n' ' ')"
+        return 0
+    fi
+    return 1
+}
+
 install_doca_ofed() {
+    # Hardware gate: only install if a Mellanox/NVIDIA NIC is detected
+    local _mlx_hw
+    if ! _mlx_hw=$(detect_mellanox_nic); then
+        msg_box "DOCA OFED — Skipped" "\
+No Mellanox / NVIDIA network adapter detected on this host.
+
+DOCA OFED provides drivers for Mellanox/NVIDIA ConnectX
+and BlueField cards. Installing it on a system without
+such hardware has no effect and is being skipped.
+
+If you believe a card is present but not detected,
+check 'lspci | grep -i mellanox' and re-run."
+        return 0
+    fi
+
     # Check if already installed
     if [[ -d /sys/class/infiniband ]] && command -v ibstat &>/dev/null; then
         local ib_devices
@@ -4183,7 +4230,9 @@ advanced_settings_menu() {
             nfs_indicator=" [OK]"
         fi
 
-        if [[ ! -d /sys/class/infiniband ]] || [[ -z "$(ls /sys/class/infiniband/ 2>/dev/null)" ]]; then
+        if ! detect_mellanox_nic >/dev/null 2>&1; then
+            doca_indicator=" [No Mellanox NIC]"
+        elif [[ ! -d /sys/class/infiniband ]] || [[ -z "$(ls /sys/class/infiniband/ 2>/dev/null)" ]]; then
             doca_indicator=" [Not Installed]"
         else
             doca_indicator=" [OK]"

--- a/client_repo/collection/roles/doca_ofed/README.md
+++ b/client_repo/collection/roles/doca_ofed/README.md
@@ -4,6 +4,25 @@ firmware updater (`mlnx-fw-updater`) from the official DOCA APT repository
 on Ubuntu. Defaults to the `latest` repo alias so each run pulls the most
 recent DOCA-Host release.
 
+### Hardware gate
+
+Every task in the role is gated on a Mellanox/NVIDIA NIC being present. The
+first task looks for PCI vendor `15b3` — via `lspci -d 15b3:` when `lspci`
+exists, otherwise by reading `/sys/bus/pci/devices/*/vendor` — and registers
+the result. When nothing matches, the role emits a single
+`No Mellanox/NVIDIA NIC detected … skipped` debug line and every subsequent
+task (build deps, signing key, APT repo, cache update, package install,
+reboot) is skipped. The detection task itself is `failed_when: false`, so a
+host without `lspci` and without a readable sysfs is treated as "no NIC"
+rather than a failure.
+
+Without the gate, a client with no ConnectX/BlueField card still added the
+DOCA repo, installed `doca-all`, built DKMS modules against the running
+kernel, and — with `doca_ofed_auto_reboot` — rebooted, all for drivers it
+has no hardware to drive. `client_setup.sh` applies the same gate at the
+menu level: the DOCA entry shows `[No Mellanox NIC]` and the action explains
+the skip instead of running the playbook.
+
 The repo's signing key is fetched from the component dir's `doca_keyring.gpg`
 (`<doca_repo_base>/<doca_repo_component>/doca_keyring.gpg`, a binary keyring) into
 `/etc/apt/trusted.gpg.d/mellanox-doca.gpg`. NVIDIA rotated the DOCA-Host key to

--- a/client_repo/collection/roles/doca_ofed/tasks/main.yml
+++ b/client_repo/collection/roles/doca_ofed/tasks/main.yml
@@ -1,3 +1,27 @@
+- name: Detect Mellanox/NVIDIA NIC (PCI vendor 15b3)
+  ansible.builtin.shell: |
+    set -o pipefail
+    if command -v lspci >/dev/null 2>&1; then
+      lspci -d 15b3: -nn | grep -q . && exit 0
+    fi
+    for v in /sys/bus/pci/devices/*/vendor; do
+      [ -r "$v" ] && grep -qi '0x15b3' "$v" && exit 0
+    done
+    exit 1
+  args:
+    executable: /bin/bash
+  register: mlx_nic_check
+  changed_when: false
+  failed_when: false
+  check_mode: no
+  tags: [ofed, detect]
+
+- name: Report no Mellanox NIC — skipping DOCA OFED
+  ansible.builtin.debug:
+    msg: "No Mellanox/NVIDIA NIC detected (PCI vendor 15b3) — DOCA OFED install skipped."
+  when: mlx_nic_check.rc != 0
+  tags: [ofed, detect]
+
 - name: Ensure build dependencies are present
   ansible.builtin.apt:
     name:
@@ -6,6 +30,7 @@
       - linux-headers-{{ ansible_kernel }}
       - libelf-dev
     state: present
+  when: mlx_nic_check.rc == 0
   tags: [ofed, deps]
 
 # NVIDIA rotated the DOCA-Host signing key (2026-01 -> 70454E6B…DC726C5E41B9CC50),
@@ -22,6 +47,7 @@
     dest: /etc/apt/trusted.gpg.d/mellanox-doca.gpg
     mode: '0644'
     force: true
+  when: mlx_nic_check.rc == 0
   tags: [ofed, repo]
 
 - name: Add DOCA-OFED APT repo
@@ -30,12 +56,15 @@
     filename: "mellanox-doca"
     state: present
   register: repo_added
+  when: mlx_nic_check.rc == 0
   tags: [ofed, repo]
 
 - name: Update APT cache (if repo added)
   ansible.builtin.apt:
     update_cache: yes
-  when: repo_added is changed
+  when:
+    - mlx_nic_check.rc == 0
+    - repo_added is changed
   tags: [ofed, repo]
 
 - name: Install DOCA-OFED packages
@@ -45,11 +74,15 @@
     update_cache: yes
   register: ofed_pkgs
   notify: restart openibd
+  when: mlx_nic_check.rc == 0
   tags: [ofed, install]
 
 - name: Reboot if kernel modules built and reboot requested
   ansible.builtin.reboot:
     msg: "Reboot after DOCA-OFED install (role doca_ofed)"
     reboot_timeout: 1200
-  when: ofed_pkgs is changed and doca_ofed_auto_reboot | bool
+  when:
+    - mlx_nic_check.rc == 0
+    - ofed_pkgs is changed
+    - doca_ofed_auto_reboot | bool
   tags: [ofed, reboot]


### PR DESCRIPTION
## Summary

Recovered from the stale branch `claude/silly-ardinghelli-c31e8f` (23 Apr), the oldest branch in the repo. The fix never landed and is still missing from `main`: neither `client_repo/collection/roles/doca_ofed/tasks/main.yml` nor `client_repo/client_setup.sh` mentions vendor `15b3` today.

A client with no ConnectX/BlueField card still added the DOCA APT repo, installed `doca-all`, built DKMS modules against the running kernel, and — with `doca_ofed_auto_reboot` — rebooted, all for drivers it has no hardware to drive.

The gate is applied in both places, so a direct `ansible-playbook` run is as safe as the menu:

- **Role** — a first task looks for PCI vendor `15b3` (`lspci -d 15b3:`, falling back to `/sys/bus/pci/devices/*/vendor`) and registers the result. No match ⇒ one `… skipped` debug line and all six mutating tasks are skipped. The probe is `failed_when: false`, so a host with neither `lspci` nor readable sysfs reads as "no NIC" rather than failing.
- **`client_setup.sh`** — `detect_mellanox_nic()` additionally recognises `mlx5_core`/`mlx4_core` drivers and existing `/sys/class/infiniband` devices. The Advanced Settings entry shows `[No Mellanox NIC]`, and choosing it explains the skip instead of running the playbook.

## Reconciliation with current main

Not a clean cherry-pick. Since April, the role's signing-key task was rewritten — `apt_key` on `GPG-KEY-Mellanox.pub` became `get_url` of `doca_keyring.gpg` after NVIDIA's 2026-01 key rotation. The original commit gated the old task, which no longer exists. Resolution keeps main's current task and puts the gate on it; all six mutating tasks in today's role are gated.

## Docs

`client_repo` has no spec document — only append-only plans under `docs/plans/` — and CLAUDE.md documents per-role behavior in `collection/roles/<role>/README.md`. The role README gains a **Hardware gate** section describing the probe, the skip, and the menu-level counterpart.

## Verification

- `pytest` — 813 passed, 14 skipped
- `yamllint -c .yamllint.yml .` — exit 0
- `ansible-lint client_repo/collection/roles/doca_ofed/` — profile `basic` (the one CI enforces) passed. The single `name[casing]` violation is pre-existing in `handlers/main.yml` (`restart openibd`), untouched here, and outside CI's `ansible-lint collection/roles/` scope
- `bash -n client_repo/client_setup.sh` — clean
- `markdownlint-cli2 'docs/**/*.md'` — 0 issues

Ansible role + shell change in the standalone client package, which is not deployed by `site.yml`, so no `Requires-Rebuild:` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)