### PR TITLE
docs: sync the Verification block with the actual CI jobs

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -26,6 +26,10 @@ ignore: |
   .claude/
   node_modules/
   xiNAS-MCP/node_modules/
+  # Local dev venv. CI never has one, but `yamllint .` walks it otherwise and
+  # a venv with ansible installed drowns the real findings in site-packages
+  # noise (~400 diagnostics), so the documented command is unusable locally.
+  .venv/
   # The OpenAPI contract is machine-validated by the blocking spectral CI
   # job; yamllint style checks add nothing there.
   docs/control-path/api-v1.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,22 +20,51 @@ anything committed to the repository must be in English.
 
 ### Verification
 
-Run these before proposing a change is done — each mirrors a blocking CI
-job in `.github/workflows/ci.yml`. The path arguments matter: they are
-repeated verbatim across five jobs, and `ruff check .` does not give the
-same result.
+Run these before proposing a change is done — each is copied verbatim
+from a blocking CI job in `.github/workflows/ci.yml`. **The scope
+arguments are part of the gate and differ per tool.** `ruff check` and
+`pyright` are scoped to the three package dirs; `ruff format` is
+whole-repo. Swapping either scope changes the result, in both
+directions — so copy these lines rather than reconstructing them.
 
 ```bash
-pytest                                                     # or: pytest --cov=xinas_history --cov-fail-under=20
+pytest --cov=xinas_history --cov-fail-under=20
 ruff check          xinas_menu xinas_history xiNAS-MCP/nfs-helper
-ruff format --check xinas_menu xinas_history xiNAS-MCP/nfs-helper
+ruff format --check .
 pyright             xinas_menu xinas_history xiNAS-MCP/nfs-helper
 ansible-lint collection/roles/     # needs: ansible-galaxy collection install community.general ansible.posix
 yamllint -c .yamllint.yml .
 npx --yes markdownlint-cli2 'docs/**/*.md'
+npx --yes -p @stoplight/spectral-cli@latest spectral lint \
+  --ruleset .spectral.yaml docs/control-path/api-v1.yaml
 ```
 
-TypeScript control path (from `xiNAS-MCP/`, Node ≥20):
+Notes on the ones with sharp edges:
+
+- **`pytest` alone is not the gate.** The `--cov-fail-under=20` floor is
+  blocking in `python-tests`, so run the full line. (Actual coverage is
+  well above the floor; the flag guards against a drop, not a target.)
+- **`ruff format --check .` is whole-repo on purpose.** Files under
+  `tests/` and `collection/` kept re-drifting while only the three
+  package dirs were checked. `.` honors `[tool.ruff] extend-exclude`
+  (`.claude`, `node_modules`, `docs`). Running the three dirs instead
+  covers 113 files where CI covers 247 — that gap is exactly how a
+  new file under `tests/` reaches CI unformatted.
+- **`ruff check .` is *not* the gate** — the inverse of the above. It
+  reports findings outside the three packages that no CI job fails on.
+  Keep the scoped paths for `ruff check`.
+- **`pyright` must resolve against the venv's interpreter.** If the venv
+  is not active on `PATH` (e.g. invoking `.venv/bin/pyright` directly),
+  pyright falls back to the system interpreter, does not find `textual`,
+  and reports hundreds of phantom `reportMissingImports` errors. Either
+  activate the venv first, or pass the interpreter explicitly:
+  `pyright --pythonpath .venv/bin/python xinas_menu xinas_history xiNAS-MCP/nfs-helper`.
+- **`yamllint`'s ignore list carries `.venv/`** for the same reason —
+  without it, `yamllint .` walks a local venv's `site-packages` and
+  buries the real findings. CI has no venv, so the entry is a no-op there.
+
+TypeScript control path (from `xiNAS-MCP/`, Node ≥20; each CI job runs
+`npm ci` first):
 
 ```bash
 npm run typecheck && npm run lint && npm run format:check
@@ -43,6 +72,11 @@ npm test && npm run test:contracts
 ```
 
 Dev dependencies: `pip install -e '.[dev]'`.
+
+Two blocking jobs have no local equivalent and are not in the list
+above: `openapi-compat` (oasdiff, PR-only — diffs `api-v1.yaml` against
+the base branch and fails on breaking changes) and `secrets` (gitleaks
+over full history). Expect those to run only on the PR.
 
 ### Running Playbooks
 ```bash


### PR DESCRIPTION
Audited every command in CLAUDE.md's Verification block against the jobs in `.github/workflows/ci.yml`. Two had drifted, and following them produced changes that pass locally and fail CI.

## Audit results

| CLAUDE.md command | CI job | Verdict |
|---|---|---|
| `pytest` | `python-tests`: `pytest --cov=xinas_history --cov-fail-under=20` | **drifted** — gate demoted to a comment |
| `ruff check <3 dirs>` | `python-lint` | matches |
| `ruff format --check <3 dirs>` | `python-format`: `ruff format --check .` | **drifted** |
| `pyright <3 dirs>` | `python-typecheck` | matches |
| `ansible-lint collection/roles/` | `ansible` | matches |
| `yamllint -c .yamllint.yml .` | `yamllint` | matches |
| `npx --yes markdownlint-cli2 'docs/**/*.md'` | `markdown` | matches |
| 5 npm commands | `typescript-*` | match verbatim |
| — | `openapi` (spectral) | **missing from the block** |
| — | `openapi-compat`, `secrets` | missing, no local equivalent |

## What changed

- **`ruff format`** — scoped to the three package dirs in the docs, whole-repo in CI. The scoped run checks 113 files where CI checks 247; that gap is exactly how a new file under `tests/` reaches CI unformatted.
- **`pytest`** — the `--cov-fail-under=20` floor is blocking in `python-tests` but sat in a trailing comment, so the documented command could pass while the gate failed. Promoted to the primary line.
- The **"repeated verbatim across five jobs"** claim was wrong either way — the three-dir path list appears in two jobs. Replaced with a note that the scopes differ per tool *in both directions*: `ruff check .` is still not the gate (it flags a `SIM300` in `tests/test_xiraid_name_rules.py:61` that no job fails on), so that caveat stays, now attached to the right command.
- Added the **spectral lint** of `docs/control-path/api-v1.yaml`, plus a note that `openapi-compat` and `gitleaks` only run on the PR.

## Two footguns documented

Both measured by running each command in a fresh worktree venv:

- **pyright** resolves against whatever interpreter is on `PATH`. Invoked without the venv active it misses `textual` and reports **257 phantom `reportMissingImports` errors**; 0 with `--pythonpath .venv/bin/python`. Both forms documented. (The precise trigger is the interpreter, not "run from a venv" — with the venv activated it auto-detects and passes.)
- **yamllint** walks a local `.venv/`. Against a venv with ansible installed that is **~400 site-packages diagnostics** and a non-zero exit, making the CI-verbatim command unusable locally.

## Note on scope

This is docs-only except for one line in `.yamllint.yml`, which adds `.venv/` to the ignore list. yamllint has no `--ignore` CLI flag, so the alternative was documenting a *divergent* local invocation — which reintroduces the docs-vs-CI gap this PR exists to close, and would silently skip newly written untracked YAML. CI never has a venv, so the entry is a no-op there and the documented command stays byte-identical to the job.

No `Requires-Rebuild:` trailer — no runtime behavior changes.

## Verification

After the change: `yamllint` 0 findings across 118 files (0 from `.venv`), `markdownlint` 0 issues, `pytest` 859 passed at 45% coverage, `ruff check` / `ruff format --check .` / `pyright` clean, `spectral` 46 warnings / 0 errors (exit 0, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)