### PR TITLE
docs(nfs): give _get_exports the reason it still has

### DIFF
--- a/xinas_menu/screens/nfs.py
+++ b/xinas_menu/screens/nfs.py
@@ -181,8 +181,14 @@ class NFSScreen(XiNASAppMixin, Screen):
         """Fetch shares from the control-path API, adapted to legacy rows.
 
         Raises ControlPathError. Callers MUST NOT degrade a failed read to
-        "no shares": Add allocates the next fsid from this list, and an
-        empty-looking list restarts numbering at 1 against a live host.
+        "no shares": Edit and Remove pick their target out of this list, and
+        Show renders it, so an empty-looking list tells the operator this host
+        exports nothing while it is still serving every one of them.
+
+        The rule predates that reasoning: the list also fed the TUI's own
+        `fsid` allocator, where a swallowed error restarted numbering at 1 and
+        collided with every existing share. Allocation moved server-side, so
+        Add no longer reads this at all — the rule stays for the callers above.
         """
         shares = await asyncio.to_thread(self.app.control.result, "/api/v1/shares")
         return [e for e in _rows_from_api(shares) if e.get("path") and e.get("id")]


### PR DESCRIPTION
One-paragraph correction, left behind by two changes that crossed.

#285 made `NFSScreen._get_exports()` propagate `ControlPathError` instead of degrading to `[]`, and documented why: the wizard allocated the next `fsid` from that list, so a swallowed error restarted numbering at `1` and collided with every existing share.

#293 then moved `fsid` allocation server-side. Add no longer reads the list at all — the spec says so in §4.1 and §10, and `nfs.py:547` carries a matching comment. The docstring on the function itself kept the old reason.

The rule is still right; only its justification died. Edit and Remove pick their target out of this list and Show renders it, so an empty-looking list tells the operator the host exports nothing while it is still serving every share. The docstring now says that, and keeps the `fsid` story as the history it is.

This is the kind of comment that gets deleted as obsolete along with the guard it protects, which is why it is worth a commit of its own.

## Verification

`pytest` 827 passed · `ruff check` / `format --check` · `pyright` 0 errors. No behaviour change; docstring only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)