### PR TITLE
fix(tui): WS5.2 — thread-safety and event-loop blocking in three screens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ scripts/node_modules/
 # End
 .worktrees/
 
+# Subagent-driven-development scratch (ledger, briefs, review packages).
+# Per-plan working state; the git history is the durable record.
+.superpowers/
+
 # pytest-cov data file (the CI coverage gate regenerates it on every run)
 .coverage
 

--- a/docs/Management/quick-actions-spec.md
+++ b/docs/Management/quick-actions-spec.md
@@ -1,0 +1,33 @@
+# Quick Actions — Day-2 Screen Specification
+
+`xinas_menu/screens/quick_actions.py` (`QuickActionsScreen`). Reached from the
+main menu; five actions plus Back.
+
+| Key | Action | Behavior |
+|---|---|---|
+| 1 | Restart NFS Server | Confirm dialog, then `service_restart("nfs-server")` in an executor thread. Audits `service.restart`. |
+| 2 | View System Logs | Recent `journalctl` entries rendered into the content pane. |
+| 3 | Service Status | Per-unit active state for the xiNAS units. The xiRAID exporter unit name is resolved at call time — see [xiraid-exporter-spec.md](xiraid-exporter-spec.md). |
+| 4 | System Monitor (btop) | Launches btop full-screen. See below. |
+| 5 | View Audit Log | Merged local + control-path trail — see [audit-log-spec.md](audit-log-spec.md). |
+
+## Launching a full-screen child program (btop)
+
+btop takes over the terminal: alternate screen buffer, raw input, its own
+signal handling. Textual owns those same resources, so the child **must** be
+run inside `App.suspend()`, which stops the driver, restores the terminal, and
+re-enters cleanly when the child exits.
+
+Contract:
+
+1. Probe with `shutil.which("btop")` — no subprocess. If absent, render the
+   install hint and return without suspending.
+2. Run btop **synchronously inside `with self.app.suspend():`**. Blocking the
+   event loop is correct here; a suspended app is not rendering. Launching it
+   in an executor thread while the app keeps running is what corrupts the
+   terminal — the two programs interleave output on one tty and btop's exit
+   restores a terminal state Textual is not expecting.
+3. `App.suspend()` raises `SuspendNotSupported` on a driver that cannot
+   suspend (headless). Catch it and tell the operator, rather than letting the
+   worker die with a traceback behind the UI.
+4. A non-zero btop exit is not an error worth a dialog — the operator quit it.

--- a/docs/Storage/fs-shares-management-spec.md
+++ b/docs/Storage/fs-shares-management-spec.md
@@ -314,12 +314,22 @@ Share ids are percent-encoded with `quote_id()` on every path — a Share id mir
 
 The renderer is intentionally rich:
 
-- **Storage line** — `df -h <path>` to show `used / total (pct)`.
+- **Storage line** — `df -h <path>` to show `used / total (pct)`, with a
+  **5-second timeout**; on timeout or error the line reads `N/A`. An export
+  whose backing filesystem is hung (dead NFS server, lost FC path) must not be
+  able to stall the render.
 - **Path-missing flag** — `os.path.isdir(path)` — flips the status badge to `[!] PATH MISSING` (red) if the export targets a directory that doesn't exist on disk.
 - **Security label** — translates `sec=krb5` / `krb5i` / `krb5p` → `"Kerberos"` / `"Kerberos+integrity"` / `"Kerberos+encryption"`, defaults to `"Standard (UID/GID)"`.
 - **Per-client explanation** — translates `*` → `"Everyone (all hosts)"`, `10.10.0.0/24` → `"Network: 10.10.0.0/24"`, and flags `no_root_squash` as `"full admin"` next to `rw` / `ro`.
 - **Empty state** — an empty share list renders `(no NFS shares configured)`. The renderer does **not** read `/etc/exports`. It used to: when the row list came back empty it parsed the file directly and displayed its contents as the share list. That made sense while the helper socket was the read path and an empty result meant "the socket failed", but under the control path an empty result means *the api observed no shares* — and the collector already observes `/etc/exports` itself, so anything genuinely exported would have come back as a row. All the fallback could still do was present unmanaged file contents as though they were the managed share list, in exactly the case where the operator most needs to see that the control path has nothing.
 - **Connected hosts** — last block. Reads `/proc/fs/nfsd/clients/*/info` for active v4 connections; if that's empty, falls back to `ss -tn state established ( dport = :2049 )` for v3 / TCP connections. IPs are de-duplicated.
+
+**The renderer runs in a worker thread.** `_format_exports` shells out to `df`
+once per share and reads `/proc/fs/nfsd/clients/*/info`, so `_load_exports`
+invokes it via `asyncio.to_thread`. `@work` on an `async def` runs the worker
+*on the event loop*, not in a thread — offloading the control-path call alone
+is not enough, and rendering inline is what froze the whole TUI when a single
+export's filesystem hung.
 
 **Degraded-backend honesty.** Like Show Filesystems (§3.2) and the RAID overview, `_load_exports` fetches the **full envelope** (`control.get`, not `control.result`) and inspects its `warnings`. When the envelope carries `DEGRADED_BACKEND_UNAVAILABLE` — the `Share` collector is errored (control-path contract: [s8-clients-spec §5.1](../control-path/s8-clients-spec.md)) — `_format_exports` renders that message as a banner above any rows, and when the list is empty the banner **replaces** the `(no NFS shares configured)` empty state. An unobservable backend must never read as "genuinely no shares". The shared extractor is [api/degraded.py](../../xinas_menu/api/degraded.py) `degraded_banner(envelope)`, the same one the other two screens use.
 

--- a/docs/Storage/fs-shares-management-spec.md
+++ b/docs/Storage/fs-shares-management-spec.md
@@ -315,9 +315,14 @@ Share ids are percent-encoded with `quote_id()` on every path — a Share id mir
 The renderer is intentionally rich:
 
 - **Storage line** — `df -h <path>` to show `used / total (pct)`, with a
-  **5-second timeout**; on timeout or error the line reads `N/A`. An export
-  whose backing filesystem is hung (dead NFS server, lost FC path) must not be
-  able to stall the render.
+  **5-second timeout**; on timeout or error the line reads `N/A`. This bounds
+  only the `df` call: an export whose filesystem is live but slow cannot stall
+  the render past 5 seconds. It does **not** cover a fully hung mount (dead
+  NFS server, lost FC path) — `os.path.isdir(path)` runs immediately before
+  `df` and gates it, and `stat(2)` on a hard-mounted unresponsive NFS export
+  blocks in uninterruptible sleep with no timeout available, so `isdir` hangs
+  before the `df` timeout ever has a chance to fire. See the residual gap
+  tracked in [docs/TODO.md](../TODO.md).
 - **Path-missing flag** — `os.path.isdir(path)` — flips the status badge to `[!] PATH MISSING` (red) if the export targets a directory that doesn't exist on disk.
 - **Security label** — translates `sec=krb5` / `krb5i` / `krb5p` → `"Kerberos"` / `"Kerberos+integrity"` / `"Kerberos+encryption"`, defaults to `"Standard (UID/GID)"`.
 - **Per-client explanation** — translates `*` → `"Everyone (all hosts)"`, `10.10.0.0/24` → `"Network: 10.10.0.0/24"`, and flags `no_root_squash` as `"full admin"` next to `rw` / `ro`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -21,6 +21,51 @@ deferred and the change that deferred it.
 
 ---
 
+## Storage — hung NFS mount can still stall the share-list render
+
+*Deferred 2026-08-14, from the WS5.2 TUI thread-safety fix
+(`fix/ws5-tui-thread-safety`).*
+
+**What is missing.** A bound on the blocking syscalls in
+[`nfs.py`](../xinas_menu/screens/nfs.py) `_format_exports` that `df`'s
+`timeout=5` does not cover: `os.path.isdir(path)` (`nfs.py:1063`), which runs
+immediately before and gates the `df` call, and the `ss -tn state established
+( dport = :2049 )` fallback in the connected-hosts block (`nfs.py:1107`).
+Neither has a timeout.
+
+**Current behavior.** `stat(2)` on a hard-mounted, unresponsive NFS export
+blocks in uninterruptible sleep (`D` state) with no timeout available at the
+syscall level, so on the spec's own headline example (dead NFS server) `isdir`
+hangs before the `df` timeout ever gets a chance to fire; `ss` can hang the
+same way against a wedged network stack. WS5.2 moved the whole render off the
+event loop (`_load_exports` awaits `_format_exports` via `asyncio.to_thread`),
+so the TUI no longer freezes — but the render for that refresh still stalls
+indefinitely, and because `_load_exports` is `@work(exclusive=True)`, each
+subsequent refresh cancels the *worker* while the `to_thread` call underneath
+keeps running on a thread borrowed from the event loop's shared default
+executor. It cannot be cancelled or reclaimed, so repeated refreshes against a
+hung export strand one thread per refresh in that shared pool.
+
+**Why it was cut.** WS5.2's scope was the event-loop-blocking defect (a hung
+call freezing the whole TUI), which `to_thread` fixes. Bounding `isdir`/`ss`
+themselves is a different problem — there is no interruptible timeout for a
+blocked `stat(2)`, so "done" means a probe-in-a-thread design (a dedicated,
+bounded worker pool with a hard wall-clock join timeout, treating a probe that
+doesn't return in time as failed and leaking that one thread deliberately
+instead of the default executor), not a parameter tweak on the existing call.
+
+**What done looks like.**
+
+1. `isdir` (and the `ss` fallback) run through a small dedicated thread pool
+   sized to survive N stranded probes, not the event loop's shared default
+   executor, so a hung mount can't starve unrelated `to_thread` work.
+2. Each probe is joined with a wall-clock timeout; a probe that doesn't
+   return in time renders the same way `df`'s timeout does today (`N/A` /
+   status badge unaffected) rather than blocking the refresh.
+3. `docs/Storage/fs-shares-management-spec.md` §4.2 is updated to state the
+   bound covers `isdir` and `ss` too, and the caveat added in this change is
+   removed.
+
 ## Storage — day-2 array creation does not enable discard
 
 *Deferred 2026-08-14, from the TRIM-support change.*

--- a/docs/config-history/architecture.md
+++ b/docs/config-history/architecture.md
@@ -218,6 +218,25 @@ calls). Commands mirror the Engine API: `snapshot create`, `snapshot list`,
 All consumers share the same lock, the same store path, and the same GC
 policy. Concurrent access is serialised by the global file lock.
 
+### 4.1 Progress callbacks run on the TUI event loop
+
+The Reset-to-Baseline screen renders Ansible output line by line as the reset
+runs. The progress callback handed to
+`TransactionalRunner.execute_reset_to_baseline(progress_cb=…)` is invoked
+**on the event loop**, from the `async for` stream reader in
+`TransactionalRunner._run_ansible_playbook`. It must therefore update the
+Textual view by calling the widget directly.
+
+It must **not** use `App.call_from_thread`: that API raises `RuntimeError` when
+called from the event-loop thread, and the runner swallows callback exceptions
+(`contextlib.suppress(Exception)`), so the failure is invisible — the reset
+appears to hang with no output for its entire multi-minute run. This is the
+inverse of the RAID teardown callback (`xinas_menu/screens/raid.py`
+`_teardown_progress`), which *is* invoked from a worker thread by
+`plan_apply_wait` and so does need `call_from_thread`.
+
+The view keeps the last 30 lines.
+
 ---
 
 ## 5. Data Flow Diagrams

--- a/docs/plans/2026-07-07-codebase-review-remediation-plan.md
+++ b/docs/plans/2026-07-07-codebase-review-remediation-plan.md
@@ -292,10 +292,26 @@ rollback mechanism everything else leans on.
 - [ ] **WS5.1** `_remove_share`: decorate with `@work` (match the other
   mutating methods in nfs.py); add a screen test that the menu action
   schedules the worker.
-- [ ] **WS5.2** Thread-safety pass: fix `config_history.py:408`
+- [x] **WS5.2** Thread-safety pass: fix `config_history.py:408`
   (`call_from_thread` only from workers; direct call otherwise); move the `df`
   calls in `nfs.py:882` into a worker with `timeout=`; suspend the app around
   btop (`app.suspend()`).
+
+  > **Status 2026-08-14:** LANDED on `fix/ws5-tui-thread-safety`. Three
+  > fixes: the `config_history.py` Reset-to-Baseline progress callback no
+  > longer calls `call_from_thread` from the event-loop thread (that call
+  > always raised `RuntimeError`, silently swallowed by the runner) —
+  > `TransactionalRunner` invokes the callback on the event loop already, so
+  > the handler now updates the widget directly; `nfs.py`'s `df` calls got a
+  > `timeout=5` and the whole `_format_exports` render moved off the event
+  > loop via `asyncio.to_thread`, so a slow-but-live export can no longer
+  > freeze the TUI; and `quick_actions.py`'s btop launch is now wrapped in
+  > `App.suspend()` instead of running in a bare executor thread, so btop and
+  > Textual no longer fight over the same terminal. Observation, not part of
+  > this landing: WS5.1 (`_remove_share` `@work`) was already fixed
+  > independently before this branch — `_remove_share` carries `@work` plus
+  > a regression test — so its box above is left unchecked rather than
+  > claimed here.
 - [ ] **WS5.3** raid.py: make teardown workers `exclusive=True` and
   non-cancellable by stray input (confirm-then-run-to-completion, disable
   bindings while running); surface envelope warnings in the empty-disk state.

--- a/docs/superpowers/plans/2026-08-14-ws5.2-tui-thread-safety.md
+++ b/docs/superpowers/plans/2026-08-14-ws5.2-tui-thread-safety.md
@@ -313,25 +313,45 @@ def test_load_exports_renders_off_the_event_loop():
     """`@work` on an async def runs ON the loop, so the blocking renderer
     (df per share + /proc reads) has to be handed to a thread explicitly."""
     src = inspect.getsource(NFSScreen._load_exports)
-    assert "to_thread" in src
-    formatted = src.split("_format_exports", 1)
-    assert len(formatted) == 2, "renderer call disappeared — update this test"
-    assert "to_thread" in formatted[0], "_format_exports is still called inline"
+    # Handed to to_thread as a reference, never called inline. A bare
+    # `_format_exports(` in this method means it runs on the event loop —
+    # and `to_thread` appearing *somewhere* in the method proves nothing,
+    # because the control-path call already uses it.
+    assert "_format_exports(" not in src, "_format_exports is still called inline"
+    assert re.search(r"to_thread\(\s*_format_exports", src), (
+        "_format_exports must be handed to asyncio.to_thread"
+    )
 ```
 
-Everything these tests reference is already available in that module — add no
-imports. Verified at plan time: `inspect` (line 5) and, from the
-`xinas_menu.screens.nfs` import block (lines 7-17), `NFSScreen`,
+This test needs `re`, which the module does not yet import. Add `import re`
+to the stdlib import block at the top of `tests/test_nfs_wizard_helpers.py`,
+directly above the existing `import inspect` (line 5).
+
+Apart from `re` (added above), everything these tests reference is already
+available in that module. Verified at plan time: `inspect` (line 5) and, from
+the `xinas_menu.screens.nfs` import block (lines 7-17), `NFSScreen`,
 `_format_exports`, and `_rows_from_api`. `_api_share` is **not** an import —
 it is a local helper defined at line 128 of the test file, so append the new
 tests at the end of the file (below it), not above.
+
+**Watch the self-reference trap.** `test_load_exports_renders_off_the_event_loop`
+asserts on the *source text* of the method it guards, so any string it forbids
+must not appear in that method — including inside a comment you add there.
+Task 1 hit exactly this: the plan prescribed an explanatory comment containing
+`call_from_thread` inside a function whose test asserts that string is absent.
+Word the implementation comments so they do not contain `_format_exports(`.
 
 - [ ] **Step 3: Run the tests to verify they fail**
 
 Run: `.venv/bin/python -m pytest tests/test_nfs_wizard_helpers.py -k "timeout or off_the_event_loop" -v`
 
 Expected: both FAIL — the first with "df has no timeout", the second with
-"_format_exports is still called inline".
+"_format_exports is still called inline" (the current method calls the renderer
+inline as `_format_exports(_rows_from_api(...))`).
+
+If either test passes at this step, stop and report it: a green test before the
+fix means the assertion does not constrain what it claims to, and the fix would
+land unverified.
 
 - [ ] **Step 4: Write the implementation**
 

--- a/docs/superpowers/plans/2026-08-14-ws5.2-tui-thread-safety.md
+++ b/docs/superpowers/plans/2026-08-14-ws5.2-tui-thread-safety.md
@@ -1,0 +1,616 @@
+# WS5.2 — TUI Thread-Safety and Event-Loop Blocking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the three WS5.2 defects where the Textual TUI either calls a
+thread-hopping API from the wrong thread or blocks its own event loop, so that
+Reset-to-Baseline shows live progress, a hung export cannot freeze the NFS
+screen, and launching btop cannot corrupt the terminal.
+
+**Architecture:** Three independent single-file fixes, one task each. Two are
+"stop doing the wrong thing on the event loop" (drop a needless
+`call_from_thread`; move a blocking renderer into a thread and bound its
+subprocess with a timeout). The third hands the terminal to a child process
+through Textual's own `App.suspend()` context manager instead of racing it from
+an executor thread. No shared abstraction is introduced — the three sites have
+nothing in common but the symptom, and inventing a helper for them would be
+YAGNI.
+
+**Tech Stack:** Python 3.11+, Textual 8.x, pytest, `asyncio.to_thread`,
+`subprocess`. No TypeScript, no Ansible.
+
+**Spec:** `docs/plans/2026-07-07-codebase-review-remediation-plan.md` §WS5.2,
+re-baselined against `origin/main` `032c3b6` on 2026-08-14. The re-baseline
+result is recorded per task under *Why this is real*; all three findings were
+confirmed against current code, and line numbers below are the current ones,
+not the plan's stale ones.
+
+## Global Constraints
+
+- **All repository artifacts are in English** — docs, comments, docstrings,
+  commit messages, branch names, test names. Non-negotiable, regardless of the
+  language of the working session.
+- **Spec-first.** Each task updates its owning spec *before* the code. A task
+  that ships code without its spec change is incomplete.
+- **No `Requires-Rebuild:` trailer on any commit in this plan.** All three
+  changes are Python TUI code. The trailer is only for changes needing an
+  Ansible role to re-run, and `xiNAS-MCP/src/` TypeScript. Adding it here
+  trains users to click past an unnecessary Ansible warning.
+- **Conventional Commits:** `fix(<scope>): <subject>`, imperative, lowercase
+  subject.
+- **Verification commands** (run from the worktree root, `.venv` already built):
+
+```bash
+.venv/bin/python -m pytest -q
+```
+
+```bash
+.venv/bin/python -m ruff check xinas_menu xinas_history xiNAS-MCP/nfs-helper
+```
+
+```bash
+.venv/bin/python -m ruff format --check xinas_menu xinas_history xiNAS-MCP/nfs-helper
+```
+
+```bash
+npx --yes markdownlint-cli2 'docs/**/*.md'
+```
+
+- **Baseline at plan time:** 804 passed, 14 skipped, 0 failures. Any task that
+  ends with a different failure count than 0 is not done.
+- Do not run `pyright` from the venv without `--pythonpath .venv/bin/python`;
+  it otherwise resolves against a interpreter with no `textual` installed and
+  reports ~260 phantom import errors.
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `docs/config-history/specs.md` | Owns the Config History TUI flows (it already documents the "Replace Baseline" flow). Gains a *Reset to Baseline — live progress* subsection. | 1 |
+| `xinas_menu/screens/config_history.py` | `ConfigHistoryScreen._reset_to_baseline` (line 333) and its nested `_on_progress` (line 405). | 1 |
+| `tests/test_config_history_reset_progress.py` | **New.** Guards the progress callback's threading contract on both sides. | 1 |
+| `docs/Storage/fs-shares-management-spec.md` | Owns the NFS share renderer; the *Storage line* bullet (line 317) documents the `df` call. | 2 |
+| `xinas_menu/screens/nfs.py` | `NFSScreen._load_exports` (line 154) and `_share_usage` nested in `_format_exports` (line 949). | 2 |
+| `tests/test_nfs_wizard_helpers.py` | Existing renderer test module. Gains two tests. | 2 |
+| `docs/Management/quick-actions-spec.md` | **New.** No spec covers the Quick Actions screen at all; spec-first requires creating one before changing observable behavior. | 3 |
+| `xinas_menu/screens/quick_actions.py` | `QuickActionsScreen._system_monitor` (line 165). | 3 |
+| `tests/test_quick_actions_suspend.py` | **New.** Guards the suspend contract. | 3 |
+
+Tasks are fully independent — no task consumes anything another produces, and
+they may be executed and reviewed in any order.
+
+---
+
+### Task 1: Reset-to-Baseline live progress
+
+**Files:**
+- Modify: `docs/config-history/specs.md` (add a subsection)
+- Modify: `xinas_menu/screens/config_history.py:405-411`
+- Test: `tests/test_config_history_reset_progress.py` (create)
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: nothing other tasks rely on.
+
+**Why this is real (verified 2026-08-14 against `origin/main` 032c3b6):**
+`_on_progress` is passed as `progress_cb=` into
+`TransactionalRunner.execute_reset_to_baseline`. That call chain reaches
+`TransactionalRunner._run_ansible_playbook` (`xinas_history/runner.py:696`),
+whose nested `async def _read_stream` (line 751) invokes `progress_cb(line)`
+from inside an `async for` — i.e. **on the event loop**, not from a worker
+thread. Textual's `call_from_thread` raises `RuntimeError` when called from the
+event-loop thread, and `_read_stream` wraps the call in
+`with contextlib.suppress(Exception)` (runner.py:760). Net effect: every
+progress line is silently discarded and the operator stares at a static
+"Resetting to baseline..." screen for the entire multi-minute run.
+
+For contrast, `xinas_menu/screens/raid.py:981` (`_teardown_progress`) uses
+`call_from_thread` **correctly** and says why in its docstring — its callback
+really is invoked from a worker thread by `plan_apply_wait`. Do not "fix" that
+one.
+
+- [ ] **Step 1: Update the spec first**
+
+In `docs/config-history/specs.md`, add this subsection immediately after the
+existing "Replace Baseline" flow description:
+
+```markdown
+#### Reset to Baseline — live progress
+
+The Reset-to-Baseline screen renders Ansible output line by line as the reset
+runs. The progress callback handed to
+`TransactionalRunner.execute_reset_to_baseline(progress_cb=…)` is invoked
+**on the event loop**, from the `async for` stream reader in
+`TransactionalRunner._run_ansible_playbook`. It must therefore update the
+Textual view by calling the widget directly.
+
+It must **not** use `App.call_from_thread`: that API raises `RuntimeError` when
+called from the event-loop thread, and the runner swallows callback exceptions
+(`contextlib.suppress(Exception)`), so the failure is invisible — the reset
+appears to hang with no output for its entire multi-minute run. This is the
+inverse of the RAID teardown callback (`xinas_menu/screens/raid.py`
+`_teardown_progress`), which *is* invoked from a worker thread by
+`plan_apply_wait` and so does need `call_from_thread`.
+
+The view keeps the last 30 lines.
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/test_config_history_reset_progress.py`:
+
+```python
+"""Threading contract of the Reset-to-Baseline progress callback.
+
+``TransactionalRunner`` invokes ``progress_cb`` from an ``async for`` stream
+reader — on the event loop, not from a worker thread — and swallows any
+exception the callback raises. A ``call_from_thread`` hop there therefore
+raises ``RuntimeError`` on every single line and is silently suppressed, so
+the reset renders no live output at all.
+
+Both halves are pinned: the screen must not hop threads, and the runner must
+keep invoking the callback on the loop (if the runner ever moves the call into
+a thread, the screen has to change with it and this test should fail loudly).
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from xinas_history.runner import TransactionalRunner
+from xinas_menu.screens.config_history import ConfigHistoryScreen
+
+
+def test_reset_progress_does_not_hop_threads():
+    src = inspect.getsource(ConfigHistoryScreen._reset_to_baseline)
+    assert "call_from_thread" not in src, (
+        "progress_cb runs on the event loop; call_from_thread raises there "
+        "and the runner suppresses it, so every progress line is dropped"
+    )
+
+
+def test_reset_progress_callback_still_updates_the_view():
+    # Guard against 'fixing' the above by deleting the update entirely.
+    src = inspect.getsource(ConfigHistoryScreen._reset_to_baseline)
+    assert "set_content" in src
+
+
+def test_runner_invokes_progress_cb_on_the_event_loop():
+    """Pins the premise of the test above."""
+    src = inspect.getsource(TransactionalRunner._run_ansible_playbook)
+    assert "async def _read_stream" in src
+    assert "progress_cb(line)" in src
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_config_history_reset_progress.py -v`
+
+Expected: `test_reset_progress_does_not_hop_threads` FAILS on the assertion
+(the other two already pass — they pin behavior that is currently correct).
+
+- [ ] **Step 4: Write the implementation**
+
+In `xinas_menu/screens/config_history.py`, replace the `_on_progress` body
+(lines 405-411) with:
+
+```python
+        def _on_progress(line: str) -> None:
+            # Invoked on the event loop by TransactionalRunner's async stream
+            # reader, so update the widget directly. call_from_thread would
+            # raise RuntimeError here, and the runner suppresses callback
+            # exceptions — every line would vanish. (raid.py's
+            # _teardown_progress is the opposite case: a real worker thread.)
+            _progress_lines.append(line)
+            tail = _progress_lines[-30:]
+            view.set_content(
+                f"{_DIM}Resetting to baseline...{_NC}\n\n" + "\n".join(tail),
+            )
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_config_history_reset_progress.py -v`
+
+Expected: 3 passed.
+
+- [ ] **Step 6: Run the full suite and linters**
+
+```bash
+.venv/bin/python -m pytest -q && .venv/bin/python -m ruff check xinas_menu xinas_history xiNAS-MCP/nfs-helper && .venv/bin/python -m ruff format --check xinas_menu xinas_history xiNAS-MCP/nfs-helper
+```
+
+Expected: 807 passed, 14 skipped; ruff clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/config-history/specs.md xinas_menu/screens/config_history.py tests/test_config_history_reset_progress.py && git commit -m "fix(config-history): render reset progress instead of dropping every line"
+```
+
+---
+
+### Task 2: NFS export renderer off the event loop, with a bounded `df`
+
+**Files:**
+- Modify: `docs/Storage/fs-shares-management-spec.md:317`
+- Modify: `xinas_menu/screens/nfs.py:154-161` and `xinas_menu/screens/nfs.py:949-955`
+- Test: `tests/test_nfs_wizard_helpers.py` (extend)
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: nothing other tasks rely on. `_format_exports` keeps its current
+  signature `(data: Any, banner: str | None = None) -> str` — six existing
+  tests call it directly and must keep working.
+
+**Why this is real (verified 2026-08-14 against `origin/main` 032c3b6):**
+`NFSScreen._load_exports` is decorated `@work(exclusive=True)`, which in
+Textual runs an `async def` as an **async worker on the event loop** — not in a
+thread. The control-path call is correctly offloaded with `asyncio.to_thread`,
+but the very next line calls `_format_exports(...)` inline. That renderer runs
+`subprocess.run(["df", "-h", path])` **per share with no timeout** (line 951)
+and additionally opens `/proc/fs/nfsd/clients/*/info`. One export on a hung NFS
+or dead FC path blocks `df` indefinitely, and with it the whole TUI — no
+keyboard, no repaint, no way out.
+
+Two changes are needed, and both are load-bearing: the timeout bounds a single
+hung `df`, and moving the renderer into a thread keeps even a bounded 5-second
+stall off the loop.
+
+- [ ] **Step 1: Update the spec first**
+
+In `docs/Storage/fs-shares-management-spec.md`, replace the *Storage line*
+bullet (line 317):
+
+```markdown
+- **Storage line** — `df -h <path>` to show `used / total (pct)`, with a
+  **5-second timeout**; on timeout or error the line reads `N/A`. An export
+  whose backing filesystem is hung (dead NFS server, lost FC path) must not be
+  able to stall the render.
+```
+
+Then add this paragraph immediately after the bullet list that follows it:
+
+```markdown
+**The renderer runs in a worker thread.** `_format_exports` shells out to `df`
+once per share and reads `/proc/fs/nfsd/clients/*/info`, so `_load_exports`
+invokes it via `asyncio.to_thread`. `@work` on an `async def` runs the worker
+*on the event loop*, not in a thread — offloading the control-path call alone
+is not enough, and rendering inline is what froze the whole TUI when a single
+export's filesystem hung.
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `tests/test_nfs_wizard_helpers.py`:
+
+```python
+def test_share_usage_df_is_bounded_by_a_timeout(monkeypatch):
+    """A hung export must not stall the renderer forever."""
+    import subprocess as _sp
+
+    from xinas_menu.screens import nfs as nfs_mod
+
+    seen: list[dict] = []
+
+    def _fake_run(cmd, **kwargs):
+        seen.append({"cmd": cmd, **kwargs})
+        return _sp.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(nfs_mod.subprocess, "run", _fake_run)
+    _format_exports(_rows_from_api(_api_share({"sync": "sync"})))
+
+    df_calls = [c for c in seen if c["cmd"][:1] == ["df"]]
+    assert df_calls, "renderer no longer calls df — update this test"
+    for call in df_calls:
+        assert isinstance(call.get("timeout"), (int, float)), "df has no timeout"
+        assert 0 < call["timeout"] <= 30
+
+
+def test_load_exports_renders_off_the_event_loop():
+    """`@work` on an async def runs ON the loop, so the blocking renderer
+    (df per share + /proc reads) has to be handed to a thread explicitly."""
+    src = inspect.getsource(NFSScreen._load_exports)
+    assert "to_thread" in src
+    formatted = src.split("_format_exports", 1)
+    assert len(formatted) == 2, "renderer call disappeared — update this test"
+    assert "to_thread" in formatted[0], "_format_exports is still called inline"
+```
+
+Everything these tests reference is already available in that module — add no
+imports. Verified at plan time: `inspect` (line 5) and, from the
+`xinas_menu.screens.nfs` import block (lines 7-17), `NFSScreen`,
+`_format_exports`, and `_rows_from_api`. `_api_share` is **not** an import —
+it is a local helper defined at line 128 of the test file, so append the new
+tests at the end of the file (below it), not above.
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_nfs_wizard_helpers.py -k "timeout or off_the_event_loop" -v`
+
+Expected: both FAIL — the first with "df has no timeout", the second with
+"_format_exports is still called inline".
+
+- [ ] **Step 4: Write the implementation**
+
+In `xinas_menu/screens/nfs.py`, change `_share_usage` (lines 950-955) to pass a
+timeout:
+
+```python
+    def _share_usage(path: str) -> str:
+        try:
+            r = subprocess.run(
+                ["df", "-h", path],
+                capture_output=True,
+                text=True,
+                # A hung backing FS (dead NFS server, lost FC path) makes df
+                # block forever; bound it and fall through to "N/A".
+                timeout=5,
+                check=False,
+            )
+```
+
+Leave the rest of the function unchanged — the existing
+`except Exception:` already catches `subprocess.TimeoutExpired` and returns
+`"N/A"`.
+
+Then change `_load_exports` (lines 154-161) to render in a thread:
+
+```python
+    @work(exclusive=True)
+    async def _load_exports(self) -> None:
+        view = self.query_one("#nfs-content", ScrollableTextView)
+        try:
+            env = await asyncio.to_thread(self.app.control.get, "/api/v1/shares")
+        except ControlPathError as exc:
+            view.set_content(f"Control API: {exc}")
+            return
+        # `@work` on an async def runs on the event loop, and the renderer
+        # shells out to df per share and reads /proc — keep it off the loop.
+        text = await asyncio.to_thread(
+            _format_exports, _rows_from_api(env.get("result")), degraded_banner(env)
+        )
+        view.set_content(text)
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_nfs_wizard_helpers.py -v`
+
+Expected: all pass, including the six pre-existing `_format_exports` tests.
+
+- [ ] **Step 6: Run the full suite and linters**
+
+```bash
+.venv/bin/python -m pytest -q && .venv/bin/python -m ruff check xinas_menu xinas_history xiNAS-MCP/nfs-helper && .venv/bin/python -m ruff format --check xinas_menu xinas_history xiNAS-MCP/nfs-helper
+```
+
+Expected: 809 passed, 14 skipped; ruff clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/Storage/fs-shares-management-spec.md xinas_menu/screens/nfs.py tests/test_nfs_wizard_helpers.py && git commit -m "fix(nfs): stop a hung export from freezing the share list"
+```
+
+---
+
+### Task 3: Suspend the app around btop
+
+**Files:**
+- Create: `docs/Management/quick-actions-spec.md`
+- Modify: `xinas_menu/screens/quick_actions.py:165-176`
+- Test: `tests/test_quick_actions_suspend.py` (create)
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: nothing other tasks rely on.
+
+**Why this is real (verified 2026-08-14 against `origin/main` 032c3b6):**
+`_system_monitor` launches btop with
+`await loop.run_in_executor(None, lambda: subprocess.run(["btop"]))`. btop is a
+full-screen terminal app that takes over the alternate screen buffer and reads
+stdin — while Textual is still running its own render loop and input reader on
+the same terminal. The two fight over the tty: output interleaves, and on exit
+the terminal is left in whatever state btop restored it to rather than
+Textual's. `grep -rn "app.suspend" xinas_menu/` returns **nothing** — the app
+is never suspended anywhere in the TUI.
+
+Textual's `App.suspend()` is the supported way to do this: a context manager
+(confirmed present in the pinned textual 8.2.8) that stops the driver, restores
+the terminal, and re-enters on exit. It raises `SuspendNotSupported` when the
+driver cannot suspend (headless), which must be handled rather than crashing
+the worker.
+
+Note the deliberate shape change: the `which btop` probe moves to
+`shutil.which`, dropping a subprocess entirely, and btop runs **synchronously
+inside the suspend block** rather than in an executor. Blocking the loop is
+correct here — that is precisely what suspending means.
+
+- [ ] **Step 1: Write the spec first**
+
+No spec covers the Quick Actions screen. Create
+`docs/Management/quick-actions-spec.md`:
+
+```markdown
+# Quick Actions — Day-2 Screen Specification
+
+`xinas_menu/screens/quick_actions.py` (`QuickActionsScreen`). Reached from the
+main menu; five actions plus Back.
+
+| Key | Action | Behavior |
+|---|---|---|
+| 1 | Restart NFS Server | Confirm dialog, then `service_restart("nfs-server")` in an executor thread. Audits `service.restart`. |
+| 2 | View System Logs | Recent `journalctl` entries rendered into the content pane. |
+| 3 | Service Status | Per-unit active state for the xiNAS units. The xiRAID exporter unit name is resolved at call time — see [xiraid-exporter-spec.md](xiraid-exporter-spec.md). |
+| 4 | System Monitor (btop) | Launches btop full-screen. See below. |
+| 5 | View Audit Log | Merged local + control-path trail — see [audit-log-spec.md](audit-log-spec.md). |
+
+## Launching a full-screen child program (btop)
+
+btop takes over the terminal: alternate screen buffer, raw input, its own
+signal handling. Textual owns those same resources, so the child **must** be
+run inside `App.suspend()`, which stops the driver, restores the terminal, and
+re-enters cleanly when the child exits.
+
+Contract:
+
+1. Probe with `shutil.which("btop")` — no subprocess. If absent, render the
+   install hint and return without suspending.
+2. Run btop **synchronously inside `with self.app.suspend():`**. Blocking the
+   event loop is correct here; a suspended app is not rendering. Launching it
+   in an executor thread while the app keeps running is what corrupts the
+   terminal — the two programs interleave output on one tty and btop's exit
+   restores a terminal state Textual is not expecting.
+3. `App.suspend()` raises `SuspendNotSupported` on a driver that cannot
+   suspend (headless). Catch it and tell the operator, rather than letting the
+   worker die with a traceback behind the UI.
+4. A non-zero btop exit is not an error worth a dialog — the operator quit it.
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/test_quick_actions_suspend.py`:
+
+```python
+"""btop must run inside App.suspend(), not alongside a live Textual app.
+
+btop drives the alternate screen buffer and raw stdin — the same terminal
+resources Textual holds. Running it in an executor thread while the app keeps
+rendering makes the two interleave on one tty and leaves the terminal in
+btop's state on exit. `App.suspend()` is the supported handover.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from xinas_menu.screens.quick_actions import QuickActionsScreen
+
+
+def _src() -> str:
+    return inspect.getsource(QuickActionsScreen._system_monitor)
+
+
+def test_btop_runs_inside_app_suspend():
+    assert "suspend()" in _src()
+
+
+def test_btop_is_not_launched_from_an_executor():
+    src = _src()
+    assert "run_in_executor" not in src, (
+        "btop must run synchronously inside the suspend block — a suspended "
+        "app is not rendering, so blocking the loop is correct here"
+    )
+
+
+def test_suspend_not_supported_is_handled():
+    assert "SuspendNotSupported" in _src()
+
+
+def test_missing_btop_still_reports_the_install_hint():
+    assert "not installed" in _src()
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_quick_actions_suspend.py -v`
+
+Expected: the first three FAIL, `test_missing_btop_still_reports_the_install_hint`
+passes.
+
+- [ ] **Step 4: Write the implementation**
+
+In `xinas_menu/screens/quick_actions.py`, add to the imports at the top of the
+file (keep them alphabetical within their group):
+
+```python
+import shutil
+```
+
+```python
+from textual.app import SuspendNotSupported
+```
+
+Then replace `_system_monitor` (lines 165-176) with:
+
+```python
+    @work(exclusive=True)
+    async def _system_monitor(self) -> None:
+        """Launch btop with the terminal handed over via App.suspend().
+
+        btop owns the alternate screen buffer and raw stdin while it runs —
+        the same resources Textual holds. See
+        docs/Management/quick-actions-spec.md.
+        """
+        view = self.query_one("#qa-content", ScrollableTextView)
+        if shutil.which("btop") is None:
+            view.set_content("btop is not installed.\n\nInstall with: sudo apt-get install btop")
+            return
+        view.set_content("Launching btop -- press q to return to menu.")
+        try:
+            with self.app.suspend():
+                # Synchronous on purpose: a suspended app is not rendering,
+                # so there is no event loop to keep responsive.
+                subprocess.run(["btop"], check=False)
+        except SuspendNotSupported:
+            view.set_content(
+                "btop needs a real terminal.\n\nThis app cannot be suspended here."
+            )
+            return
+        view.set_content("btop closed.")
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_quick_actions_suspend.py -v`
+
+Expected: 4 passed.
+
+- [ ] **Step 6: Run the full suite and linters**
+
+```bash
+.venv/bin/python -m pytest -q && .venv/bin/python -m ruff check xinas_menu xinas_history xiNAS-MCP/nfs-helper && .venv/bin/python -m ruff format --check xinas_menu xinas_history xiNAS-MCP/nfs-helper
+```
+
+Expected: 813 passed, 14 skipped; ruff clean.
+
+If ruff flags `asyncio` or `loop` as now-unused in `quick_actions.py`, remove
+the dead local — `_system_monitor` was the only user of
+`asyncio.get_running_loop()` in that method, but other methods in the file
+(`_restart_nfs`) still use it, so the module-level `import asyncio` stays.
+
+- [ ] **Step 7: Lint the new markdown**
+
+```bash
+npx --yes markdownlint-cli2 'docs/**/*.md'
+```
+
+Expected: 0 issues. If MD033 (inline HTML) or MD013 fires on the new spec, fix
+the spec — do not add an inline-HTML anchor, use a real heading instead.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add docs/Management/quick-actions-spec.md xinas_menu/screens/quick_actions.py tests/test_quick_actions_suspend.py && git commit -m "fix(quick-actions): hand the terminal to btop via App.suspend()"
+```
+
+---
+
+## Finishing
+
+After all three tasks, run the full verification sweep once more, then follow
+`superpowers:finishing-a-development-branch`. Expected end state: **813 passed,
+14 skipped, 0 failures**, ruff and markdownlint clean, three commits on
+`fix/ws5-tui-thread-safety`, no `Requires-Rebuild:` trailer on any of them.
+
+Update `docs/plans/2026-07-07-codebase-review-remediation-plan.md` to tick the
+WS5.2 checkbox **only** as part of the branch's final commit — that file is an
+append-only execution record, so add a `> **Status 2026-08-14:**` note in the
+same style as the WS1/WS2/WS3 entries rather than rewriting the finding rows.
+
+Do **not** tick WS5.1 while you are there. It was already fixed independently
+(`_remove_share` has `@work` plus a regression test); the re-baseline covers
+that, and it is not this branch's work to claim.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,4 +5,29 @@ request `stub_socket` by parameter name without importing it (which would
 shadow the parameter and trip ruff F811).
 """
 
+import os
+import pytest
+
 from tests.test_control_client import stub_socket  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def _mock_path_exists(monkeypatch):
+    """Make os.path.isdir return True for export paths in tests.
+
+    This allows tests to verify filesystem operations without needing
+    actual paths to exist. Specifically handles /mnt paths while
+    preserving normal behavior for /proc paths.
+    """
+    original_isdir = os.path.isdir
+
+    def mock_isdir(path):
+        # Convert to string to handle both str and Path objects
+        path_str = str(path)
+        # For test paths like /mnt/data or /srv, return True
+        if path_str.startswith("/mnt") or path_str.startswith("/srv"):
+            return True
+        # For /proc paths, use original behavior (will return False)
+        return original_isdir(path)
+
+    monkeypatch.setattr(os.path, "isdir", mock_isdir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,29 +5,4 @@ request `stub_socket` by parameter name without importing it (which would
 shadow the parameter and trip ruff F811).
 """
 
-import os
-import pytest
-
 from tests.test_control_client import stub_socket  # noqa: F401
-
-
-@pytest.fixture(autouse=True)
-def _mock_path_exists(monkeypatch):
-    """Make os.path.isdir return True for export paths in tests.
-
-    This allows tests to verify filesystem operations without needing
-    actual paths to exist. Specifically handles /mnt paths while
-    preserving normal behavior for /proc paths.
-    """
-    original_isdir = os.path.isdir
-
-    def mock_isdir(path):
-        # Convert to string to handle both str and Path objects
-        path_str = str(path)
-        # For test paths like /mnt/data or /srv, return True
-        if path_str.startswith("/mnt") or path_str.startswith("/srv"):
-            return True
-        # For /proc paths, use original behavior (will return False)
-        return original_isdir(path)
-
-    monkeypatch.setattr(os.path, "isdir", mock_isdir)

--- a/tests/test_config_history_reset_progress.py
+++ b/tests/test_config_history_reset_progress.py
@@ -15,18 +15,12 @@ from __future__ import annotations
 
 import inspect
 import re
-from collections import namedtuple
 
 from xinas_history.runner import TransactionalRunner
 from xinas_menu.screens.config_history import ConfigHistoryScreen
 
 # Thread-hopping primitives that would raise RuntimeError on the event loop
-_ThreadHopAPI = namedtuple("_ThreadHopAPI", ["name"])
-_FORBIDDEN_APIS = [
-    _ThreadHopAPI("call_from_thread"),
-    _ThreadHopAPI("call_soon_threadsafe"),
-    _ThreadHopAPI("run_coroutine_threadsafe"),
-]
+_FORBIDDEN_APIS = ["call_from_thread", "call_soon_threadsafe", "run_coroutine_threadsafe"]
 
 
 def test_reset_progress_does_not_hop_threads():
@@ -38,8 +32,8 @@ def test_reset_progress_does_not_hop_threads():
     """
     src = inspect.getsource(ConfigHistoryScreen._reset_to_baseline)
     for api in _FORBIDDEN_APIS:
-        assert api.name not in src, (
-            f"progress_cb runs on the event loop; {api.name} raises RuntimeError "
+        assert api not in src, (
+            f"progress_cb runs on the event loop; {api} raises RuntimeError "
             "there and the runner suppresses it, so every progress line is dropped"
         )
 
@@ -48,6 +42,27 @@ def test_reset_progress_callback_still_updates_the_view():
     # Guard against 'fixing' the above by deleting the update entirely.
     src = inspect.getsource(ConfigHistoryScreen._reset_to_baseline)
     assert "set_content" in src
+
+
+def test_screen_awaits_runner_on_its_own_loop():
+    """Pins the screen's half of the threading contract.
+
+    The direct `view.set_content()` call in the progress callback is only
+    correct because the screen awaits `runner.execute_reset_to_baseline`
+    inline, on the same event loop the callback runs on. If a future change
+    wrapped that call to move it off-loop (e.g.
+    `await asyncio.to_thread(lambda: asyncio.run(runner.execute_reset_to_baseline(...)))`),
+    the callback would land back on a thread on a foreign loop and
+    `call_from_thread` would become necessary again — but every assertion
+    above would stay green, since they only inspect the callback body. This
+    test catches that class of regression directly.
+    """
+    src = inspect.getsource(ConfigHistoryScreen._reset_to_baseline)
+    assert re.search(r"await\s+runner\.execute_reset_to_baseline", src), (
+        "the screen must await runner.execute_reset_to_baseline() inline; "
+        "moving it off the event loop (to_thread/asyncio.run) breaks the "
+        "callback's direct set_content() call"
+    )
 
 
 def test_runner_invokes_progress_cb_on_the_event_loop():

--- a/tests/test_config_history_reset_progress.py
+++ b/tests/test_config_history_reset_progress.py
@@ -2,7 +2,7 @@
 
 ``TransactionalRunner`` invokes ``progress_cb`` from an ``async for`` stream
 reader — on the event loop, not from a worker thread — and swallows any
-exception the callback raises. A ``call_from_thread`` hop there therefore
+exception the callback raises. A thread-hopping API hop there therefore
 raises ``RuntimeError`` on every single line and is silently suppressed, so
 the reset renders no live output at all.
 
@@ -14,17 +14,34 @@ a thread, the screen has to change with it and this test should fail loudly).
 from __future__ import annotations
 
 import inspect
+import re
+from collections import namedtuple
 
 from xinas_history.runner import TransactionalRunner
 from xinas_menu.screens.config_history import ConfigHistoryScreen
 
+# Thread-hopping primitives that would raise RuntimeError on the event loop
+_ThreadHopAPI = namedtuple("_ThreadHopAPI", ["name"])
+_FORBIDDEN_APIS = [
+    _ThreadHopAPI("call_from_thread"),
+    _ThreadHopAPI("call_soon_threadsafe"),
+    _ThreadHopAPI("run_coroutine_threadsafe"),
+]
+
 
 def test_reset_progress_does_not_hop_threads():
+    """Callback must not use thread-hopping primitives.
+
+    All of these raise RuntimeError when called from the event loop,
+    and the runner suppresses callback exceptions, so every progress
+    line is silently dropped.
+    """
     src = inspect.getsource(ConfigHistoryScreen._reset_to_baseline)
-    assert "call_from_thread" not in src, (
-        "progress_cb runs on the event loop; call_from_thread raises there "
-        "and the runner suppresses it, so every progress line is dropped"
-    )
+    for api in _FORBIDDEN_APIS:
+        assert api.name not in src, (
+            f"progress_cb runs on the event loop; {api.name} raises RuntimeError "
+            "there and the runner suppresses it, so every progress line is dropped"
+        )
 
 
 def test_reset_progress_callback_still_updates_the_view():
@@ -34,7 +51,27 @@ def test_reset_progress_callback_still_updates_the_view():
 
 
 def test_runner_invokes_progress_cb_on_the_event_loop():
-    """Pins the premise of the test above."""
+    """Pins the premise of the test above.
+
+    The runner must invoke the callback on the event loop, not in a thread pool.
+    We check: (1) the method is async (2) progress_cb is called by the method,
+    tolerant of formatting (3) the method does not use thread pool executors
+    (to_thread, run_in_executor) which would move the callback off the loop.
+    """
     src = inspect.getsource(TransactionalRunner._run_ansible_playbook)
-    assert "async def _read_stream" in src
-    assert "progress_cb(line)" in src
+
+    # Method must be async (callback is on the event loop)
+    assert inspect.iscoroutinefunction(TransactionalRunner._run_ansible_playbook)
+
+    # Callback must be invoked, tolerant of whitespace and keyword form
+    assert re.search(r"progress_cb\s*\(", src), (
+        "runner must invoke progress_cb; if this assertion fails, check for "
+        "reformat (different call style, whitespace, keyword args)"
+    )
+
+    # Runner must not move callback into a thread pool
+    assert "to_thread" not in src and "run_in_executor" not in src, (
+        "callback must run on event loop; to_thread/run_in_executor would move "
+        "it into a thread pool, causing the screen's direct view.set_content() "
+        "to fail"
+    )

--- a/tests/test_config_history_reset_progress.py
+++ b/tests/test_config_history_reset_progress.py
@@ -1,0 +1,40 @@
+"""Threading contract of the Reset-to-Baseline progress callback.
+
+``TransactionalRunner`` invokes ``progress_cb`` from an ``async for`` stream
+reader — on the event loop, not from a worker thread — and swallows any
+exception the callback raises. A ``call_from_thread`` hop there therefore
+raises ``RuntimeError`` on every single line and is silently suppressed, so
+the reset renders no live output at all.
+
+Both halves are pinned: the screen must not hop threads, and the runner must
+keep invoking the callback on the loop (if the runner ever moves the call into
+a thread, the screen has to change with it and this test should fail loudly).
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from xinas_history.runner import TransactionalRunner
+from xinas_menu.screens.config_history import ConfigHistoryScreen
+
+
+def test_reset_progress_does_not_hop_threads():
+    src = inspect.getsource(ConfigHistoryScreen._reset_to_baseline)
+    assert "call_from_thread" not in src, (
+        "progress_cb runs on the event loop; call_from_thread raises there "
+        "and the runner suppresses it, so every progress line is dropped"
+    )
+
+
+def test_reset_progress_callback_still_updates_the_view():
+    # Guard against 'fixing' the above by deleting the update entirely.
+    src = inspect.getsource(ConfigHistoryScreen._reset_to_baseline)
+    assert "set_content" in src
+
+
+def test_runner_invokes_progress_cb_on_the_event_loop():
+    """Pins the premise of the test above."""
+    src = inspect.getsource(TransactionalRunner._run_ansible_playbook)
+    assert "async def _read_stream" in src
+    assert "progress_cb(line)" in src

--- a/tests/test_nfs_wizard_helpers.py
+++ b/tests/test_nfs_wizard_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import inspect
 
 from xinas_menu.screens.nfs import (
@@ -314,3 +315,39 @@ def test_edit_and_remove_distinguish_unreadable_from_empty():
         src = inspect.getsource(method)
         assert "Could not load shares." in src, f"{method.__name__} reports a failed read as empty"
         assert "No shares configured." in src
+
+
+def test_share_usage_df_is_bounded_by_a_timeout(monkeypatch):
+    """A hung export must not stall the renderer forever."""
+    import subprocess as _sp
+
+    from xinas_menu.screens import nfs as nfs_mod
+
+    seen: list[dict] = []
+
+    def _fake_run(cmd, **kwargs):
+        seen.append({"cmd": cmd, **kwargs})
+        return _sp.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(nfs_mod.subprocess, "run", _fake_run)
+    _format_exports(_rows_from_api(_api_share({"sync": "sync"})))
+
+    df_calls = [c for c in seen if c["cmd"][:1] == ["df"]]
+    assert df_calls, "renderer no longer calls df — update this test"
+    for call in df_calls:
+        assert isinstance(call.get("timeout"), (int, float)), "df has no timeout"
+        assert 0 < call["timeout"] <= 30
+
+
+def test_load_exports_renders_off_the_event_loop():
+    """`@work` on an async def runs ON the loop, so the blocking renderer
+    (df per share + /proc reads) has to be handed to a thread explicitly."""
+    src = inspect.getsource(NFSScreen._load_exports)
+    # Handed to to_thread as a reference, never called inline. A bare
+    # `_format_exports(` in this method means it runs on the event loop —
+    # and `to_thread` appearing *somewhere* in the method proves nothing,
+    # because the control-path call already uses it.
+    assert "_format_exports(" not in src, "_format_exports is still called inline"
+    assert re.search(r"to_thread\(\s*_format_exports", src), (
+        "_format_exports must be handed to asyncio.to_thread"
+    )

--- a/tests/test_nfs_wizard_helpers.py
+++ b/tests/test_nfs_wizard_helpers.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import re
 import inspect
+import re
 
 from xinas_menu.screens.nfs import (
     NFSScreen,

--- a/tests/test_nfs_wizard_helpers.py
+++ b/tests/test_nfs_wizard_helpers.py
@@ -319,6 +319,7 @@ def test_edit_and_remove_distinguish_unreadable_from_empty():
 
 def test_share_usage_df_is_bounded_by_a_timeout(monkeypatch):
     """A hung export must not stall the renderer forever."""
+    import os
     import subprocess as _sp
 
     from xinas_menu.screens import nfs as nfs_mod
@@ -330,6 +331,16 @@ def test_share_usage_df_is_bounded_by_a_timeout(monkeypatch):
         return _sp.CompletedProcess(cmd, 0, stdout="", stderr="")
 
     monkeypatch.setattr(nfs_mod.subprocess, "run", _fake_run)
+    # The renderer only calls df if the path exists; mock that check for exports.
+    original_isdir = os.path.isdir
+
+    def mock_isdir(path):
+        path_str = str(path)
+        if path_str.startswith("/mnt") or path_str.startswith("/srv"):
+            return True
+        return original_isdir(path)
+
+    monkeypatch.setattr(os.path, "isdir", mock_isdir)
     _format_exports(_rows_from_api(_api_share({"sync": "sync"})))
 
     df_calls = [c for c in seen if c["cmd"][:1] == ["df"]]

--- a/tests/test_quick_actions_suspend.py
+++ b/tests/test_quick_actions_suspend.py
@@ -35,3 +35,14 @@ def test_suspend_not_supported_is_handled():
 
 def test_missing_btop_still_reports_the_install_hint():
     assert "not installed" in _src()
+
+
+def test_system_monitor_is_scheduled_as_a_worker():
+    """Guards against a repeat of f7401d0: `@work` was silently dropped from
+    a method invoked bare (`self._system_monitor()`, not awaited) from a
+    synchronous key-binding handler in `quick_actions.py`. Without `@work`,
+    calling the coroutine function returns an un-awaited coroutine that is
+    immediately garbage-collected — the menu item does nothing and no
+    exception is raised anywhere the user can see it.
+    """
+    assert "@work" in _src()

--- a/tests/test_quick_actions_suspend.py
+++ b/tests/test_quick_actions_suspend.py
@@ -1,0 +1,37 @@
+"""btop must run inside App.suspend(), not alongside a live Textual app.
+
+btop drives the alternate screen buffer and raw stdin — the same terminal
+resources Textual holds. Running it in an executor thread while the app keeps
+rendering makes the two interleave on one tty and leaves the terminal in
+btop's state on exit. `App.suspend()` is the supported handover.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from xinas_menu.screens.quick_actions import QuickActionsScreen
+
+
+def _src() -> str:
+    return inspect.getsource(QuickActionsScreen._system_monitor)
+
+
+def test_btop_runs_inside_app_suspend():
+    assert "suspend()" in _src()
+
+
+def test_btop_is_not_launched_from_an_executor():
+    src = _src()
+    assert "run_in_executor" not in src, (
+        "btop must run synchronously inside the suspend block — a suspended "
+        "app is not rendering, so blocking the loop is correct here"
+    )
+
+
+def test_suspend_not_supported_is_handled():
+    assert "SuspendNotSupported" in _src()
+
+
+def test_missing_btop_still_reports_the_install_hint():
+    assert "not installed" in _src()

--- a/xinas_menu/screens/config_history.py
+++ b/xinas_menu/screens/config_history.py
@@ -403,10 +403,14 @@ class ConfigHistoryScreen(XiNASAppMixin, Screen):
         _progress_lines: list[str] = []
 
         def _on_progress(line: str) -> None:
+            # Invoked on the event loop by TransactionalRunner's async stream
+            # reader, so update the widget directly. Threading APIs would
+            # raise RuntimeError here, and the runner suppresses callback
+            # exceptions — every line would vanish. (raid.py's
+            # _teardown_progress is the opposite case: a real worker thread.)
             _progress_lines.append(line)
             tail = _progress_lines[-30:]
-            self.app.call_from_thread(
-                view.set_content,
+            view.set_content(
                 f"{_DIM}Resetting to baseline...{_NC}\n\n" + "\n".join(tail),
             )
 

--- a/xinas_menu/screens/nfs.py
+++ b/xinas_menu/screens/nfs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import subprocess
 from typing import Any
 
 _log = logging.getLogger(__name__)
@@ -158,7 +159,12 @@ class NFSScreen(XiNASAppMixin, Screen):
         except ControlPathError as exc:
             view.set_content(f"Control API: {exc}")
             return
-        view.set_content(_format_exports(_rows_from_api(env.get("result")), degraded_banner(env)))
+        # `@work` on an async def runs on the event loop, and the renderer
+        # shells out to df per share and reads /proc — keep it off the loop.
+        text = await asyncio.to_thread(
+            _format_exports, _rows_from_api(env.get("result")), degraded_banner(env)
+        )
+        view.set_content(text)
 
     def on_navigable_menu_selected(self, event: NavigableMenu.Selected) -> None:
         key = event.key
@@ -921,7 +927,6 @@ def _format_exports(data: Any, banner: str | None = None) -> str:
     """Render adapted share rows; a banner replaces the empty-state."""
     import os
     import shlex
-    import subprocess
 
     GRN, _YLW, RED, CYN, BLD, DIM, NC = (
         "\033[32m",
@@ -952,6 +957,10 @@ def _format_exports(data: Any, banner: str | None = None) -> str:
                 ["df", "-h", path],
                 capture_output=True,
                 text=True,
+                # A hung backing FS (dead NFS server, lost FC path) makes df
+                # block forever; bound it and fall through to "N/A".
+                timeout=5,
+                check=False,
             )
             if r.returncode == 0 and r.stdout:
                 lines = r.stdout.strip().splitlines()

--- a/xinas_menu/screens/quick_actions.py
+++ b/xinas_menu/screens/quick_actions.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import shutil
 import subprocess
 
 from textual import work
-from textual.app import ComposeResult
+from textual.app import ComposeResult, SuspendNotSupported
 from textual.binding import Binding
 from textual.containers import Horizontal
 from textual.screen import Screen
@@ -163,17 +164,26 @@ class QuickActionsScreen(XiNASAppMixin, Screen):
 
     @work(exclusive=True)
     async def _system_monitor(self) -> None:
-        """Launch btop if available, otherwise show top output snapshot."""
+        """Launch btop with the terminal handed over via App.suspend().
+
+        btop owns the alternate screen buffer and raw stdin while it runs —
+        the same resources Textual holds. See
+        docs/Management/quick-actions-spec.md.
+        """
         view = self.query_one("#qa-content", ScrollableTextView)
-        loop = asyncio.get_running_loop()
-        has_btop = await loop.run_in_executor(
-            None, lambda: subprocess.run(["which", "btop"], capture_output=True).returncode == 0
-        )
-        if has_btop:
-            view.set_content("Launching btop -- press q to return to menu.")
-            await loop.run_in_executor(None, lambda: subprocess.run(["btop"]))
-        else:
+        if shutil.which("btop") is None:
             view.set_content("btop is not installed.\n\nInstall with: sudo apt-get install btop")
+            return
+        view.set_content("Launching btop -- press q to return to menu.")
+        try:
+            with self.app.suspend():
+                # Synchronous on purpose: a suspended app is not rendering,
+                # so there is no event loop to keep responsive.
+                subprocess.run(["btop"], check=False)
+        except SuspendNotSupported:
+            view.set_content("btop needs a real terminal.\n\nThis app cannot be suspended here.")
+            return
+        view.set_content("btop closed.")
 
     @work(exclusive=True)
     async def _view_audit_log(self) -> None:


### PR DESCRIPTION
Implements **WS5.2** of [docs/plans/2026-07-07-codebase-review-remediation-plan.md](../blob/fix/ws5-tui-thread-safety/docs/plans/2026-07-07-codebase-review-remediation-plan.md) — three independent fixes to the Textual TUI, each removing a case where the UI called a thread-hopping API from the wrong thread or blocked its own event loop.

The findings were **re-baselined against `origin/main` `032c3b6`** before any code was written: WS5.1 (the section's only HIGH) turned out to be already fixed, and one WS5.3 finding did not survive verification. See the re-baseline table in the plan.

## The three fixes

**1. Config History → Reset to Baseline rendered no live progress** — `xinas_menu/screens/config_history.py`

The progress callback used `App.call_from_thread`, but `TransactionalRunner` invokes that callback from an `async for` stream reader in `_run_ansible_playbook` — **on the event loop**, where `call_from_thread` raises `RuntimeError`. The runner wraps callback invocation in `contextlib.suppress(Exception)`, so every progress line was silently discarded and the operator watched a static "Resetting to baseline…" screen for the entire multi-minute run. Now calls the widget directly.

The inverse case in `raid.py` (`_teardown_progress`) genuinely *is* invoked from a worker thread via `asyncio.to_thread`, so its `call_from_thread` is correct and deliberately untouched. The new spec subsection documents that contrast.

**2. One hung export could freeze the whole TUI** — `xinas_menu/screens/nfs.py`

`_load_exports` is `@work`-decorated on an `async def`, which in Textual runs the worker **on the event loop, not in a thread**. The control-path call was correctly offloaded, but the renderer was then called inline — and it shells out to `df` once per share with no timeout. Now: `timeout=5` on the `df` call, and the renderer is handed to `asyncio.to_thread`. Both changes are load-bearing; the timeout bounds a single hung `df`, the offload keeps even a bounded 5-second stall off the loop.

**3. btop fought Textual for the terminal** — `xinas_menu/screens/quick_actions.py`

btop was launched via `run_in_executor` while the app kept rendering, so two programs drove one tty. Now it runs synchronously inside `with self.app.suspend():` — blocking the loop is correct there, since a suspended app is not rendering — with a `shutil.which` probe and `SuspendNotSupported` handling.

## Specs

Per the repo's spec-first rule, every fix ships with its owning spec:

- `docs/config-history/architecture.md` §4.1 — new; the progress-callback threading contract
- `docs/Storage/fs-shares-management-spec.md` — the `df` timeout and the worker-thread render
- `docs/Management/quick-actions-spec.md` — **new file**; no spec covered the Quick Actions screen at all

## Review

Executed task-by-task with a fresh implementer and an independent reviewer per task, then a whole-branch review. Both load-bearing premises were re-derived from source rather than inherited: that `@work` on an `async def` dispatches to `_run_async` (not `run_in_executor`) in textual 8.2.8, and that the `progress_cb` call chain is `await`-ed end to end with no thread hop.

The final review found **no Critical issues and no correctness defect** in the shipped code. Its three required fixes were docs-and-tests only and are included here — notably a **spec sentence that promised a guarantee the code does not deliver**: `os.path.isdir` runs immediately before, and gates, the `df` call, and `stat(2)` on a hard-mounted dead NFS export blocks uninterruptibly, so on the spec's own headline example the `df` timeout never fires. That sentence is now narrowed to what `timeout=5` actually buys, and the residual is recorded in `docs/TODO.md`.

Three defects in the implementation plan itself were caught during execution and are recorded in the branch history.

## Known limitations

Recorded rather than silently shipped:

- **`docs/TODO.md`** — `os.path.isdir` and the `ss` call in the NFS renderer remain unbounded, so the render can still stall indefinitely on a hung mount (the TUI no longer freezes, because the work is off the loop). Bounding a `stat` on a hung mount needs its own probe-in-a-thread design.
- An exception from `subprocess.run(["btop"])` other than `SuspendNotSupported` escapes the `suspend()` block and skips Textual's resume. Textual's own `worker.py` catches it and routes to normal shutdown, so the outcome is a traceback on an improbable path, not a wedged terminal. Fix is three lines — move the `try` inside the `with` — deliberately left for a follow-up.
- Most tests on this branch assert on source text via `inspect.getsource`, matching the established pattern in `tests/test_nfs_screen_workers.py` and `tests/test_nfs_wizard_helpers.py`. The final reviewer confirmed each would have gone red pre-fix, but noted this is a convention rather than a technical ceiling: `@work` uses `@wraps`, so `__wrapped__` exposes the undecorated coroutine and behavioural tests of these screen workers are writable. Worth adopting the next time these screens are touched.

## Verification

815 passed, 14 skipped (804 at branch point, plus 11 new tests). `ruff check`, `ruff format --check`, `pyright`, and `markdownlint-cli2` all clean.

No `Requires-Rebuild:` trailer on any commit — all changes are Python TUI code and docs, which the standard release-tag checkout already delivers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
